### PR TITLE
build: 用 animal-sniffer 看守 Java 8 API 边界

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,43 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <!--
+                Animal Sniffer — 看守 Java 8 API 边界。
+                编译用的是 source/target 1.8 而不是 <release>8</release>，所以 javac
+                链接的是 JDK 21 的类库：误用 Java 9+ 的 API（String.strip、List.of、
+                Map.entry 等）能编译通过，直到在真 Java 8 上运行才抛 NoSuchMethodError。
+                这里在字节码层比对 java18 签名，把那个缺口补上。
+
+                不要改用 <release>8</release> —— 它会拒绝本项目已在使用的
+                @Deprecated(since=, forRemoval=)，而那些元数据是废弃契约的一部分。
+
+                Animal Sniffer — guards the Java 8 API boundary.
+                The build uses source/target 1.8 rather than <release>8</release>, so
+                javac links against the JDK 21 class library and Java 9+ API calls
+                compile cleanly, only failing with NoSuchMethodError on a real Java 8
+                runtime. This checks the emitted bytecode against the java18 signature.
+            -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.27</version>
+                <configuration>
+                    <signature>
+                        <groupId>org.codehaus.mojo.signature</groupId>
+                        <artifactId>java18</artifactId>
+                        <version>1.0</version>
+                    </signature>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-java18-api</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
Closes #186

## 问题

编译用的是 `source`/`target` 1.8 而不是 `release` 8，所以 javac 链接的是 **JDK 21 的类库**。误用 Java 9+ 的 API 会安安静静编译通过，直到在真 Java 8 上运行才抛 `NoSuchMethodError`。目前没有任何东西在看守这条边界。

## 改动

加 `animal-sniffer-maven-plugin:1.27`，签名 `org.codehaus.mojo.signature:java18:1.0`，绑定到 `verify`。它在字节码层比对 Java 8 的 API 面，补上 javac 看不见的那段。

**没有改用 `release` 8** —— 按 issue 的要求。那个方案更彻底，但会拒绝本项目已在使用的 `@Deprecated(since=, forRemoval=)`（Java 9+ 语法），而这些元数据正是 6.3.0 废弃契约要加强的东西。

绑定在 `verify` 而不是更早的阶段，是照 issue 写的。#185 刚把 PR job 改成跑 `verify`，所以这道检查在每个 PR 上都会实际执行——两条是配套的，顺序不能反。

## 验证

**正向**：`mvn -B clean verify -Dgpg.skip=true` 通过，印证 issue 说的当前零违规。

```
[INFO] --- animal-sniffer-maven-plugin:1.27:check (check-java18-api) @ UltiTools-API ---
[INFO] Checking unresolved references to org.codehaus.mojo.signature:java18:1.0
[INFO] BUILD SUCCESS
```

**反向**（验收标准）：在 `VersionComparatorUtil.stripPrefix` 里临时插一行 `version.strip()`——**这行编译通过了**，然后：

```
[ERROR] .../VersionComparatorUtil.java:83: Undefined reference: String String.strip()
[ERROR] Failed to execute goal ...animal-sniffer-maven-plugin:1.27:check: Signature errors found.
[INFO] BUILD FAILURE
```

移除后恢复通过。插桩已还原，本 PR 只改 `pom.xml` 一个文件。

## 备注

如果以后想要更快的反馈，可以把 `phase` 从 `verify` 挪到 `process-classes`，这样 `mvn test` 也会跑到它。我按 issue 原文用了 `verify`，也和账本里「本地先跑 `mvn clean verify`」的流程一致。