### PR TITLE
24/1/12 更新 版本 6.0.5

### DIFF
--- a/Home/src/main/java/com/ultikits/plugins/home/commands/HomeCommands.java
+++ b/Home/src/main/java/com/ultikits/plugins/home/commands/HomeCommands.java
@@ -8,7 +8,6 @@ import com.ultikits.ultitools.annotations.command.*;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -17,9 +16,11 @@ import java.util.List;
 @CmdTarget(CmdTarget.CmdTargetType.PLAYER)
 @CmdExecutor(permission = "ultikits.home.command.all", description = "家功能", alias = {"home"})
 public class HomeCommands extends AbstractCommendExecutor {
-    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
-    @Autowired
-    private HomeService homeService;
+    private final HomeService homeService;
+
+    public HomeCommands(HomeService homeService) {
+        this.homeService = homeService;
+    }
 
     @CmdMapping(format = "list")
     public void openList(@CmdSender Player player) {

--- a/UltiTools-API/src/main/java/com/ultikits/ultitools/annotations/EventListener.java
+++ b/UltiTools-API/src/main/java/com/ultikits/ultitools/annotations/EventListener.java
@@ -1,11 +1,12 @@
 package com.ultikits.ultitools.annotations;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import org.springframework.stereotype.Component;
 
+import java.lang.annotation.*;
+
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Component
 public @interface EventListener {
 }

--- a/UltiTools-API/src/main/java/com/ultikits/ultitools/annotations/command/CmdExecutor.java
+++ b/UltiTools-API/src/main/java/com/ultikits/ultitools/annotations/command/CmdExecutor.java
@@ -1,5 +1,7 @@
 package com.ultikits.ultitools.annotations.command;
 
+import org.springframework.stereotype.Component;
+
 import java.lang.annotation.*;
 
 /**
@@ -11,6 +13,7 @@ import java.lang.annotation.*;
 @Documented
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
+@Component
 public @interface CmdExecutor {
 
     /**

--- a/UltiTools-API/src/main/java/com/ultikits/ultitools/context/ContextConfig.java
+++ b/UltiTools-API/src/main/java/com/ultikits/ultitools/context/ContextConfig.java
@@ -2,8 +2,11 @@ package com.ultikits.ultitools.context;
 
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 
 @Configuration
-@ComponentScan("com.ultikits.ultitools")
+@ComponentScan(basePackages = "com.ultikits.ultitools", excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.ultikits\\.ultitools\\.commands\\..*")
+})
 public class ContextConfig {
 }

--- a/UltiTools-API/src/main/java/com/ultikits/ultitools/manager/ListenerManager.java
+++ b/UltiTools-API/src/main/java/com/ultikits/ultitools/manager/ListenerManager.java
@@ -42,6 +42,13 @@ public class ListenerManager {
         }
     }
 
+    public void registerAll(UltiToolsPlugin plugin) {
+        for (String listenerBean : plugin.getContext().getBeanNamesForType(Listener.class)) {
+            Listener listener = plugin.getContext().getBean(listenerBean, Listener.class);
+            register(plugin, listener);
+        }
+    }
+
     public void unregister(Listener listener) {
         HandlerList.unregisterAll(listener);
     }

--- a/UltiTools-API/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/UltiTools-API/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -14,7 +14,11 @@ import org.springframework.core.annotation.AnnotationUtils;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.*;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -81,7 +85,7 @@ public class PluginManager {
         }
         boolean result = invokeRegisterSelf(plugin);
         if (result) {
-            registerBukkit(plugin);
+            registerBukkit(plugin, true);
         }
         return result;
     }
@@ -95,6 +99,19 @@ public class PluginManager {
             int minUltiToolsVersion,
             String mainClass
     ) {
+        URLClassLoader urlClassLoader = (URLClassLoader) pluginClass.getClassLoader();
+        Method method;
+        try {
+            method = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+        method.setAccessible(true);
+        try {
+            method.invoke(urlClassLoader, getServerJar());
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
         UltiToolsPlugin plugin;
         try {
             plugin = initializePlugin(
@@ -109,7 +126,7 @@ public class PluginManager {
         }
         boolean result = invokeRegisterSelf(plugin);
         if (result) {
-            registerBukkit(plugin);
+            registerBukkit(plugin, false);
         }
         return result;
     }
@@ -139,7 +156,7 @@ public class PluginManager {
         }
         boolean result = invokeRegisterSelf(plugin);
         if (result) {
-            registerBukkit(plugin);
+            registerBukkit(plugin, false);
         }
         return result;
     }
@@ -175,7 +192,10 @@ public class PluginManager {
         try {
             @SuppressWarnings("resource")
             URLClassLoader classLoader = new URLClassLoader(
-                    new URL[]{new URL(URLDecoder.decode(pluginJar.toURI().toASCIIString(), "UTF-8"))},
+                    new URL[]{
+                            new URL(URLDecoder.decode(pluginJar.toURI().toASCIIString(), "UTF-8")),
+                            getServerJar()
+                    },
                     UltiTools.getInstance().getPluginClassLoader()
             );
             try (JarFile jarFile = new JarFile(pluginJar)) {
@@ -222,7 +242,6 @@ public class PluginManager {
         }
         try {
             boolean registerSelf = plugin.registerSelf();
-            registerBukkit(plugin);
             if (registerSelf) {
                 pluginList.add(plugin);
                 Bukkit.getLogger().log(
@@ -258,7 +277,7 @@ public class PluginManager {
         return plugin;
     }
 
-    private void registerBukkit(UltiToolsPlugin plugin) {
+    private void registerBukkit(UltiToolsPlugin plugin, boolean flag) {
         EnableAutoRegister annotation = AnnotationUtils.findAnnotation(plugin.getClass(), EnableAutoRegister.class);
         if (annotation == null) {
             return;
@@ -266,11 +285,28 @@ public class PluginManager {
         String[] packages = CommonUtils.getPluginPackages(plugin);
         for (String packageName : packages) {
             if (annotation.cmdExecutor()) {
-                UltiTools.getInstance().getCommandManager().registerAll(plugin, packageName);
+                if (flag) {
+                    UltiTools.getInstance().getCommandManager().registerAll(plugin);
+                } else {
+                    UltiTools.getInstance().getCommandManager().registerAll(plugin, packageName);
+                }
             }
             if (annotation.eventListener()) {
-                UltiTools.getInstance().getListenerManager().registerAll(plugin, packageName);
+                if (flag) {
+                    UltiTools.getInstance().getListenerManager().registerAll(plugin);
+                } else {
+                    UltiTools.getInstance().getListenerManager().registerAll(plugin, packageName);
+                }
             }
         }
+    }
+
+    private URL getServerJar() {
+        ProtectionDomain protectionDomain = Bukkit.class.getProtectionDomain();
+        CodeSource codeSource = protectionDomain.getCodeSource();
+        if (codeSource == null) {
+            return null;
+        }
+        return codeSource.getLocation();
     }
 }


### PR DESCRIPTION
1. feat(API) 添加了 CmdExecutor 和 EventListener 注解的Bean支持

2. feat(API) 现在继承或实现服务端类或接口的类可被注册为Bean

3. refactor(API) 重构了 CommandManager 以便更好地对模块指令进行管理

4. impr(Home) 修改了相关代码以适应了新的 API