### PR TITLE
ci(security): SHA-pin Framework publish workflows (SEC-04/SEC-05)

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - name: 📥 Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
     - name: ☕ Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4 (v4.8.0)
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -89,10 +89,10 @@ jobs:
 
     steps:
     - name: 📥 Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
     - name: ☕ Set up JDK 21 with Sonatype credentials
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4 (v4.8.0)
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,12 @@ jobs:
     
     steps:
     - name: 📥 Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
       with:
         fetch-depth: 0  # 获取完整历史用于生成 changelog
     
     - name: ☕ Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4 (v4.8.0)
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -49,7 +49,7 @@ jobs:
 
     - name: 🏷️ Get Project Version from pom.xml
       id: version
-      uses: avides/actions-project-version-check@v1.4.0
+      uses: avides/actions-project-version-check@aea12770ffdbeed8f603d36ec8be75cd89965bac # v1.4.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         file-to-check: pom.xml
@@ -105,10 +105,10 @@ jobs:
     
     steps:
     - name: 📥 Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
     
     - name: ☕ Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4 (v4.8.0)
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -118,13 +118,13 @@ jobs:
       run: mvn -B package javadoc:javadoc -DskipTests
 
     - name: 📦 Archive artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4 (v4.6.2)
       with:
         name: ultitools-release-${{ needs.validate.outputs.version }}
         path: target/UltiTools-API-${{ needs.validate.outputs.version }}.jar
 
     - name: 📚 Archive JavaDoc
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4 (v4.6.2)
       with:
         name: javadoc-${{ needs.validate.outputs.version }}
         path: target/site/apidocs/
@@ -140,7 +140,7 @@ jobs:
     
     steps:
     - name: 📥 Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
       with:
         fetch-depth: 0
 
@@ -167,13 +167,13 @@ jobs:
         echo "notes=${NOTES}" >> $GITHUB_OUTPUT
 
     - name: 📥 Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 (v4.3.0)
       with:
         name: ultitools-release-${{ needs.validate.outputs.version }}
 
     - name: 🎉 Create GitHub Release
       id: create_release
-      uses: actions/create-release@v1
+      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1 (v1.1.4) DEPRECATED/ARCHIVED
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -192,7 +192,7 @@ jobs:
         prerelease: ${{ github.event.inputs.release_type == 'prerelease' }}
 
     - name: 📤 Upload Release Asset
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1 (v1.0.2) DEPRECATED/ARCHIVED
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -202,13 +202,13 @@ jobs:
         asset_content_type: application/java-archive
 
     - name: 📚 Deploy JavaDoc
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 (v4.3.0)
       with:
         name: javadoc-${{ needs.validate.outputs.version }}
         path: javadoc/
         
     - name: 📚 Upload JavaDoc to FTP
-      uses: SamKirkland/FTP-Deploy-Action@v4.3.4
+      uses: SamKirkland/FTP-Deploy-Action@8a24039354ee91000cb948cb4a1dbdf1a1b94a3c # v4.3.4
       with:
         server: ${{ secrets.FTP_HOST }}
         username: ${{ secrets.FTP_USERNAME }}


### PR DESCRIPTION
## SHA-pin Framework publish workflows (`uses:`-value-only) — SEC-04 / SEC-05

Pins every GitHub Actions `uses:` ref in both Framework publish workflows to an immutable **40-hex commit SHA**. This is a **`uses:`-SHA-value-only** change — **no** trigger / `on:` / `if:` / `with:` / `env:` / `needs:` / step-ordering / job-logic change, and **no** `v4 → v5` (or any) version bump. The human-readable version is preserved as a trailing `# vX.Y.Z` comment on each line.

- **Diffstat:** `2 files changed, 17 insertions(+), 17 deletions(-)` — `publish-packages.yml` (4 `uses:` lines) + `release.yml` (13 `uses:` lines).
- **Base:** `alpha` @ `0d49d956e62c3a7e8d7e9fb7ab80d49a460045be`.

> ⛔ **DO NOT MERGE YET.** Per the v1.9 publish-security milestone safety rule, this publish-path edit must not be merged until the maintainer supplies the approval token **and** both per-file no-release proofs are recorded **PASS**. Both proofs are PASS and pasted below (the PR-body half of the D-05 double key; the planning-artifact half is `27-01-no-release-proof-verdicts.md`).

---

## Section A — `publish-packages.yml` (SEC-04, Archetype A) — C1–C6

- **C1 — Diff is SHA-value-only.** Only the SHA token on the 4 mapped `uses:` lines changed (L17/L20/L92/L95: `actions/checkout@v4` → `@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)`, `actions/setup-java@v4` → `@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4 (v4.8.0)`), plus the trailing version comment. No trigger / `if:` / `with:` / `env:` / `needs:` / step-ordering / job-logic change. **Verified against the applied diff.**
- **C2 — Trigger model.** `on: release: types: [published]` — only a *published GitHub Release* can start this workflow. No `pull_request`, no `push`, no `workflow_dispatch`. A SHA-pin commit creates no release, so it cannot start this workflow (and it will not run on this PR).
- **C3 — Guard.** Two jobs: `publish-github` (runs on the release event); `publish-central` gated `if: ${{ vars.PUBLISH_TO_CENTRAL == 'true' }}` (repo-variable opt-in). Only `actions/checkout` + `actions/setup-java` `uses:` refs in scope.
- **C4 — Diff-reachability = unreachable-to-publish.** Because C1 holds, the C2 trigger and C3 guard are byte-identical pre/post pin; the set of conditions under which any publish step runs is unchanged. The pin cannot emit a release event nor reach a publish step.
- **C5 — N/A.** Existing-version-guard applies to module `publish.yml` only; this is a Framework workflow.
- **C6 — Verdict: `PASS — config-only pin, unreachable-to-publish`.** Alpha base `0d49d956…`; `publish-packages.yml` alpha sha256 `475e397af141fb6691090228b43adc329dfa0398735d59faeaebe0cbae994940` (pre == post).

## Section B — `release.yml` (SEC-05, Archetype B, **DRY-RUN-ONLY** per D-06) — C1–C6

- **C1 — Diff is SHA-value-only.** Only the SHA token on the 13 mapped `uses:` lines changed (L39/L44/L52/L108/L111/L121/L127/L143/L170/L176/L195/L205/L211), plus trailing version comments. **The `if: ${{ github.event.inputs.dry_run != 'true' }}` gate at L139 is UNTOUCHED** (byte-identical, absent from the diff). No trigger / `if:` / `with:` / `env:` / `needs:` / job-logic change. **Verified against the applied diff.**
- **C2 — Trigger model.** `on: workflow_dispatch:` only (inputs `release_type`, `release_notes`, `dry_run` default `false`). Manual dispatch only — no automatic trigger. The milestone fence forbids dispatching it; no run was performed for this proof, and it will not run on this PR.
- **C3 — Guard.** `validate` runs under `environment: release` (protected env, required reviewers). The release-creating `release` job is gated `if: ${{ github.event.inputs.dry_run != 'true' }}` (L139) and holds `create-release@v1` (L176), `upload-release-asset@v1` (L195), `download-artifact@v4` (L170/L205), `FTP-Deploy-Action@v4.3.4` (L211); `dry-run-report` is gated `dry_run == 'true'` (L243).
- **C4 — Diff-reachability = unreachable-to-publish.** Because C1 holds, the `if: dry_run != 'true'` gate (L139) is byte-identical pre/post pin. A pin cannot flip `dry_run` nor reach the gated release/FTP job; the condition separating "release happens" from "no release" is unchanged.
- **C5 — N/A.** Modules only.
- **C6 — Verdict: `PASS — config-only pin, unreachable-to-publish (dry-run-only scope per D-06)`.** Alpha base `0d49d956…`; `release.yml` alpha sha256 `9250959dfca2cbd42ce7ad55d4237e9456fab61e85453c7c15b9e4b8780011af` (pre == post).

### Scope / deferral (D-06)
The **non-dry-run** release path — `actions/create-release` (archived), `actions/upload-release-asset` (archived), and the `SamKirkland/FTP-Deploy-Action` FTP deploy, all behind the L139 `dry_run != 'true'` gate — carries **NO proof obligation this milestone**. It is **deferred to SEC-07**; its actions are pinned **mechanically only** (still `uses:`-value-only, gate untouched). The two archived `actions/create-release@v1` and `actions/upload-release-asset@v1` are pinned to their last-published commit and labelled `DEPRECATED/ARCHIVED` in-line.

---

**Requirements:** SEC-04 (`publish-packages.yml`), SEC-05 (`release.yml`, dry-run-only). Phase 27 / workstream `ultikits-maintainability` / milestone v1.9.
