### PR TITLE
ci: build-snapshot 门禁改为 alpha

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -104,7 +104,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # alpha 是开发主干，SNAPSHOT 构件对它才有意义；main 上的正式产物由
+    # publish-packages.yml 在 release 时产出。
+    if: github.event_name == 'push' && github.ref == 'refs/heads/alpha'
     
     steps:
     - name: 📥 Checkout code


### PR DESCRIPTION
Closes #240

`build-snapshot` 的门禁是 `github.ref == 'refs/heads/main'`，但开发主干是 `alpha` —— PR 都开向 `alpha`，日常合并落在 `alpha`，`main` 只在准备发版时才动。结果这个 job 实际上从不运行，它存在的理由（每个主干提交产出一个带 short SHA 的 SNAPSHOT 构件，保留 14 天）一次都没兑现过。

门禁改成 `refs/heads/alpha`。发版产物由 `publish-packages.yml` 在 release 事件上产出，`main` 不需要这个 job。

`test` job 的 `name:` 没有动（必需检查名）。YAML 已用 `yaml.safe_load` 校验，两个 job 都能正确解析。

> 如果你希望 `main` 上也保留，改成
> `contains(fromJSON('["refs/heads/alpha","refs/heads/main"]'), github.ref)` 即可，我按你说的先只改 alpha。

**验收在合并之后**：这个 PR 合进 `alpha` 的那次 push 就会触发 `🔨 Build SNAPSHOT`，Artifacts 里应当出现 `ultitools-snapshot-6.2.5-SNAPSHOT-<sha>`。