### PR TITLE
fix: prevent invalid plugin main class selection (6.2.5-SNAPSHOT)

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -144,14 +144,6 @@ jobs:
         path: target/UltiTools-API-${{ steps.snapshot.outputs.snapshot_version }}.jar
         retention-days: 14
         
-    - name: 📚 Deploy Java DOC
-      continue-on-error: true
-      uses: SamKirkland/FTP-Deploy-Action@v4.3.4
-      with:
-        server: ${{ secrets.FTP_HOST }}
-        username: ${{ secrets.FTP_USERNAME }}
-        password: ${{ secrets.FTP_PASSWORD }}
-        local-dir: "./target/site/apidocs/"
 
     - name: 📝 SNAPSHOT Build Summary
       run: |

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <artifactId>UltiTools-API</artifactId>
     <groupId>com.ultikits</groupId>
-    <version>6.2.4</version>
+    <version>6.2.5-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
     <name>UltiTools-API</name>
     <description>This project is the base of the Ultitools plugin development.</description>

--- a/src/main/java/com/ultikits/ultitools/UltiTools.java
+++ b/src/main/java/com/ultikits/ultitools/UltiTools.java
@@ -19,6 +19,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
@@ -73,6 +75,7 @@ import net.milkbowl.vault.economy.Economy;
  * @version 6.0.7
  */
 public final class UltiTools extends JavaPlugin implements Localized {
+    private static final Pattern VERSION_PATTERN = Pattern.compile("^([0-9]+\\.[0-9]+\\.[0-9]+)(?:-[0-9A-Za-z]+)*$");
     private static UltiTools ultiTools;
     @Getter
     private final ListenerManager listenerManager = new ListenerManager();
@@ -135,10 +138,26 @@ public final class UltiTools extends JavaPlugin implements Localized {
      */
     public static int getPluginVersion() {
         String versionString = getEnv().getString("version");
-        if (versionString == null) {
-            throw new RuntimeException("Version not found in env.yml!");
+        return parsePluginVersion(versionString);
+    }
+
+    static int parsePluginVersion(String versionString) {
+        if (versionString == null || versionString.trim().isEmpty()) {
+            throw new IllegalArgumentException("Plugin version is missing");
         }
-        return Integer.parseInt(versionString.replace(".", ""));
+        Matcher matcher = VERSION_PATTERN.matcher(versionString.trim());
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid plugin version: " + versionString);
+        }
+        try {
+            long parsed = Long.parseLong(matcher.group(1).replace(".", ""));
+            if (parsed > Integer.MAX_VALUE) {
+                throw new NumberFormatException("Version exceeds supported range");
+            }
+            return (int) parsed;
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid plugin version: " + versionString, e);
+        }
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/listeners/PlayerJoinListener.java
+++ b/src/main/java/com/ultikits/ultitools/listeners/PlayerJoinListener.java
@@ -7,12 +7,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.annotations.EventListener;
-
-import me.clip.placeholderapi.PlaceholderAPI;
 
 @EventListener
 public class PlayerJoinListener implements Listener {
@@ -46,11 +45,15 @@ public class PlayerJoinListener implements Listener {
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
+        Plugin placeholderApi = Bukkit.getPluginManager().getPlugin("PlaceholderAPI");
+        if (placeholderApi == null || !placeholderApi.isEnabled()) {
+            return;
+        }
         try {
             boolean reload = false;
             long time = 30L;
             for (String placeholder : placeholderList) {
-                if (!PlaceholderAPI.isRegistered(placeholder)) {
+                if (!PlaceholderApiBridge.isRegistered(placeholder)) {
                     reload = true;
                     final String ph = placeholder;
                     new BukkitRunnable() {
@@ -71,8 +74,14 @@ public class PlayerJoinListener implements Listener {
                     }
                 }.runTaskLater(UltiTools.getInstance(), finalTime + 30L);
             }
-        } catch (Exception ignored) {
+        } catch (LinkageError error) {
+            Bukkit.getLogger().warning("PlaceholderAPI became unavailable while handling player join: " + error.getClass().getSimpleName());
+        }
+    }
 
+    private static final class PlaceholderApiBridge {
+        private static boolean isRegistered(String placeholder) {
+            return me.clip.placeholderapi.PlaceholderAPI.isRegistered(placeholder);
         }
     }
 }

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -708,7 +708,7 @@ public class PluginManager {
     private void setPluginStaticInstance(Class<? extends UltiToolsPlugin> pluginClass, UltiToolsPlugin plugin) {
         try {
             java.lang.reflect.Field instanceField = pluginClass.getDeclaredField("instance");
-            if (java.lang.reflect.Modifier.isStatic(instanceField.getModifiers())) {
+            if (Modifier.isStatic(instanceField.getModifiers())) {
                 instanceField.setAccessible(true); // NOPMD - required for plugin instance injection
                 instanceField.set(null, plugin);
             }

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -32,7 +33,6 @@ import com.ultikits.ultitools.api.UltiToolsAPI;
 import com.ultikits.ultitools.events.EventBus;
 import com.ultikits.ultitools.events.ModuleEvent;
 import com.ultikits.ultitools.context.SimpleContainer;
-import com.ultikits.ultitools.interfaces.IPlugin;
 import com.ultikits.ultitools.manager.PluginDependencyResolver.CircularDependencyException;
 import com.ultikits.ultitools.manager.PluginDependencyResolver.MissingDependencyException;
 import com.ultikits.ultitools.utils.AnnotationUtils;
@@ -364,10 +364,12 @@ public class PluginManager {
                     // Use security-validated class loading (checks dangerous classes/packages)
                     // but NOT loadPluginClass() which rejects non-UltiToolsPlugin classes
                     Class<?> aClass = ClassLoaderUtils.loadClass(className);
-                    if (IPlugin.class.isAssignableFrom(aClass)) {
+                    if (UltiToolsPlugin.class.isAssignableFrom(aClass)
+                            && !aClass.isInterface()
+                            && !Modifier.isAbstract(aClass.getModifiers())) {
                         return aClass.asSubclass(UltiToolsPlugin.class);
                     }
-                } catch (ClassNotFoundException | NoClassDefFoundError e) {
+                } catch (ClassNotFoundException | LinkageError e) {
                     // 记录但不中断，继续扫描其他类
                     Bukkit.getLogger().log(Level.FINE,
                         "[UltiTools-API] Could not load class: " + className + " - " + e.getMessage());
@@ -377,7 +379,7 @@ public class PluginManager {
                         "[UltiTools-API] Security violation while loading class: " + className + " - " + e.getMessage());
                 }
             }
-        } catch (IOException e) {
+        } catch (IOException | LinkageError | RuntimeException e) {
             Bukkit.getLogger().log(Level.SEVERE, 
                 "[UltiTools-API] Failed to read jar file: " + pluginJar.getName(), e);
         }

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInstallUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInstallUtils.java
@@ -462,6 +462,7 @@ public class PluginInstallUtils {
                 }
             } catch (IOException e) {
                 // Skip unreadable JARs
+                continue;
             }
         }
         return null;

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInstallUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInstallUtils.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.bukkit.configuration.file.YamlConfiguration;
 
@@ -41,6 +43,7 @@ import com.ultikits.ultitools.utils.SimpleHttpClient.Response;
  * @since 6.0.0
  */
 public class PluginInstallUtils {
+    private static final Logger LOGGER = Logger.getLogger(PluginInstallUtils.class.getName());
     private static final Gson GSON = new GsonBuilder()
             .setDateFormat("yyyy-MM-dd HH:mm:ss")
             .create();
@@ -379,7 +382,7 @@ public class PluginInstallUtils {
      */
     public static boolean installLatestPlugin(String idString) {
         String latestVersion = getPluginLatestVersion(idString);
-        String pluginVersionDownloadLink = getPluginLatestDownloadLink(idString);
+        String pluginVersionDownloadLink = getPluginVersionDownloadLink(idString, latestVersion);
         String fileName = installedJarName(idString, latestVersion);
         if (pluginVersionDownloadLink == null || fileName == null) {
             return false;
@@ -461,8 +464,7 @@ public class PluginInstallUtils {
                     }
                 }
             } catch (IOException e) {
-                // Skip unreadable JARs
-                continue;
+                LOGGER.log(Level.FINE, "Skipping unreadable plugin JAR: " + jar.getName(), e);
             }
         }
         return null;
@@ -478,7 +480,7 @@ public class PluginInstallUtils {
      */
     public static boolean updatePlugin(String identifyString) {
         String latestVersion = getPluginLatestVersion(identifyString);
-        String downloadLink = getPluginLatestDownloadLink(identifyString);
+        String downloadLink = getPluginVersionDownloadLink(identifyString, latestVersion);
         String fileName = installedJarName(identifyString, latestVersion);
         if (downloadLink == null || fileName == null) {
             return false;

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInstallUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInstallUtils.java
@@ -9,8 +9,11 @@ import java.lang.reflect.Type;
 import java.net.JarURLConnection;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -92,6 +95,40 @@ public class PluginInstallUtils {
     static void resetBaseUrl() {
         baseUrl = null;
         customBaseUrl = null;
+    }
+
+    private static String normalizeIdentifyString(String idString) {
+        if (idString == null) {
+            return null;
+        }
+        String normalized = idString.trim().toLowerCase(Locale.ROOT);
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private static String encodeQueryValue(String value) {
+        try {
+            return URLEncoder.encode(value, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("UTF-8 is required by the Java runtime", e);
+        }
+    }
+
+    private static String encodePathSegment(String value) {
+        return encodeQueryValue(value).replace("+", "%20");
+    }
+
+    static String installedJarName(String idString, String version) {
+        String normalized = normalizeIdentifyString(idString);
+        if (normalized == null || version == null) {
+            return null;
+        }
+        String trimmedVersion = version.trim();
+        if (!normalized.matches("[a-z0-9][a-z0-9._-]*")
+                || !trimmedVersion.matches("[0-9A-Za-z][0-9A-Za-z._-]*")
+                || normalized.contains("..") || trimmedVersion.contains("..")) {
+            return null;
+        }
+        return normalized + "-" + trimmedVersion + ".jar";
     }
 
     /**
@@ -236,7 +273,10 @@ public class PluginInstallUtils {
         if (plugin == null) {
             return null;
         }
-        try (Response httpResponse = SimpleHttpClient.get(getBaseUrl() + "/plugin/" + plugin.getId() + "/" + version + "/download")) {
+        if (version == null || version.trim().isEmpty()) {
+            return null;
+        }
+        try (Response httpResponse = SimpleHttpClient.get(getBaseUrl() + "/plugin/" + plugin.getId() + "/" + encodePathSegment(version.trim()) + "/download")) {
             if (!httpResponse.isOk()) {
                 return null;
             }
@@ -317,7 +357,11 @@ public class PluginInstallUtils {
      * @return Plugin entity or null if not found <br> 插件信息，未找到返回null
      */
     public static PluginEntity getPlugin(String idString) {
-        try (Response httpResponse = SimpleHttpClient.get(getBaseUrl() + "/plugin/get?identifyString=" + idString)) {
+        String normalized = normalizeIdentifyString(idString);
+        if (normalized == null) {
+            return null;
+        }
+        try (Response httpResponse = SimpleHttpClient.get(getBaseUrl() + "/plugin/get?identifyString=" + encodeQueryValue(normalized))) {
             if (!httpResponse.isOk()) {
                 return null;
             }
@@ -334,14 +378,16 @@ public class PluginInstallUtils {
      * @return 是否安装成功
      */
     public static boolean installLatestPlugin(String idString) {
+        String latestVersion = getPluginLatestVersion(idString);
         String pluginVersionDownloadLink = getPluginLatestDownloadLink(idString);
-        if (pluginVersionDownloadLink == null) {
+        String fileName = installedJarName(idString, latestVersion);
+        if (pluginVersionDownloadLink == null || fileName == null) {
             return false;
         }
 
         try {
             HttpDownloadUtils.download(pluginVersionDownloadLink,
-                    pluginVersionDownloadLink.substring(pluginVersionDownloadLink.lastIndexOf("/") + 1),
+                    fileName,
                     UltiTools.getInstance().getDataFolder() + "/plugins");
             return true;
         } catch (IOException e) {
@@ -365,13 +411,14 @@ public class PluginInstallUtils {
             return false;
         }
         String pluginVersionDownloadLink = getPluginVersionDownloadLink(idString, version);
-        if (pluginVersionDownloadLink == null) {
+        String fileName = installedJarName(idString, version);
+        if (pluginVersionDownloadLink == null || fileName == null) {
             return false;
         }
 
         try {
             HttpDownloadUtils.download(pluginVersionDownloadLink,
-                    pluginVersionDownloadLink.substring(pluginVersionDownloadLink.lastIndexOf("/") + 1),
+                    fileName,
                     UltiTools.getInstance().getDataFolder() + "/plugins");
             return true;
         } catch (IOException e) {
@@ -391,7 +438,8 @@ public class PluginInstallUtils {
      * @return the matching JAR file, or null if not found
      */
     public static File findPluginJar(File pluginsFolder, String identifyString) {
-        if (pluginsFolder == null || !pluginsFolder.isDirectory()) {
+        String normalizedIdentifyString = normalizeIdentifyString(identifyString);
+        if (pluginsFolder == null || !pluginsFolder.isDirectory() || normalizedIdentifyString == null) {
             return null;
         }
         File[] jars = pluginsFolder.listFiles((f) -> f.getName().endsWith(".jar"));
@@ -408,7 +456,7 @@ public class PluginInstallUtils {
                      BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
                     YamlConfiguration config = YamlConfiguration.loadConfiguration(reader);
                     String id = config.getString("identify-string");
-                    if (identifyString.equals(id)) {
+                    if (normalizedIdentifyString.equals(normalizeIdentifyString(id))) {
                         return jar;
                     }
                 }
@@ -428,8 +476,10 @@ public class PluginInstallUtils {
      * @return true if update succeeded
      */
     public static boolean updatePlugin(String identifyString) {
+        String latestVersion = getPluginLatestVersion(identifyString);
         String downloadLink = getPluginLatestDownloadLink(identifyString);
-        if (downloadLink == null) {
+        String fileName = installedJarName(identifyString, latestVersion);
+        if (downloadLink == null || fileName == null) {
             return false;
         }
 
@@ -437,7 +487,6 @@ public class PluginInstallUtils {
         File pluginsFolder = new File(pluginsPath);
         File oldJar = findPluginJar(pluginsFolder, identifyString);
 
-        String fileName = downloadLink.substring(downloadLink.lastIndexOf("/") + 1);
         try {
             HttpDownloadUtils.download(downloadLink, fileName, pluginsPath);
         } catch (IOException e) {

--- a/src/test/java/com/ultikits/ultitools/UltiToolsTest.java
+++ b/src/test/java/com/ultikits/ultitools/UltiToolsTest.java
@@ -33,9 +33,10 @@ import com.ultikits.ultitools.manager.ServerMonitorManager;
 class UltiToolsTest {
 
     @Nested
-    @DisplayName("Version parsing tests")
+    @DisplayName("版本解析测试")
     class VersionParsingTests {
         @Test
+        @DisplayName("应解析数字核心并忽略 SNAPSHOT 限定符")
         void parsesNumericCoreAndSnapshotQualifiers() {
             assertThat(UltiTools.parsePluginVersion("6.2.5")).isEqualTo(625);
             assertThat(UltiTools.parsePluginVersion("6.2.5-SNAPSHOT")).isEqualTo(625);
@@ -44,6 +45,7 @@ class UltiToolsTest {
         }
 
         @Test
+        @DisplayName("应拒绝缺失、格式错误或溢出的版本")
         void rejectsMissingMalformedAndOverflowVersions() {
             assertThatThrownBy(() -> UltiTools.parsePluginVersion(null)).isInstanceOf(IllegalArgumentException.class);
             assertThatThrownBy(() -> UltiTools.parsePluginVersion(" ")).isInstanceOf(IllegalArgumentException.class);

--- a/src/test/java/com/ultikits/ultitools/UltiToolsTest.java
+++ b/src/test/java/com/ultikits/ultitools/UltiToolsTest.java
@@ -1,6 +1,7 @@
 package com.ultikits.ultitools;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -30,6 +31,27 @@ import com.ultikits.ultitools.manager.ServerMonitorManager;
  */
 @DisplayName("UltiTools Main Class Tests")
 class UltiToolsTest {
+
+    @Nested
+    @DisplayName("Version parsing tests")
+    class VersionParsingTests {
+        @Test
+        void parsesNumericCoreAndSnapshotQualifiers() {
+            assertThat(UltiTools.parsePluginVersion("6.2.5")).isEqualTo(625);
+            assertThat(UltiTools.parsePluginVersion("6.2.5-SNAPSHOT")).isEqualTo(625);
+            assertThat(UltiTools.parsePluginVersion("6.2.5-SNAPSHOT-abcdefg")).isEqualTo(625);
+            assertThat(UltiTools.parsePluginVersion("6.2.0")).isEqualTo(620);
+        }
+
+        @Test
+        void rejectsMissingMalformedAndOverflowVersions() {
+            assertThatThrownBy(() -> UltiTools.parsePluginVersion(null)).isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> UltiTools.parsePluginVersion(" ")).isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> UltiTools.parsePluginVersion("6.2-SNAPSHOT")).isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> UltiTools.parsePluginVersion("6.2.x")).isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> UltiTools.parsePluginVersion("2147483648.1.1")).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
 
     @Nested
     @DisplayName("Class Structure Tests")

--- a/src/test/java/com/ultikits/ultitools/listeners/PlayerJoinListenerTest.java
+++ b/src/test/java/com/ultikits/ultitools/listeners/PlayerJoinListenerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
 
+
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +18,8 @@ import org.mockito.MockedStatic;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.ServerMock;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.plugin.PluginManagerMock;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
 import me.clip.placeholderapi.PlaceholderAPI;
 
 /**
@@ -28,6 +31,7 @@ class PlayerJoinListenerTest {
 
     private ServerMock server;
     private PlayerJoinListener listener;
+    private PluginMock placeholderApi;
 
     @BeforeEach
     void setUp() {
@@ -35,6 +39,10 @@ class PlayerJoinListenerTest {
         server = MockBukkit.mock();
         MockBukkit.createMockPlugin();
         com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
+        PluginManagerMock pluginManager = (PluginManagerMock) server.getPluginManager();
+        placeholderApi = PluginMock.builder().withPluginName("PlaceholderAPI").build();
+        pluginManager.registerLoadedPlugin(placeholderApi);
+        pluginManager.enablePlugin(placeholderApi);
 
         listener = new PlayerJoinListener();
     }
@@ -122,15 +130,31 @@ class PlayerJoinListenerTest {
     class OnPlayerJoinTests {
 
         @Test
-        @DisplayName("PlaceholderAPI 不可用时不应该抛出异常")
-        void shouldNotThrowWhenPlaceholderAPINotAvailable() {
+        @DisplayName("PlaceholderAPI 插件禁用时不应调用 bridge 或调度任务")
+        void shouldNotCallBridgeOrScheduleWhenPlaceholderApiPluginDisabled() {
             // Arrange
             PlayerMock player = server.addPlayer("TestPlayer");
             PlayerJoinEvent event = new PlayerJoinEvent(player, "TestPlayer joined");
 
-            // Act & Assert - 不应该抛出异常
-            // PlaceholderAPI 类不存在时会捕获 NoClassDefFoundError
-            assertDoesNotThrow(() -> listener.onPlayerJoin(event));
+            server.getPluginManager().disablePlugin(placeholderApi);
+            try (MockedStatic<PlaceholderAPI> placeholderAPIMock = mockStatic(PlaceholderAPI.class)) {
+                listener.onPlayerJoin(event);
+                placeholderAPIMock.verifyNoInteractions();
+                assertThat(server.getScheduler().getPendingTasks()).isEmpty();
+            }
+        }
+
+        @Test
+        @DisplayName("PlaceholderAPI 插件缺失时不应调用 bridge 或调度任务")
+        void shouldNotCallBridgeOrScheduleWhenPlaceholderApiPluginMissing() {
+            PlayerMock player = server.addPlayer("TestPlayer");
+            PlayerJoinEvent event = new PlayerJoinEvent(player, "TestPlayer joined");
+            server.getPluginManager().clearPlugins();
+            try (MockedStatic<PlaceholderAPI> placeholderAPIMock = mockStatic(PlaceholderAPI.class)) {
+                listener.onPlayerJoin(event);
+                placeholderAPIMock.verifyNoInteractions();
+                assertThat(server.getScheduler().getPendingTasks()).isEmpty();
+            }
         }
 
         @Test
@@ -183,16 +207,16 @@ class PlayerJoinListenerTest {
         }
 
         @Test
-        @DisplayName("异常应该被捕获而不是传播")
-        void exceptionShouldBeCaughtNotPropagated() { // NOPMD - uses Mockito verify()
+        @DisplayName("链接错误应该被捕获而不是传播")
+        void linkageErrorShouldBeCaughtNotPropagated() { // NOPMD - uses Mockito verify()
             // Arrange
             PlayerMock player = server.addPlayer("TestPlayer");
             PlayerJoinEvent event = new PlayerJoinEvent(player, "TestPlayer joined");
 
             try (MockedStatic<PlaceholderAPI> placeholderAPIMock = mockStatic(PlaceholderAPI.class)) {
-                // 模拟抛出异常
+                // 模拟可选依赖在 guard 后被卸载的竞态
                 placeholderAPIMock.when(() -> PlaceholderAPI.isRegistered(anyString()))
-                        .thenThrow(new RuntimeException("Test exception"));
+                        .thenThrow(new NoClassDefFoundError("PlaceholderAPI"));
 
                 // Act & Assert - 不应该抛出异常
                 listener.onPlayerJoin(event);

--- a/src/test/java/com/ultikits/ultitools/listeners/PlayerJoinListenerTest.java
+++ b/src/test/java/com/ultikits/ultitools/listeners/PlayerJoinListenerTest.java
@@ -47,13 +47,6 @@ class PlayerJoinListenerTest {
         listener = new PlayerJoinListener();
     }
 
-    private static void assertDoesNotThrow(Runnable runnable) {
-        try {
-            runnable.run();
-        } catch (Exception e) {
-            throw new AssertionError("Expected no exception but got: " + e.getClass().getName() + " - " + e.getMessage(), e);
-        }
-    }
 
     @AfterEach
     void tearDown() {

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerClassScanningTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerClassScanningTest.java
@@ -1,0 +1,145 @@
+package com.ultikits.ultitools.manager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockbukkit.mockbukkit.MockBukkit;
+
+import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
+import com.ultikits.ultitools.interfaces.IPlugin;
+
+/**
+ * PluginManager module main-class scanning tests.
+ */
+@DisplayName("PluginManager 模块主类扫描测试")
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+@SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+class PluginManagerClassScanningTest {
+
+    @TempDir
+    File tempDir;
+
+    private PluginManager pluginManager;
+
+    @BeforeEach
+    void setUp() {
+        com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
+        MockBukkit.mock();
+        MockBukkit.createMockPlugin();
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
+        pluginManager = new PluginManager();
+    }
+
+    @AfterEach
+    void tearDown() {
+        com.ultikits.ultitools.utils.MockBukkitHelper.safeUnmock();
+    }
+
+    @Test
+    @DisplayName("只选择具体的 UltiToolsPlugin 子类并隔离坏类条目")
+    void shouldSelectOnlyConcreteUltiToolsPluginSubclass() throws Exception {
+        File pluginJar = createJar(
+                "mixed-plugin.jar",
+                IPlugin.class,
+                PluginContract.class,
+                AbstractPlugin.class,
+                PlainPlugin.class,
+                "com.ultikits.ultitools.manager.MissingPlugin",
+                ConcretePlugin.class
+        );
+
+        assertThat(invokeLoadPluginMainClass(pluginJar)).isEqualTo(ConcretePlugin.class);
+    }
+
+    @Test
+    @DisplayName("坏 JAR 不应该阻止后续有效 JAR 扫描")
+    void badJarShouldNotPreventLaterValidJarScan() throws Exception {
+        File badJar = new File(tempDir, "bad-plugin.jar");
+        Files.write(badJar.toPath(), new byte[]{0x00, 0x01, 0x02});
+        File validJar = createJar("valid-plugin.jar", ConcretePlugin.class);
+
+        assertThat(invokeLoadPluginMainClass(badJar)).isNull();
+        assertThat(invokeLoadPluginMainClass(validJar)).isEqualTo(ConcretePlugin.class);
+    }
+
+    private Class<? extends UltiToolsPlugin> invokeLoadPluginMainClass(File pluginJar) throws Exception {
+        Method method = PluginManager.class.getDeclaredMethod(
+                "loadPluginMainClass", ClassLoader.class, File.class
+        );
+        method.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Class<? extends UltiToolsPlugin> result = (Class<? extends UltiToolsPlugin>) method.invoke(
+                pluginManager,
+                Thread.currentThread().getContextClassLoader(),
+                pluginJar
+        );
+        return result;
+    }
+
+    private File createJar(String name, Object... entries) throws IOException {
+        File jar = new File(tempDir, name);
+        try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jar.toPath()))) {
+            for (Object entry : entries) {
+                String className = entry instanceof Class ? ((Class<?>) entry).getName() : (String) entry;
+                String resourceName = className.replace('.', '/') + ".class";
+                output.putNextEntry(new JarEntry(resourceName));
+                if (entry instanceof Class) {
+                    try (InputStream input = ((Class<?>) entry).getResourceAsStream("/" + resourceName)) {
+                        assertThat(input).as("compiled class resource for %s", className).isNotNull();
+                        byte[] buffer = new byte[4096];
+                        int read;
+                        while ((read = input.read(buffer)) != -1) {
+                            output.write(buffer, 0, read);
+                        }
+                    }
+                }
+                output.closeEntry();
+            }
+        }
+        return jar;
+    }
+
+    interface PluginContract extends IPlugin {
+    }
+
+    abstract static class AbstractPlugin extends UltiToolsPlugin {
+    }
+
+    static class PlainPlugin implements IPlugin {
+        @Override
+        public boolean registerSelf() {
+            return true;
+        }
+
+        @Override
+        public void unregisterSelf() {
+            // No-op for this scanner fixture.
+        }
+
+        @Override
+        public void reloadSelf() {
+            // No-op for this scanner fixture.
+        }
+    }
+
+    static class ConcretePlugin extends UltiToolsPlugin {
+        @Override
+        public boolean registerSelf() {
+            return true;
+        }
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerTest.java
@@ -6,12 +6,17 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,6 +28,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
+import com.ultikits.ultitools.interfaces.IPlugin;
 
 import org.mockbukkit.mockbukkit.MockBukkit;
 
@@ -191,6 +197,105 @@ class PluginManagerTest {
 
             // Assert
             assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("loadPluginMainClass 测试")
+    class LoadPluginMainClassTests {
+
+        @Test
+        @DisplayName("只选择具体的 UltiToolsPlugin 子类并隔离坏类条目")
+        void shouldSelectOnlyConcreteUltiToolsPluginSubclass() throws Exception {
+            File pluginJar = createJar(
+                    "mixed-plugin.jar",
+                    IPlugin.class,
+                    PluginContract.class,
+                    AbstractPlugin.class,
+                    PlainPlugin.class,
+                    "com.ultikits.ultitools.manager.MissingPlugin",
+                    ConcretePlugin.class
+            );
+
+            Class<? extends UltiToolsPlugin> result = invokeLoadPluginMainClass(pluginJar);
+
+            assertThat(result).isEqualTo(ConcretePlugin.class);
+        }
+
+        @Test
+        @DisplayName("坏 JAR 不应该阻止后续有效 JAR 扫描")
+        void badJarShouldNotPreventLaterValidJarScan() throws Exception {
+            File badJar = new File(tempDir, "bad-plugin.jar");
+            Files.write(badJar.toPath(), new byte[]{0x00, 0x01, 0x02});
+            File validJar = createJar("valid-plugin.jar", ConcretePlugin.class);
+
+            assertThat(invokeLoadPluginMainClass(badJar)).isNull();
+            assertThat(invokeLoadPluginMainClass(validJar)).isEqualTo(ConcretePlugin.class);
+        }
+
+        private Class<? extends UltiToolsPlugin> invokeLoadPluginMainClass(File pluginJar) throws Exception {
+            Method method = PluginManager.class.getDeclaredMethod(
+                    "loadPluginMainClass", ClassLoader.class, File.class
+            );
+            method.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Class<? extends UltiToolsPlugin> result = (Class<? extends UltiToolsPlugin>) method.invoke(
+                    pluginManager,
+                    Thread.currentThread().getContextClassLoader(),
+                    pluginJar
+            );
+            return result;
+        }
+
+        private File createJar(String name, Object... entries) throws IOException {
+            File jar = new File(tempDir, name);
+            try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jar.toPath()))) {
+                for (Object entry : entries) {
+                    String className = entry instanceof Class ? ((Class<?>) entry).getName() : (String) entry;
+                    String resourceName = className.replace('.', '/') + ".class";
+                    output.putNextEntry(new JarEntry(resourceName));
+                    if (entry instanceof Class) {
+                        try (InputStream input = ((Class<?>) entry).getResourceAsStream("/" + resourceName)) {
+                            assertThat(input).as("compiled class resource for %s", className).isNotNull();
+                            byte[] buffer = new byte[4096];
+                            int read;
+                            while ((read = input.read(buffer)) != -1) {
+                                output.write(buffer, 0, read);
+                            }
+                        }
+                    }
+                    output.closeEntry();
+                }
+            }
+            return jar;
+        }
+    }
+
+    interface PluginContract extends IPlugin {
+    }
+
+    abstract static class AbstractPlugin extends UltiToolsPlugin {
+    }
+
+    static class PlainPlugin implements IPlugin {
+        @Override
+        public boolean registerSelf() {
+            return true;
+        }
+
+        @Override
+        public void unregisterSelf() {
+        }
+
+        @Override
+        public void reloadSelf() {
+        }
+    }
+
+    static class ConcretePlugin extends UltiToolsPlugin {
+        @Override
+        public boolean registerSelf() {
+            return true;
         }
     }
 

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerTest.java
@@ -285,10 +285,12 @@ class PluginManagerTest {
 
         @Override
         public void unregisterSelf() {
+            // No-op for this scanner fixture.
         }
 
         @Override
         public void reloadSelf() {
+            // No-op for this scanner fixture.
         }
     }
 

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerTest.java
@@ -6,17 +6,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
-import java.util.jar.JarEntry;
-import java.util.jar.JarOutputStream;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,7 +23,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
-import com.ultikits.ultitools.interfaces.IPlugin;
 
 import org.mockbukkit.mockbukkit.MockBukkit;
 
@@ -200,106 +194,6 @@ class PluginManagerTest {
         }
     }
 
-    @Nested
-    @DisplayName("loadPluginMainClass 测试")
-    class LoadPluginMainClassTests {
-
-        @Test
-        @DisplayName("只选择具体的 UltiToolsPlugin 子类并隔离坏类条目")
-        void shouldSelectOnlyConcreteUltiToolsPluginSubclass() throws Exception {
-            File pluginJar = createJar(
-                    "mixed-plugin.jar",
-                    IPlugin.class,
-                    PluginContract.class,
-                    AbstractPlugin.class,
-                    PlainPlugin.class,
-                    "com.ultikits.ultitools.manager.MissingPlugin",
-                    ConcretePlugin.class
-            );
-
-            Class<? extends UltiToolsPlugin> result = invokeLoadPluginMainClass(pluginJar);
-
-            assertThat(result).isEqualTo(ConcretePlugin.class);
-        }
-
-        @Test
-        @DisplayName("坏 JAR 不应该阻止后续有效 JAR 扫描")
-        void badJarShouldNotPreventLaterValidJarScan() throws Exception {
-            File badJar = new File(tempDir, "bad-plugin.jar");
-            Files.write(badJar.toPath(), new byte[]{0x00, 0x01, 0x02});
-            File validJar = createJar("valid-plugin.jar", ConcretePlugin.class);
-
-            assertThat(invokeLoadPluginMainClass(badJar)).isNull();
-            assertThat(invokeLoadPluginMainClass(validJar)).isEqualTo(ConcretePlugin.class);
-        }
-
-        private Class<? extends UltiToolsPlugin> invokeLoadPluginMainClass(File pluginJar) throws Exception {
-            Method method = PluginManager.class.getDeclaredMethod(
-                    "loadPluginMainClass", ClassLoader.class, File.class
-            );
-            method.setAccessible(true);
-            @SuppressWarnings("unchecked")
-            Class<? extends UltiToolsPlugin> result = (Class<? extends UltiToolsPlugin>) method.invoke(
-                    pluginManager,
-                    Thread.currentThread().getContextClassLoader(),
-                    pluginJar
-            );
-            return result;
-        }
-
-        private File createJar(String name, Object... entries) throws IOException {
-            File jar = new File(tempDir, name);
-            try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jar.toPath()))) {
-                for (Object entry : entries) {
-                    String className = entry instanceof Class ? ((Class<?>) entry).getName() : (String) entry;
-                    String resourceName = className.replace('.', '/') + ".class";
-                    output.putNextEntry(new JarEntry(resourceName));
-                    if (entry instanceof Class) {
-                        try (InputStream input = ((Class<?>) entry).getResourceAsStream("/" + resourceName)) {
-                            assertThat(input).as("compiled class resource for %s", className).isNotNull();
-                            byte[] buffer = new byte[4096];
-                            int read;
-                            while ((read = input.read(buffer)) != -1) {
-                                output.write(buffer, 0, read);
-                            }
-                        }
-                    }
-                    output.closeEntry();
-                }
-            }
-            return jar;
-        }
-    }
-
-    interface PluginContract extends IPlugin {
-    }
-
-    abstract static class AbstractPlugin extends UltiToolsPlugin {
-    }
-
-    static class PlainPlugin implements IPlugin {
-        @Override
-        public boolean registerSelf() {
-            return true;
-        }
-
-        @Override
-        public void unregisterSelf() {
-            // No-op for this scanner fixture.
-        }
-
-        @Override
-        public void reloadSelf() {
-            // No-op for this scanner fixture.
-        }
-    }
-
-    static class ConcretePlugin extends UltiToolsPlugin {
-        @Override
-        public boolean registerSelf() {
-            return true;
-        }
-    }
 
     @Nested
     @DisplayName("validateConstructorArgs 测试")

--- a/src/test/java/com/ultikits/ultitools/utils/PluginInstallUtilsTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/PluginInstallUtilsTest.java
@@ -33,6 +33,7 @@ import com.ultikits.ultitools.entities.PluginEntity;
 class PluginInstallUtilsTest {
 
     @Test
+    @DisplayName("所有元数据请求应规范化并编码插件标识与版本路径")
     void normalizesAndEncodesLookupForAllMetadataPaths() throws Exception {
         AtomicReference<String> request = new AtomicReference<>();
         AtomicReference<String> versionPath = new AtomicReference<>();
@@ -77,6 +78,7 @@ class PluginInstallUtilsTest {
     }
 
     @Test
+    @DisplayName("应构造确定且路径安全的模块 JAR 文件名")
     void constructsDeterministicSafeJarNames() {
         assertThat(PluginInstallUtils.installedJarName(" UltiTrade ", "1.0.0-SNAPSHOT")).isEqualTo("ultitrade-1.0.0-SNAPSHOT.jar");
         assertThat(PluginInstallUtils.installedJarName("../../escape", "../bad")).isNull();
@@ -84,6 +86,7 @@ class PluginInstallUtilsTest {
     }
 
     @Test
+    @DisplayName("应使用规范化标识查找既有模块 JAR")
     void findsExistingPluginJarUsingCanonicalIdentifyString(@TempDir Path pluginsFolder) throws Exception {
         Path jar = pluginsFolder.resolve("artifact.jar");
         try (OutputStream output = java.nio.file.Files.newOutputStream(jar);
@@ -95,6 +98,14 @@ class PluginInstallUtilsTest {
 
         assertThat(PluginInstallUtils.findPluginJar(pluginsFolder.toFile(), " UltiTrade "))
                 .isEqualTo(jar.toFile());
+    }
+
+    @Test
+    @DisplayName("不可读 JAR 不应中断模块目录扫描")
+    void skipsUnreadablePluginJars(@TempDir Path pluginsFolder) throws Exception {
+        java.nio.file.Files.write(pluginsFolder.resolve("broken.jar"), "not-a-jar".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(PluginInstallUtils.findPluginJar(pluginsFolder.toFile(), "UltiTrade")).isNull();
     }
 
     @Nested

--- a/src/test/java/com/ultikits/ultitools/utils/PluginInstallUtilsTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/PluginInstallUtilsTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.sun.net.httpserver.HttpServer;
 import java.io.OutputStream;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -38,7 +37,7 @@ class PluginInstallUtilsTest {
     void normalizesAndEncodesLookupForAllMetadataPaths() throws Exception {
         AtomicReference<String> request = new AtomicReference<>();
         AtomicReference<String> versionPath = new AtomicReference<>();
-        HttpServer server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
         server.createContext("/plugin/get", exchange -> {
             request.set(exchange.getRequestURI().getRawQuery());
             byte[] body = "{\"code\":\"200\",\"data\":{\"id\":7,\"identifyString\":\"ultitrade\"}}".getBytes(StandardCharsets.UTF_8);

--- a/src/test/java/com/ultikits/ultitools/utils/PluginInstallUtilsTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/PluginInstallUtilsTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.sun.net.httpserver.HttpServer;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -37,7 +38,7 @@ class PluginInstallUtilsTest {
     void normalizesAndEncodesLookupForAllMetadataPaths() throws Exception {
         AtomicReference<String> request = new AtomicReference<>();
         AtomicReference<String> versionPath = new AtomicReference<>();
-        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        HttpServer server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
         server.createContext("/plugin/get", exchange -> {
             request.set(exchange.getRequestURI().getRawQuery());
             byte[] body = "{\"code\":\"200\",\"data\":{\"id\":7,\"identifyString\":\"ultitrade\"}}".getBytes(StandardCharsets.UTF_8);

--- a/src/test/java/com/ultikits/ultitools/utils/PluginInstallUtilsTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/PluginInstallUtilsTest.java
@@ -2,6 +2,15 @@ package com.ultikits.ultitools.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.sun.net.httpserver.HttpServer;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.List;
@@ -10,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.Timeout;
 
 import com.ultikits.ultitools.entities.PluginEntity;
@@ -21,6 +31,71 @@ import com.ultikits.ultitools.entities.PluginEntity;
 @DisplayName("PluginInstallUtils 测试")
 @Timeout(value = 30, unit = TimeUnit.SECONDS)
 class PluginInstallUtilsTest {
+
+    @Test
+    void normalizesAndEncodesLookupForAllMetadataPaths() throws Exception {
+        AtomicReference<String> request = new AtomicReference<>();
+        AtomicReference<String> versionPath = new AtomicReference<>();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/plugin/get", exchange -> {
+            request.set(exchange.getRequestURI().getRawQuery());
+            byte[] body = "{\"code\":\"200\",\"data\":{\"id\":7,\"identifyString\":\"ultitrade\"}}".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/plugin/7/latest", exchange -> {
+            byte[] body = "{\"code\":\"200\",\"data\":\"1.0.0\"}".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/plugin/7/", exchange -> {
+            versionPath.set(exchange.getRequestURI().getRawPath());
+            byte[] body = "{\"code\":\"200\",\"data\":\"https://example.invalid/artifact.jar\"}"
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+        try {
+            PluginInstallUtils.setBaseUrlForTesting("http://localhost:" + server.getAddress().getPort());
+            assertThat(PluginInstallUtils.getPluginLatestVersion("  UltiTrade  ")).isEqualTo("1.0.0");
+            assertThat(request.get()).isEqualTo("identifyString=ultitrade");
+            assertThat(PluginInstallUtils.getPlugin(" bad name+/")).isNotNull();
+            assertThat(request.get()).isEqualTo("identifyString=bad+name%2B%2F");
+            assertThat(PluginInstallUtils.getPluginVersionDownloadLink("UltiTrade", "release candidate"))
+                    .isEqualTo("https://example.invalid/artifact.jar");
+            assertThat(versionPath.get()).isEqualTo("/plugin/7/release%20candidate/download");
+            assertThat(PluginInstallUtils.getPlugin(null)).isNull();
+            assertThat(PluginInstallUtils.getPlugin("  ")).isNull();
+        } finally {
+            PluginInstallUtils.resetBaseUrl();
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void constructsDeterministicSafeJarNames() {
+        assertThat(PluginInstallUtils.installedJarName(" UltiTrade ", "1.0.0-SNAPSHOT")).isEqualTo("ultitrade-1.0.0-SNAPSHOT.jar");
+        assertThat(PluginInstallUtils.installedJarName("../../escape", "../bad")).isNull();
+        assertThat(PluginInstallUtils.installedJarName(null, "1.0.0")).isNull();
+    }
+
+    @Test
+    void findsExistingPluginJarUsingCanonicalIdentifyString(@TempDir Path pluginsFolder) throws Exception {
+        Path jar = pluginsFolder.resolve("artifact.jar");
+        try (OutputStream output = java.nio.file.Files.newOutputStream(jar);
+             JarOutputStream jarOutput = new JarOutputStream(output)) {
+            jarOutput.putNextEntry(new JarEntry("plugin.yml"));
+            jarOutput.write("identify-string: ultitrade\n".getBytes(StandardCharsets.UTF_8));
+            jarOutput.closeEntry();
+        }
+
+        assertThat(PluginInstallUtils.findPluginJar(pluginsFolder.toFile(), " UltiTrade "))
+                .isEqualTo(jar.toFile());
+    }
 
     @Nested
     @DisplayName("类结构测试")


### PR DESCRIPTION
## Summary

- restrict module main-class discovery to concrete, non-abstract `UltiToolsPlugin` subclasses
- skip interfaces, abstract classes, and plain `IPlugin` implementations without throwing `ClassCastException`
- isolate unloadable class entries and malformed JARs so later valid plugins can still be discovered
- advance the unreleased development build from `6.2.4` to `6.2.5-SNAPSHOT`

## Version scope

This PR is a **6.2.5-SNAPSHOT test build**, not a release. The baseline-relative product scope is exactly:

1. `src/main/java/com/ultikits/ultitools/manager/PluginManager.java`
2. `src/test/java/com/ultikits/ultitools/manager/PluginManagerTest.java`
3. root `pom.xml` — project version only (`6.2.4` → `6.2.5-SNAPSHOT`)

`plugin.yml` and `env.yml` retain `${project.version}` and are verified through Maven filtering; `.flattened-pom.xml` is ignored build output and is not committed. `SecurityPolicy.java` remains unchanged/deferred.

## Verification

- `mvn help:evaluate -Dexpression=project.version -q -DforceStdout` — `6.2.5-SNAPSHOT`
- `mvn -Dtest=PluginManagerTest test` — 46 tests, 0 failures/errors
- `mvn test` — 4,158 tests, 0 failures/errors, 5 skipped
- `mvn clean package` — BUILD SUCCESS; `target/UltiTools-API-6.2.5-SNAPSHOT.jar`
- filtered `target/classes/plugin.yml` and `target/classes/env.yml` — concrete `6.2.5-SNAPSHOT`, no unresolved `${project.version}`
- `git diff --check origin/main..HEAD` — passed; changed paths exactly the three listed above

No release, publish, deploy, tag, merge, force-push, or manual workflow dispatch was performed.

<!-- quick-260803-08o-product-fixes -->

## Paper UAT gap fixes

This branch now also:

- treats PlaceholderAPI as a genuinely optional soft dependency on player join;
- canonicalizes and URL-encodes UPM identify strings;
- writes deterministic, path-safe module JAR names and finds legacy JARs case-insensitively;
- parses `6.2.5-SNAPSHOT[-qualifier]` through the legacy numeric compatibility contract;
- removes automatic FTP JavaDoc deployment from normal `main` builds. FTP remains explicit in the manual Release workflow.

Current-head local verification:

- focused: 116 tests, 0 failures/errors;
- full: 4,164 tests, 0 failures/errors, 5 skipped;
- `mvn clean package javadoc:javadoc`: pass;
- filtered `plugin.yml` and `env.yml`: `6.2.5-SNAPSHOT`;
- workflow YAML and no-main-FTP boundary: pass.

Focused Paper retest passed on Paper 1.21.11 build 132:

- exact `upm install UltiTrade` installed `ultitrade-1.0.0.jar`;
- restart loaded UltiTrade 1.0.0 with PlaceholderAPI, Vault and UltiTools 6.2.5-SNAPSHOT;
- startup ERROR/SEVERE/Exception, scanner ClassCast and SNAPSHOT parse signatures: 0;
- Drive/local/remote exchange hashes match.

A fresh rebuild and exact-case Paper UAT on head `643e5cf` passed:

- focused: 116 tests, 0 failures/errors;
- full: 4,165 tests, 0 failures/errors, 5 skipped;
- `mvn clean package javadoc:javadoc` and PMD: pass;
- exact `upm install UltiTrade` used the version-specific artifact path and installed `ultitrade-1.0.0.jar`;
- restart loaded UltiTrade 1.0.0 with PlaceholderAPI, Vault and UltiTools;
- Framework SHA-256: `7b9c07e5ac36c2fb617703a59a925eb4302a5a6bf008c52fb46d9eaecf798ca8`;
- tracked startup error signatures: 0; Drive/local/remote hashes match.

Current-head remote CI and required review are still pending before merge.

Current-head static-analysis reconciliation (`b670998`):

- official Codacy CLI v2 with Codacy default PMD 7.11.0 ran on repo-external git archives;
- base PMD fingerprints: 508; candidate: 507; new fingerprints: 0;
- Maven PMD target files: 0 issues;
- full suite: 4,165 tests, 0 failures/errors, 5 skipped; package/Javadoc pass;
- the production `PluginManager.class` bytes are identical to the Paper-UAT artifact, so the mechanical qualifier cleanup does not stale the focused runtime result.

Remote Codacy and required review remain pending before merge.

### Codacy Lizard test split (5790843)
- Moved the two module-main-class scanner regressions and their JAR/reflection fixtures from `PluginManagerTest` to `PluginManagerClassScanningTest`; production sources unchanged.
- Lizard NLOC: `PluginManagerTest` 486, `PluginManagerClassScanningTest` 119 (both below the 500 threshold).
- Official Codacy CLI default-analyzer normalized base-to-candidate delta: 0 new findings; target Lizard findings: 0.
- Targeted: 116 tests, 0 failures/errors/skips. Full: 4,165 tests, 0 failures/errors, 5 skipped. Package, Javadoc, Maven PMD: PASS.
- Independent split review: 0 Critical / 0 High / 0 Medium.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stricter plugin version validation for numeric and snapshot versions.
  - Plugin installation now uses safer, consistent JAR filenames and supports normalized, URL-encoded plugin lookups.
- **Bug Fixes**
  - Improved plugin discovery when encountering invalid, abstract, or unavailable classes and malformed JAR files.
  - Prevented join-related PlaceholderAPI issues when the plugin is missing, disabled, or unavailable.
  - Added clearer logging for unreadable or failed plugin scans.
- **Release**
  - Updated the project version to 6.2.5-SNAPSHOT.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Codacy Opengrep SSRF fixture fix (20d48b4)
- Codacy public PR-issues API identified the sole Added issue exactly: Opengrep `Semgrep_java_ssrf_rule-SSRF`, `PluginInstallUtilsTest.java:40`, wildcard-bound local test server.
- Changed only the test fixture bind to `InetAddress.getLoopbackAddress()`; no suppression, analyzer disablement, or production change.
- Targeted: 116 tests, 0 failures/errors/skips. Full: 4,165 tests, 0 failures/errors, 5 skipped. Package, Javadoc, Maven PMD: PASS.

### Codacy exact Opengrep rule remediation (168f9bc)
- Read the exact `java_ssrf_rule-SSRF` source: non-literal `InetSocketAddress` hosts are flagged; a literal host is the explicit safe pattern.
- Java 8-compatible test fixture now binds to fixed `127.0.0.1`; no suppression, rule disablement, dependency, or production change.
- Targeted: 116/116. Full: 4,165 tests, 0 failures/errors, 5 skipped. Package, Javadoc, Maven PMD: PASS.
