### PR TITLE
24/1/13 更新 版本 6.0.5

### DIFF
--- a/UltiTools-API/src/main/java/com/ultikits/ultitools/context/ContextConfig.java
+++ b/UltiTools-API/src/main/java/com/ultikits/ultitools/context/ContextConfig.java
@@ -2,7 +2,6 @@ package com.ultikits.ultitools.context;
 
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.FilterType;
 
 @Configuration
 @ComponentScan("com.ultikits.ultitools")

--- a/UltiTools-API/src/main/java/com/ultikits/ultitools/context/ContextConfig.java
+++ b/UltiTools-API/src/main/java/com/ultikits/ultitools/context/ContextConfig.java
@@ -5,8 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 
 @Configuration
-@ComponentScan(basePackages = "com.ultikits.ultitools", excludeFilters = {
-        @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.ultikits\\.ultitools\\.commands\\..*")
-})
+@ComponentScan("com.ultikits.ultitools")
 public class ContextConfig {
 }

--- a/UltiTools-API/src/main/java/com/ultikits/ultitools/manager/DataStoreManager.java
+++ b/UltiTools-API/src/main/java/com/ultikits/ultitools/manager/DataStoreManager.java
@@ -23,7 +23,7 @@ public class DataStoreManager {
     }
 
     public static void close() {
-        Bukkit.getLogger().log(Level.INFO, "Unregistering all data operators...");
+        Bukkit.getLogger().log(Level.INFO, "[UltiTools-API] Unregistering all data operators...");
         for (DataStore dataStore : dataMap.values()) {
             dataStore.destroyAllOperators();
         }

--- a/UltiTools-API/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/UltiTools-API/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -99,19 +99,10 @@ public class PluginManager {
             int minUltiToolsVersion,
             String mainClass
     ) {
-        URLClassLoader urlClassLoader = (URLClassLoader) pluginClass.getClassLoader();
-        Method method;
-        try {
-            method = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException(e);
-        }
-        method.setAccessible(true);
-        try {
-            method.invoke(urlClassLoader, getServerJar());
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException(e);
-        }
+        URLClassLoader urlClassLoader = new URLClassLoader(
+                new URL[]{CommonUtils.getServerJar()},
+                pluginClass.getClassLoader()
+        );
         UltiToolsPlugin plugin;
         try {
             plugin = initializePlugin(
@@ -194,7 +185,7 @@ public class PluginManager {
             URLClassLoader classLoader = new URLClassLoader(
                     new URL[]{
                             new URL(URLDecoder.decode(pluginJar.toURI().toASCIIString(), "UTF-8")),
-                            getServerJar()
+                            CommonUtils.getServerJar()
                     },
                     UltiTools.getInstance().getPluginClassLoader()
             );
@@ -299,14 +290,5 @@ public class PluginManager {
                 }
             }
         }
-    }
-
-    private URL getServerJar() {
-        ProtectionDomain protectionDomain = Bukkit.class.getProtectionDomain();
-        CodeSource codeSource = protectionDomain.getCodeSource();
-        if (codeSource == null) {
-            return null;
-        }
-        return codeSource.getLocation();
     }
 }

--- a/UltiTools-API/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/UltiTools-API/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -14,11 +14,7 @@ import org.springframework.core.annotation.AnnotationUtils;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.*;
-import java.security.CodeSource;
-import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -99,10 +95,6 @@ public class PluginManager {
             int minUltiToolsVersion,
             String mainClass
     ) {
-        URLClassLoader urlClassLoader = new URLClassLoader(
-                new URL[]{CommonUtils.getServerJar()},
-                pluginClass.getClassLoader()
-        );
         UltiToolsPlugin plugin;
         try {
             plugin = initializePlugin(
@@ -255,10 +247,14 @@ public class PluginManager {
     }
 
     private UltiToolsPlugin initializePlugin(Class<? extends UltiToolsPlugin> pluginClass, Object... constructorArgs) {
+        URLClassLoader urlClassLoader = new URLClassLoader(
+                new URL[]{CommonUtils.getServerJar()},
+                pluginClass.getClassLoader()
+        );
         AnnotationConfigApplicationContext pluginContext = new AnnotationConfigApplicationContext();
         pluginContext.setParent(UltiTools.getInstance().getContext());
         pluginContext.registerShutdownHook();
-        pluginContext.setClassLoader(pluginClass.getClassLoader());
+        pluginContext.setClassLoader(urlClassLoader);
         pluginContext.registerBean(pluginClass, constructorArgs);
         pluginContext.refresh();
         UltiToolsPlugin plugin = pluginContext.getBean(pluginClass);

--- a/UltiTools-API/src/main/java/com/ultikits/ultitools/utils/CommonUtils.java
+++ b/UltiTools-API/src/main/java/com/ultikits/ultitools/utils/CommonUtils.java
@@ -6,12 +6,16 @@ import cn.hutool.json.JSONUtil;
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.annotations.EnableAutoRegister;
+import org.bukkit.Bukkit;
 import org.springframework.context.annotation.ComponentScan;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
 
 public class CommonUtils {
 
@@ -54,4 +58,12 @@ public class CommonUtils {
         return packages;
     }
 
+    public static URL getServerJar() {
+        ProtectionDomain protectionDomain = Bukkit.class.getProtectionDomain();
+        CodeSource codeSource = protectionDomain.getCodeSource();
+        if (codeSource == null) {
+            return null;
+        }
+        return codeSource.getLocation();
+    }
 }


### PR DESCRIPTION
1. fix(API) 修复了外部插件无法正常注册Bean的问题

2. impr(API) 修改了 DataStoreManager 中的卸载提示文本