### PR TITLE
ci: restrict main to alpha-sourced PRs, run CI on alpha PRs

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "**" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "alpha" ]
 
 jobs:
   # ==================== 测试阶段 ====================

--- a/.github/workflows/pr-source-guard.yml
+++ b/.github/workflows/pr-source-guard.yml
@@ -1,0 +1,38 @@
+name: PR Source Guard
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+# `main` accepts pull requests from `alpha` only. Everything else integrates
+# into `alpha` first. GitHub has no native way to restrict a pull request's
+# source branch, so this job provides it and is wired up as a required check.
+#
+# To allow emergency fixes to bypass the alpha integration step, add a second
+# accepted pattern below, e.g.:
+#     case "$HEAD_REF" in alpha|hotfix/*) ;; *) exit 1 ;; esac
+
+jobs:
+  check-source:
+    name: PR into main must come from alpha
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Verify head branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          THIS_REPO: ${{ github.repository }}
+        run: |
+          if [ "$HEAD_REPO" != "$THIS_REPO" ]; then
+            echo "::error::Pull requests into main must come from this repository. This one is from '$HEAD_REPO'."
+            echo "Open it against 'alpha' instead."
+            exit 1
+          fi
+          if [ "$HEAD_REF" != "alpha" ]; then
+            echo "::error::Pull requests into main must originate from 'alpha'. This one is from '$HEAD_REF'."
+            echo "Merge into 'alpha' first, then open alpha -> main."
+            exit 1
+          fi
+          echo "Source branch OK: $HEAD_REF"


### PR DESCRIPTION
## What

Implements the code half of a `feature → alpha → main` branch policy. The other half is repository settings, which cannot be expressed in code — see "What still has to be configured by hand" below.

### `pr-source-guard.yml` (new)

**GitHub branch protection and rulesets cannot restrict a pull request's source branch** — there is no such rule type. This workflow supplies it: a pull request into `main` fails unless its head branch is `alpha` *and* it comes from this repository, not a fork.

The fork check is not redundant. `github.head_ref` carries the branch name alone with no owner, so anyone could fork the repo, name a branch `alpha`, and open a PR against `main`. `head.repo.full_name` is what actually distinguishes them.

The workflow is **advisory until it is added to the required status checks for `main`** — until then it just paints a red X and the PR stays mergeable.

### `maven-ci.yml` (+1/-1)

```diff
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "alpha" ]
```

Under the new flow most pull requests target `alpha`, and `alpha` previously received **no pull-request-level CI at all** — the exact review step that most needs a gate was the one without one.

## Expected failure on the `main` copy

This change is self-referential: the guard it introduces rejects the very branch that introduces it (`ci/branch-policy-main` is not `alpha`). The red X on the `main`-targeted copy is the workflow proving it works.

**Merge this before adding the check to required status checks**, or the rule locks its own introduction out.

## What still has to be configured by hand

Code cannot set any of these — they live in repository settings:

1. **`alpha` has no protection at all** — needs a ruleset (restrict deletions, block force pushes, require a pull request).
2. **The existing `Main` ruleset grants `OrganizationAdmin` and `RepositoryRole` `bypass_mode: always`**, and classic protection has `enforce_admins: false`. The rules are already in place; they are simply waived for everyone who would trigger them.
3. **This guard must be added to required status checks for `main`** — after this PR merges and the job has run once, otherwise it does not appear in the picker.

## Verification

- Both workflow files parse as YAML.
- The guard's branch logic was exercised offline against three cases: `alpha` from this repo → pass; `ci/branch-policy-main` from this repo → reject; `alpha` from a fork → reject.
- `maven-ci.yml` uses CRLF line endings; the edit preserves them, so the diff is one line rather than a whole-file rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dNyRoPKefTmHVbWCwgPLP
