### PR TITLE
ci: PR 阶段跑完整 verify 生命周期

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -25,8 +25,12 @@ jobs:
         distribution: 'temurin'
         cache: maven
 
-    - name: 🧪 Run Tests with Coverage
-      run: mvn -B clean test
+    - name: 🧪 Build & Test with Coverage
+      # verify 而不是 test：shade 过滤器、资源过滤、jar 打包与 javadoc 生成都绑定在
+      # package 阶段，只跑 test 的话这些在合并之后才第一次执行。
+      # gpg.skip：maven-gpg-plugin 绑在 verify 上，签名只在发布时需要，
+      # 这里没有也不应该有私钥（与 publish-packages.yml 的 GitHub Packages 构建一致）。
+      run: mvn -B clean verify -Dgpg.skip=true
       
     - name: 📊 Generate JaCoCo Coverage Report
       run: mvn -B jacoco:report


### PR DESCRIPTION
Closes #185

## 问题

`maven-ci.yml` 的 `test` job 只跑 `mvn -B clean test`。`maven-shade-plugin`、`maven-jar-plugin`、`maven-javadoc-plugin` 全部绑定在 `package` 阶段，所以 shade 过滤器、资源过滤、jar 打包和 javadoc 生成在 PR 阶段**一次都没执行过**——第一次执行是在合并之后的 `build-snapshot`（而且那个 job 还有 `github.ref == 'refs/heads/main'` 的门禁）。整类打包回归可以合进 `alpha` 而不被发现。

## 改动

`test` job 的命令改为 `mvn -B clean verify -Dgpg.skip=true`。

`-Dgpg.skip=true` 不是可选的：`maven-gpg-plugin` 绑在 `verify` 上且不在任何 profile 内（`pom.xml:317-330`），runner 上没有私钥，不加这个标志会直接 `gpg: no default secret key` 构建失败。这与 `publish-packages.yml` 里 GitHub Packages 构建的写法一致；Maven Central 那个 job 仍然签名，因为密钥是在那一步导入的。

Job 的 `name:` 没有动 —— 它是 `alpha` 和 `main` 上的必需检查名，改了会让所有 PR 卡在 pending。

## 验证

本地 `mvn -B clean verify -Dgpg.skip=true`：

```
[INFO] --- maven-jar-plugin:3.1.0:jar (default-jar) @ UltiTools-API ---
[INFO] --- maven-shade-plugin:3.5.1:shade (default) @ UltiTools-API ---
[INFO] --- maven-javadoc-plugin:3.6.3:jar (default) @ UltiTools-API ---
[INFO] --- maven-gpg-plugin:1.6:sign (sign-artifacts) @ UltiTools-API ---
[WARNING] Tests run: 4165, Failures: 0, Errors: 0, Skipped: 5
[INFO] BUILD SUCCESS
```

本 PR 自己的 CI run 就是验收证据：日志里应当能看到上面这几个 package 阶段插件。

## 顺带发现（不在本 PR 范围）

`maven-gpg-plugin` 无条件绑在 `verify` 上，意味着任何没有配置 GPG 私钥的开发者跑 `mvn clean verify` 都会失败。要么把它挪进 release profile，要么在文档里把本地命令写成带 `-Dgpg.skip=true`。留给后续单独处理。