### PR TITLE
docs: add PROJECT.md control card for coding agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,9 @@ CLAUDE.md
 secring.gpg
 .claude/settings.local.json
 data.json
+
+# Eclipse / JDT
+.classpath
+.project
+.factorypath
+.settings/

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,171 @@
+# PROJECT: UltiTools-Reborn
+
+> Control card for coding agents working in this repository.
+> Scope: **this repository only.** Every number here is a snapshot — verify against `git`, `pom.xml`,
+> and the workflow files before relying on it.
+
+## Identity
+
+- **What it is:** `UltiTools-API` — an annotation-driven plugin framework for Minecraft **Paper** servers.
+  It ships its own IoC container, CGLIB-based AOP, an ORM over MySQL/SQLite/JSON, a declarative reactive
+  GUI layer, a module EventBus, and a WebSocket client for remote server management.
+- **Maven coordinates:** `com.ultikits:UltiTools-API` — read the current version from `pom.xml`;
+  `main` and `alpha` do not always carry the same one. Produces a shaded JAR via maven-shade-plugin.
+- **No Spring.** The IoC container is hand-written (`context/SimpleContainer`); `pom.xml` declares no Spring
+  dependency at all. `@Service`, `@Autowired`, `@Configuration` and friends are **this framework's own
+  annotations** under `com.ultikits.ultitools.annotations` — importing Spring's will not resolve against the
+  published artifact.
+- **Three version numbers, all different, all intentional:**
+
+  | Where | Value | Meaning |
+  |---|---|---|
+  | `pom.xml` `<java.version>` | `1.8` | `-source` / `-target` bytecode level |
+  | CI toolchain + `paper-api` | JDK 21 · Paper `1.21.11-R0.1-SNAPSHOT` | build toolchain and compile-time API |
+  | `plugin.yml` `api-version` | `1.19` | Bukkit API level |
+
+  The pom uses `-source`/`-target`, **not** `--release`, and the codebase relies on that gap (for example
+  `@Deprecated(since=…, forRemoval=…)` is a Java 9+ construct). Adding `<release>8</release>` breaks the
+  build. Practically: avoid `var` and records, but do not assume a real JDK 8 compiles this.
+- **Runtime dependency model:** only `paper-api`, at `provided` scope. Paper auto-downloads the `libraries:`
+  entries declared in `plugin.yml`. Adventure `Component` is used throughout, so plain Spigot is not a
+  supported build target.
+- **Downstream:** consumer plugin modules declare `com.ultikits:UltiTools-API` at `provided` scope. Bumping
+  the version here affects every consumer that hard-codes it rather than inheriting a property.
+
+## Branching Rule
+
+**Two long-lived branches. Never commit to either directly.**
+
+- **`main` is the GitHub default branch** (`origin/HEAD` → `origin/main`). It is also the only branch
+  `maven-ci.yml` accepts pull requests into.
+- **`alpha` is a parallel long-lived branch**, not the default. The two have diverged, and the same change is
+  sometimes shipped to both as separate PRs (for example #166 → `main`, #167 → `alpha`).
+- **Ask which branch to target before starting.** Release-bound work goes to `main`; work coordinated with
+  the downstream module rollout has historically gone to `alpha`. Do not guess.
+- **Before editing, run `git branch --show-current`.** If it returns `main` or `alpha`, branch off first.
+- **Enforcement is configured through repository rulesets and branch protection, and it changes.** Do not
+  assume a branch is locked just because this file says so — check the live state:
+
+  ```bash
+  gh api repos/UltiKits/UltiTools-Reborn/rulesets \
+    --jq '.[] | "\(.name)\t\(.enforcement)"'
+  gh api repos/UltiKits/UltiTools-Reborn/branches/main/protection \
+    --jq '.required_pull_request_reviews'
+  ```
+- **Branch naming:** `feature/<short-description>`, `fix/<short-description>`, `chore/<short-description>`,
+  `docs/<short-description>`.
+- Measure the current divergence instead of trusting a number written here:
+
+  ```bash
+  MB=$(git merge-base origin/main origin/alpha)
+  git rev-list --count $MB..origin/main     # commits main is ahead
+  git rev-list --count $MB..origin/alpha    # commits alpha is ahead
+  ```
+
+## Build / Test / Verify
+
+All commands run from the repository root.
+
+| Goal | Command |
+|---|---|
+| Build shaded JAR | `mvn clean package` → `target/UltiTools-API-<version>.jar` |
+| Test | `mvn test` |
+| Single test class | `mvn test -Dtest=ClassName` |
+| Include isolated tests | `mvn test -DexcludedGroups=` |
+| Javadoc | `mvn javadoc:javadoc` → `target/site/apidocs/` |
+
+- `pom.xml` sets `<excludedGroups>isolated</excludedGroups>`, so `@Tag("isolated")` tests are skipped by
+  default. That property name is also Surefire's own user property, which is why passing it empty re-enables
+  them.
+- JaCoCo runs automatically during `mvn test` → `target/site/jacoco/index.html`. **No coverage threshold is
+  enforced** — the `check` rule exists but is commented out.
+- `mvn package` also runs `ultitools-maven-plugin`, which copies the JAR to `${ultitools.deploy.folder}`
+  (default `target/deploy/`). Override it on the command line to deploy to a local test server:
+  `mvn package -Dultitools.deploy.folder=/path/to/server/plugins`. **Never hard-code a local path into
+  `pom.xml`** — see "Public repository hygiene".
+
+## CI
+
+All jobs run on JDK 21 (temurin). Re-read the workflow files rather than trusting this table if behaviour
+surprises you.
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `maven-ci.yml` | `push` on every branch, **and** `pull_request` into `main` only | `mvn -B test`, then `mvn -B package` |
+| `publish-packages.yml` | `release: [published]` — a published GitHub Release, **not** a tag push | Sets the version from the release tag, builds skipping tests and GPG, publishes to GitHub Packages under the lowercase id `ultitools-api`. A second `publish-central` job targets Maven Central but is gated behind the repository variable `PUBLISH_TO_CENTRAL == 'true'` — it does not run unless that variable is set. |
+| `release.yml` | `workflow_dispatch` only, with inputs `release_type`, `release_notes`, `dry_run` | Rejects versions containing `SNAPSHOT`, runs tests, builds package + javadoc, creates the GitHub Release, uploads javadoc over FTP |
+
+Maven Central publishing goes through `central-publishing-maven-plugin` with server id `ultikits-sonatype`.
+
+The release path is shared with every downstream module repository — **get maintainer sign-off before
+changing `publish-packages.yml` or `release.yml`.** Verification-only changes to `maven-ci.yml` are made
+routinely.
+
+## Scope Boundaries
+
+- **Do NOT modify:** `target/` (build output), `.flattened-pom.xml` (generated by flatten-maven-plugin), IDE
+  artifacts (`.idea/`, `*.iml`, `.classpath`, `.project`, `.settings/`), generated sources.
+- **Do NOT commit:** secrets, `.env*`, `data.json`, local config overrides, OS junk (`.DS_Store`,
+  `Thumbs.db`).
+- **Leave unrelated dirty entries alone.** Do not stage, restore, stash, or overwrite working-tree changes
+  you did not make. Run `git status --porcelain` and check what is actually yours first.
+
+### ⚠ Credential hazard: `data.json`
+
+`data.json` in the repository root holds the server UUID and — once `ulticloud login` has run against this
+working copy — the UltiCloud `access_token` and `refresh_token`. Running the framework or a build with the
+repository root as the working directory creates it. **This is a public repository.**
+
+`main` and `alpha` both gitignore and untrack it. **Branches cut before PRs #166/#167 do not.** Before
+staging anything, run both:
+
+```bash
+git ls-files --error-unmatch data.json   # expected to FAIL: "did not match any file"
+git check-ignore -v data.json            # expected to print a .gitignore line
+```
+
+If it is tracked, `git rm --cached data.json` and rebase onto the current default branch before committing.
+
+### Public repository hygiene
+
+- No absolute developer paths (`/home/<user>/`, `/Users/<user>/`, `C:\Users\`) in tracked files —
+  parameterize them as Maven properties, or write `/path/to/...` in documentation.
+- No real server IDs, tokens, or panel identifiers in `config-example.yml` or documentation — use
+  `<your-server-id>`-style placeholders.
+- CI credentials come from `${{ secrets.* }}` only, and must never be echoed into job logs.
+- **Tracked text files use CRLF line endings** (`.gitignore`, `README.md`, `pom.xml` at minimum). Scripted
+  edits that normalize to LF turn a three-line change into a whole-file rewrite — disable newline
+  translation when editing programmatically.
+
+## Pitfalls
+
+1. **`@Service` must be `com.ultikits.ultitools.annotations.Service`** — not Spring's. There is no Spring on
+   the classpath.
+2. **`UltiToolsPlugin` is not a Bukkit `Plugin`.** For scheduler tasks use
+   `Bukkit.getPluginManager().getPlugin("UltiTools")`; do not cast it to `JavaPlugin`.
+3. **`BaseCommandExecutor` is not auto-registered.** `CommandManager`'s package scan casts discovered classes
+   to the legacy `AbstractCommandExecutor`, so a `BaseCommandExecutor` picked up by `@CmdExecutor` scanning
+   throws `ClassCastException` — which the surrounding catch swallows. Register it explicitly via
+   `CommandManager.register(plugin, Class)`.
+4. **Bukkit thread safety.** Anything reaching Bukkit from an async context must go through
+   `Bukkit.getScheduler().runTask()`, or Paper's AsyncCatcher rejects it.
+5. **AOP uses CGLIB subclass proxies only.** `final` classes and methods cannot be proxied, and
+   self-invocation (`this.method()`) bypasses the interceptor chain.
+6. **Event listeners need the framework's `@EventListener`**, not just Bukkit's `Listener` interface.
+
+## Related Docs
+
+Reading order for an agent starting work here:
+
+1. This `PROJECT.md`
+2. `README.md` — quick start, dependency snippet, module scaffolding
+3. `pom.xml` — published coordinates, shaded JAR layout, plugin configuration
+4. Developer documentation — [dev.ultikits.com](https://dev.ultikits.com)
+5. Issues and discussion — [GitHub Issues](https://github.com/UltiKits/UltiTools-Reborn/issues)
+
+## Last Verified
+
+- **Date:** 2026-08-10
+- **How:** every claim re-checked against `git`, `pom.xml`, `plugin.yml`, the workflow files, and the source
+  tree. Nothing was carried over on trust.
+- **Next verification due:** after the next release, or whenever `main` and `alpha` are reconciled.


### PR DESCRIPTION
## What

Adds `PROJECT.md` — a per-repo control card for coding agents working in this repository — and gitignores Eclipse/JDT artifacts.

### `PROJECT.md` (new, 161 lines)

Describes **this repository only**: identity and the three-version matrix, branching rules for the `main`/`alpha` pair, build and test commands, CI triggers, scope boundaries, a `data.json` credential warning, and six pitfalls that repeatedly bite newcomers (`@Service` is not Spring's, `UltiToolsPlugin` is not a Bukkit `Plugin`, `BaseCommandExecutor` is not auto-registered, …).

Numbers that go stale are replaced with the command to measure them live — e.g. branch divergence is given as a `git merge-base` + `git rev-list --count` snippet rather than a hard-coded count.

### `.gitignore` (+6)

`.classpath`, `.project`, `.factorypath`, `.settings/` were untracked but **not ignored**, so any `git add -A` would have swept them in. This mirrors the existing `.idea/` entry for IntelliJ. Appended with CRLF to match the file's existing line endings, so the diff stays at 6 lines instead of a whole-file rewrite.

## Verification

Every claim was checked against the repo rather than carried over from an earlier draft. Corrections made in the process:

| Earlier draft said | Actual |
|---|---|
| "the shaded artifact excludes Spring" | `pom.xml` contains **zero** occurrences of `spring` — the IoC container is hand-written, Spring was never a dependency |
| FTP deploy at `release.yml:210` | line **211** — line-number references dropped entirely as too fragile |
| Cited commits `26b4982`, `9be900c` as recent CI work | Neither exists on any remote branch (local, unpushed) — removed |

Confirmed accurate and kept: the `PUBLISH_TO_CENTRAL` gate, `release: [published]` trigger, `workflow_dispatch`-only release, `<java.version>1.8</java.version>`, `paper-api 1.21.11-R0.1-SNAPSHOT`, `api-version: '1.19'`, `excludedGroups=isolated`, the `@Service` package, and the `CommandManager` cast to `AbstractCommandExecutor`.

No absolute developer paths, no local tooling references, no credentials.

---

**Companion PR:** the same change targets `alpha` separately, following the #166/#167 precedent. This copy states the Maven coordinate as `6.2.5-SNAPSHOT` to match `main`'s `pom.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dNyRoPKefTmHVbWCwgPLP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a repository guide covering project structure, development workflows, build and test commands, release processes, and contribution boundaries.

* **Chores**
  * Updated ignore rules to exclude Eclipse and JDT-generated project and workspace files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->