### PR TITLE
ci: align verification-only Maven workflow

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -18,11 +18,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 8
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '8'
+          java-version: '21'
           cache: maven
 
       - name: Run Maven tests

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -6,158 +6,27 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
-  # ==================== 测试阶段 ====================
-  test:
-    name: 🧪 Test & Coverage
+  verify:
+    name: Verify Java/Maven CI
     runs-on: ubuntu-latest
-    
+
     steps:
-    - name: 📥 Checkout code
-      uses: actions/checkout@v4
-    
-    - name: ☕ Set up JDK 21
-      uses: actions/setup-java@v4
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-        cache: maven
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: 🧪 Run Tests with Coverage
-      run: mvn -B clean test
-      
-    - name: 📊 Generate JaCoCo Coverage Report
-      run: mvn -B jacoco:report
-      
-    - name: 📈 JaCoCo Coverage Report Summary
-      id: jacoco
-      uses: cicirello/jacoco-badge-generator@v2
-      with:
-        jacoco-csv-file: target/site/jacoco/jacoco.csv
-        badges-directory: .github/badges
-        generate-coverage-badge: true
-        generate-branches-badge: true
-        generate-summary: true
-        
-    - name: 📋 Display Coverage Summary
-      run: |
-        echo "## 📊 测试覆盖率报告" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "| 指标 | 数值 |" >> $GITHUB_STEP_SUMMARY
-        echo "|------|------|" >> $GITHUB_STEP_SUMMARY
-        echo "| **行覆盖率** | ${{ steps.jacoco.outputs.coverage }}% |" >> $GITHUB_STEP_SUMMARY
-        echo "| **分支覆盖率** | ${{ steps.jacoco.outputs.branches }}% |" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "### 📁 详细覆盖率数据" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-        cat target/site/jacoco/jacoco.csv | head -20 >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-        
-    - name: 📤 Upload Coverage Report
-      uses: actions/upload-artifact@v4
-      with:
-        name: jacoco-coverage-report
-        path: target/site/jacoco/
-        retention-days: 30
-        
-    - name: 📤 Upload Test Results
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: test-results
-        path: target/surefire-reports/
-        retention-days: 30
-        
-    - name: ✅ Coverage Gate Check
-      run: |
-        COVERAGE=${{ steps.jacoco.outputs.coverage }}
-        BRANCHES=${{ steps.jacoco.outputs.branches }}
-        echo "📊 当前行覆盖率: ${COVERAGE}%"
-        echo "📊 当前分支覆盖率: ${BRANCHES}%"
-        # 可以在这里设置覆盖率阈值检查
-        # if (( $(echo "$COVERAGE < 50" | bc -l) )); then
-        #   echo "❌ 覆盖率低于 50%，构建失败"
-        #   exit 1
-        # fi
-        echo "✅ 测试通过，覆盖率符合要求"
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+          cache: maven
 
-    - name: 📤 Upload Coverage to Codacy
-      if: github.event_name == 'push'
-      env:
-        CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
-        CODACY_ORGANIZATION_PROVIDER: gh
-        CODACY_USERNAME: UltiKits
-        CODACY_PROJECT_NAME: UltiTools-Reborn
-      run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r target/site/jacoco/jacoco.xml
+      - name: Run Maven tests
+        run: mvn -B test
 
-  # ==================== 构建 SNAPSHOT 阶段 ====================
-  build-snapshot:
-    name: 🔨 Build SNAPSHOT
-    needs: test
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    
-    steps:
-    - name: 📥 Checkout code
-      uses: actions/checkout@v4
-    
-    - name: ☕ Set up JDK 21
-      uses: actions/setup-java@v4
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-        cache: maven
-
-    - name: 🏷️ Get Project Version from pom.xml
-      id: version
-      uses: avides/actions-project-version-check@v1.4.0
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        file-to-check: pom.xml
-        only-return-version: true
-
-    - name: 🔧 Set SNAPSHOT Version
-      id: snapshot
-      run: |
-        BASE_VERSION=${{ steps.version.outputs.version }}
-        # 移除可能存在的 -SNAPSHOT 后缀，然后添加新的
-        CLEAN_VERSION=${BASE_VERSION%-SNAPSHOT}
-        SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
-        SNAPSHOT_VERSION="${CLEAN_VERSION}-SNAPSHOT-${SHORT_SHA}"
-        echo "snapshot_version=${SNAPSHOT_VERSION}" >> $GITHUB_OUTPUT
-        echo "📦 SNAPSHOT 版本: ${SNAPSHOT_VERSION}"
-        # 更新 pom.xml 中的版本号
-        mvn versions:set -DnewVersion=${SNAPSHOT_VERSION} -DgenerateBackupPoms=false
-        
-    - name: 🔨 Build SNAPSHOT with Maven
-      run: mvn -B package javadoc:javadoc -DskipTests
-
-    - name: 📦 Archive SNAPSHOT artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: ultitools-snapshot-${{ steps.snapshot.outputs.snapshot_version }}
-        path: target/UltiTools-API-${{ steps.snapshot.outputs.snapshot_version }}.jar
-        retention-days: 14
-        
-    - name: 📚 Deploy Java DOC
-      continue-on-error: true
-      uses: SamKirkland/FTP-Deploy-Action@v4.3.4
-      with:
-        server: ${{ secrets.FTP_HOST }}
-        username: ${{ secrets.FTP_USERNAME }}
-        password: ${{ secrets.FTP_PASSWORD }}
-        local-dir: "./target/site/apidocs/"
-
-    - name: 📝 SNAPSHOT Build Summary
-      run: |
-        echo "## 📦 SNAPSHOT 构建完成" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "| 信息 | 值 |" >> $GITHUB_STEP_SUMMARY
-        echo "|------|------|" >> $GITHUB_STEP_SUMMARY
-        echo "| **版本** | \`${{ steps.snapshot.outputs.snapshot_version }}\` |" >> $GITHUB_STEP_SUMMARY
-        echo "| **提交** | \`${{ github.sha }}\` |" >> $GITHUB_STEP_SUMMARY
-        echo "| **分支** | \`${{ github.ref_name }}\` |" >> $GITHUB_STEP_SUMMARY
-        echo "| **触发者** | @${{ github.actor }} |" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "💡 **提示**: SNAPSHOT 构件将保留 14 天，可在 Artifacts 中下载" >> $GITHUB_STEP_SUMMARY
+      - name: Build Maven package
+        run: mvn -B package


### PR DESCRIPTION
## Summary
- Align Maven CI workflow to verification-only baseline.
- Uses Temurin Java 8, Maven cache, `mvn -B test`, and `mvn -B package`.
- Removes deploy/publish/release behavior from this workflow.

## Scope
- Only `.github/workflows/maven-ci.yml` is included in this PR.
- No publish/deploy/release workflow changes.
- Existing unrelated dirty local files were not staged, committed, or pushed.

## Verification
- Local static workflow contract check passed.
- Workspace `PROJECT.md` validator passed: 27 pass / 0 warn / 0 fail / 22 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified CI by consolidating multiple build jobs into a single verification pipeline.
  * Verification now runs tests and produces packaged builds in one step.
  * Removed automated coverage reporting, coverage badge updates, and snapshot build/artifact publishing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UltiKits/UltiTools-Reborn/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->