### PR TITLE
ci: 发布正式版后自动开文档同步 issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,7 +231,7 @@ jobs:
         - [ ] \`examples/pom.xml\` 的 \`<ultitools.version>\` 更新为 ${VERSION}
         - [ ] \`.vitepress/config.mts\` 的 \`versionsConfig.current\` 更新为 v${VERSION}，并把 \`docs/src/\` 快照进 \`docs/archive/\`
         - [ ] \`mvn -f examples/pom.xml compile\` 通过（编译失败的示例即需要改的页面）
-        - [ ] 跑 \`./scripts/report-doc-coverage.sh <上一版本> ${VERSION}\` 并处理报告中的两段清单
+        - [ ] 跑 \`./scripts/report-doc-coverage.sh 6.2.4 ${VERSION}\`（第一个参数替换为上一个正式发布版本号，示例中的 6.2.4 仅供参考）并处理报告中的两段清单
 
         关闭本 issue 即代表本次同步完成。
         EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,6 +220,7 @@ jobs:
         GH_TOKEN: ${{ secrets.DOCS_REPO_TOKEN }}
         VERSION: ${{ needs.validate.outputs.version }}
       if: ${{ env.GH_TOKEN != '' }}
+      continue-on-error: true
       run: |
         gh issue create \
           --repo UltiKits/UltiTools-Dev-Doc \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,27 @@ jobs:
         password: ${{ secrets.FTP_PASSWORD }}
         local-dir: "./javadoc/"
 
+    - name: 📖 Open documentation sync issue
+      env:
+        GH_TOKEN: ${{ secrets.DOCS_REPO_TOKEN }}
+        VERSION: ${{ needs.validate.outputs.version }}
+      if: ${{ env.GH_TOKEN != '' }}
+      run: |
+        gh issue create \
+          --repo UltiKits/UltiTools-Dev-Doc \
+          --title "docs: sync v${VERSION}" \
+          --body "$(cat <<EOF
+        UltiTools-API v${VERSION} 已发布，文档需要同步。
+
+        - [ ] \`examples/pom.xml\` 的 \`<ultitools.version>\` 更新为 ${VERSION}
+        - [ ] \`.vitepress/config.mts\` 的 \`versionsConfig.current\` 更新为 v${VERSION}，并把 \`docs/src/\` 快照进 \`docs/archive/\`
+        - [ ] \`mvn -f examples/pom.xml compile\` 通过（编译失败的示例即需要改的页面）
+        - [ ] 跑 \`./scripts/report-doc-coverage.sh <上一版本> ${VERSION}\` 并处理报告中的两段清单
+
+        关闭本 issue 即代表本次同步完成。
+        EOF
+        )"
+
     - name: 📝 Release Summary
       env:
         VERSION: ${{ needs.validate.outputs.version }}


### PR DESCRIPTION
正式版发布成功后，自动去 `UltiKits/UltiTools-Dev-Doc` 开一个 `docs: sync vX.Y.Z` issue，body 是一份可勾的 checklist（更新示例模块依赖版本、更新文档站 current 并归档上一版、跑编译门禁、跑覆盖率报告）。关掉那个 issue 就代表这一版的文档同步完成了。

这样留痕的颗粒度跟发布节奏对齐——**一个正式版一条记录，SNAPSHOT 阶段不产生任何噪音**。文档仓库那边的机制见 UltiKits/UltiTools-Dev-Doc#5。

三点安全性说明：

**不配 token 就不生效。** `if: ${{ env.GH_TOKEN != '' }}` 守着，没配 `DOCS_REPO_TOKEN` 时这一步直接跳过，发布流程完全不受影响。这个 guard 的语义不是靠推测——查了真实生产仓库里同款写法（`env:` 紧跟 `if: env.X` 在同一 step）某次成功运行的 step conclusion 确认的。

**配了也不会拖垮发版。** 加了 `continue-on-error: true`。开 issue 这一步的语义是「尽力而为的辅助通知」，token 权限不对、GitHub API 抖动、文档仓库改名——任何瞬时故障都不该让一次 JAR、Release、JavaDoc 全部成功的发布显示成失败。

**那段 heredoc 验证过三次。** 它嵌在 `run: |` 里，`EOF` 看着带缩进——YAML block scalar 会剥离公共缩进，剥离后正好顶格，heredoc 正常终止；`${VERSION}` 正常展开；转义反引号输出的是字面反引号而不是触发命令替换。三方各自独立把 `run` 提取出来配假 `gh` 实跑验证过。

合并后需要你在本仓库 Settings → Secrets 配 `DOCS_REPO_TOKEN`（要有 UltiTools-Dev-Doc 的 issue 写权限），这一步才会真正开始工作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzTkgBjRdaTcLrbvkoaFkp
