### PR TITLE
feat(api): 用 @ApiStatus.Internal 标出框架内部实现的边界

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -461,6 +461,24 @@
             <version>1.18.38</version>
             <scope>provided</scope>
         </dependency>
+        <!--
+            JetBrains @ApiStatus —— 只用来标 API 稳定性边界，是给人和 IDE 看的信号，
+            不产生任何运行期约束。全系注解都是 RetentionPolicy.CLASS，运行时不需要
+            这个 jar：所以 scope 用 provided、plugin.yml 的 libraries: 不加条目、
+            shaded JAR 里也不该出现 org/jetbrains/**。这三件事是一套的，动一个要一起动。
+
+            JetBrains @ApiStatus — used only to mark API stability boundaries. It is a
+            signal for humans and IDEs, and enforces nothing at runtime. Every annotation
+            in the family is RetentionPolicy.CLASS, so the jar is not needed at runtime:
+            hence provided scope, no plugin.yml libraries: entry, and no org/jetbrains/**
+            inside the shaded JAR. Those three facts move together.
+        -->
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>26.0.2</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>com.github.MilkBowl</groupId>
             <artifactId>VaultAPI</artifactId>

--- a/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
@@ -18,6 +18,7 @@ import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.jetbrains.annotations.ApiStatus;
 
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
@@ -69,7 +70,6 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
     @Getter
     @Setter
     private String resourceFolderPath;
-    @Setter
     @Getter
     private SimpleContainer context;
 
@@ -200,6 +200,37 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Injects the IoC container created for this plugin.
+     * <p>
+     * 注入为本插件创建的 IoC 容器。
+     * <p>
+     * Called by {@code PluginManager} while a module is being loaded, before
+     * {@code registerSelf()} runs. It is not part of the module-facing API — a
+     * module that calls it replaces the container the framework already wired up,
+     * losing every bean that was injected into it.
+     * <p>
+     * 由 {@code PluginManager} 在加载模块时调用，早于 {@code registerSelf()}。它不属于
+     * 面向模块的 API——模块自己调用它，等于把框架已经装配好的容器整个换掉，里面注入过的
+     * bean 全部丢失。
+     * <p>
+     * Deliberately still public: {@code PluginManager} lives in another package, so
+     * this cannot be narrowed to package-private, and deleting it outright would
+     * remove a public method, which the compatibility policy forbids in a PATCH
+     * release. The annotation is a signal to humans and IDEs; it enforces nothing
+     * at runtime.
+     * <p>
+     * 刻意保持 public：{@code PluginManager} 不在同一个包，降不成 package-private；
+     * 直接删掉则是移除一个 public 方法，兼容性策略不允许 PATCH 版本这么做。注解只是给人
+     * 和 IDE 看的信号，运行期不做任何强制。
+     *
+     * @param context the container created for this plugin <br> 为本插件创建的容器
+     */
+    @ApiStatus.Internal
+    public void setContext(SimpleContainer context) {
+        this.context = context;
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/context/AutowireFactory.java
+++ b/src/main/java/com/ultikits/ultitools/context/AutowireFactory.java
@@ -3,6 +3,7 @@ package com.ultikits.ultitools.context;
 import com.ultikits.ultitools.annotations.Autowired;
 
 import java.lang.reflect.Field;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Simple autowire factory to replace Spring's AutowireCapableBeanFactory.
@@ -10,6 +11,7 @@ import java.lang.reflect.Field;
  * 简单的自动装配工厂，用于替换Spring的AutowireCapableBeanFactory。
  */
 @SuppressWarnings("PMD.AvoidAccessibilityAlteration") // Autowiring requires reflection
+@ApiStatus.Internal
 public class AutowireFactory {
     private final SimpleContainer container;
 

--- a/src/main/java/com/ultikits/ultitools/context/BeanDefinition.java
+++ b/src/main/java/com/ultikits/ultitools/context/BeanDefinition.java
@@ -3,12 +3,14 @@ package com.ultikits.ultitools.context;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Bean definition to hold metadata about a bean.
  * <br>
  * Bean定义类，用于保存Bean的元数据。
  */
+@ApiStatus.Internal
 public class BeanDefinition {
     private Class<?> beanClass;
     private String beanName;

--- a/src/main/java/com/ultikits/ultitools/context/BeanFactory.java
+++ b/src/main/java/com/ultikits/ultitools/context/BeanFactory.java
@@ -1,10 +1,13 @@
 package com.ultikits.ultitools.context;
 
+import org.jetbrains.annotations.ApiStatus;
+
 /**
  * Simple bean factory to replace Spring's BeanFactory.
  * <br>
  * 简单的Bean工厂，用于替换Spring的BeanFactory。
  */
+@ApiStatus.Internal
 public class BeanFactory {
     private final SimpleContainer container;
 

--- a/src/main/java/com/ultikits/ultitools/context/ComponentScanner.java
+++ b/src/main/java/com/ultikits/ultitools/context/ComponentScanner.java
@@ -20,12 +20,14 @@ import com.ultikits.ultitools.annotations.EventListener;
 import com.ultikits.ultitools.annotations.Service;
 
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Component scanner to find and register components.
  * <br>
  * 组件扫描器，用于查找和注册组件。
  */
+@ApiStatus.Internal
 public class ComponentScanner {
     private final SimpleContainer container;
 

--- a/src/main/java/com/ultikits/ultitools/context/ContextConfig.java
+++ b/src/main/java/com/ultikits/ultitools/context/ContextConfig.java
@@ -2,8 +2,10 @@ package com.ultikits.ultitools.context;
 
 import com.ultikits.ultitools.annotations.ComponentScan;
 import com.ultikits.ultitools.annotations.Configuration;
+import org.jetbrains.annotations.ApiStatus;
 
 @Configuration
 @ComponentScan("com.ultikits.ultitools")
+@ApiStatus.Internal
 public class ContextConfig {
 }

--- a/src/main/java/com/ultikits/ultitools/context/UltiToolsBean.java
+++ b/src/main/java/com/ultikits/ultitools/context/UltiToolsBean.java
@@ -8,8 +8,10 @@ import com.ultikits.ultitools.manager.ConfigManager;
 import com.ultikits.ultitools.manager.PluginManager;
 import com.ultikits.ultitools.annotations.Bean;
 import com.ultikits.ultitools.annotations.Configuration;
+import org.jetbrains.annotations.ApiStatus;
 
 @Configuration
+@ApiStatus.Internal
 public class UltiToolsBean {
     @Bean
     public UltiTools getUltiTools() {

--- a/src/main/java/com/ultikits/ultitools/handler/package-info.java
+++ b/src/main/java/com/ultikits/ultitools/handler/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * Framework-internal logging bridge.
+ * <p>
+ * 框架内部的日志桥接层。
+ * <p>
+ * {@code SystemLogHandler} is installed on the JUL root logger by the framework
+ * itself during bootstrap. Module authors never construct, register or subclass
+ * anything here — log records reach UltiPanel through this handler automatically.
+ * <p>
+ * {@code SystemLogHandler} 由框架在启动时挂到 JUL 根 logger 上。模块作者不需要
+ * 也不应该自己构造、注册或继承这里的任何东西——日志会自动经由它送到 UltiPanel。
+ *
+ * @since 6.2.5
+ */
+@ApiStatus.Internal
+package com.ultikits.ultitools.handler;
+
+import org.jetbrains.annotations.ApiStatus;

--- a/src/main/java/com/ultikits/ultitools/listeners/package-info.java
+++ b/src/main/java/com/ultikits/ultitools/listeners/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Framework-owned Bukkit listeners.
+ * <p>
+ * 框架自身注册的 Bukkit 监听器。
+ * <p>
+ * These listeners back core behaviour (player cache eviction, update
+ * notification on join, enhanced player events forwarded to UltiPanel). They are
+ * registered by the framework during bootstrap. Modules declare their own
+ * listeners with {@code @EventListener} instead of touching these.
+ * <p>
+ * 这些监听器支撑核心行为（玩家缓存清理、进服时的更新提示、转发给 UltiPanel 的
+ * 增强玩家事件），由框架在启动时注册。模块请用 {@code @EventListener} 声明自己的
+ * 监听器，不要碰这里的类。
+ *
+ * @since 6.2.5
+ */
+@ApiStatus.Internal
+package com.ultikits.ultitools.listeners;
+
+import org.jetbrains.annotations.ApiStatus;

--- a/src/main/java/com/ultikits/ultitools/manager/ChatCallbackManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/ChatCallbackManager.java
@@ -12,6 +12,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandMap;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.SimplePluginManager;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Manager for chat-based callback commands.
@@ -40,6 +41,7 @@ import org.bukkit.plugin.SimplePluginManager;
  * @see com.ultikits.ultitools.widgets.impl.ChatConfirm
  * @since 6.0.0
  */
+@ApiStatus.Internal
 public class ChatCallbackManager {
     /** Thread-safe storage for pending callbacks / 待处理回调的线程安全存储 */
     private static final Map<UUID, Runnable> callbacks = new ConcurrentHashMap<>();

--- a/src/main/java/com/ultikits/ultitools/manager/CommandExecutionManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/CommandExecutionManager.java
@@ -15,11 +15,13 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * 命令执行管理器
  * 负责处理来自WebSocket的命令执行请求
  */
+@ApiStatus.Internal
 public class CommandExecutionManager {
     private UltiPanelWebSocketClient webSocketClient;
     private final ConcurrentHashMap<String, CompletableFuture<CommandResult>> pendingCommands;

--- a/src/main/java/com/ultikits/ultitools/manager/DataSourceTransactionManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/DataSourceTransactionManager.java
@@ -9,6 +9,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * DataSource-based implementation of {@link TransactionManager}.
@@ -19,6 +20,7 @@ import java.util.logging.Logger;
  * @author wisdomme
  * @since 6.2.0
  */
+@ApiStatus.Internal
 public class DataSourceTransactionManager implements TransactionManager {
 
     private static final Logger LOGGER = Logger.getLogger(DataSourceTransactionManager.class.getName());

--- a/src/main/java/com/ultikits/ultitools/manager/DataStoreManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/DataStoreManager.java
@@ -9,12 +9,14 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Data store manager.
  * <p>
  * 数据存储管理器
  */
+@ApiStatus.Internal
 public class DataStoreManager {
     private static final Map<String, DataStore> dataMap = new HashMap<>();
 

--- a/src/main/java/com/ultikits/ultitools/manager/DependenceManagers.java
+++ b/src/main/java/com/ultikits/ultitools/manager/DependenceManagers.java
@@ -13,12 +13,14 @@ import com.ultikits.ultitools.utils.VersionComparatorUtil;
 import lombok.Getter;
 import mc.obliviate.inventory.InventoryAPI;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Dependence managers.
  * <br>
  * 依赖管理器。
  */
+@ApiStatus.Internal
 public class DependenceManagers {
     @Getter
     private BukkitAudiences adventure;

--- a/src/main/java/com/ultikits/ultitools/manager/ErrorReportCollector.java
+++ b/src/main/java/com/ultikits/ultitools/manager/ErrorReportCollector.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Collects, deduplicates, and rate-limits error reports before they reach the WebSocket.
@@ -33,6 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @since 6.2.3
  */
+@ApiStatus.Internal
 public class ErrorReportCollector {
 
     private static final int MAX_QUEUE_SIZE = 200;

--- a/src/main/java/com/ultikits/ultitools/manager/FileOperationManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/FileOperationManager.java
@@ -17,11 +17,13 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * 文件操作管理器
  * 负责处理来自WebSocket的文件操作请求
  */
+@ApiStatus.Internal
 public class FileOperationManager {
     private UltiPanelWebSocketClient webSocketClient;
     private final File serverRoot;

--- a/src/main/java/com/ultikits/ultitools/manager/LogStreamManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/LogStreamManager.java
@@ -17,6 +17,7 @@ import org.bukkit.event.server.ServerLoadEvent;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * 日志流管理器
@@ -25,6 +26,7 @@ import java.util.logging.Logger;
  * @author UltiKits
  * @version 2.0.0
  */
+@ApiStatus.Internal
 public class LogStreamManager implements Listener {
     
     private static LogStreamManager instance;

--- a/src/main/java/com/ultikits/ultitools/manager/PlayerCacheManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PlayerCacheManager.java
@@ -10,6 +10,7 @@ import java.util.logging.Logger;
 
 import com.ultikits.ultitools.annotations.PlayerCache;
 import com.ultikits.ultitools.annotations.PlayerCacheSaver;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Manages automatic cleanup of @PlayerCache-annotated Map fields when players quit.
@@ -18,6 +19,7 @@ import com.ultikits.ultitools.annotations.PlayerCacheSaver;
  *
  * @since 6.2.0
  */
+@ApiStatus.Internal
 public class PlayerCacheManager {
 
     private static final Logger LOGGER = Logger.getLogger(PlayerCacheManager.class.getName());

--- a/src/main/java/com/ultikits/ultitools/manager/PlayerEventManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PlayerEventManager.java
@@ -14,12 +14,14 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import com.google.gson.JsonObject;
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * 玩家事件管理器
  * 处理玩家相关事件的WebSocket消息
  */
 @SuppressWarnings("deprecation")
+@ApiStatus.Internal
 public class PlayerEventManager implements Listener {
     private UltiPanelWebSocketClient webSocketClient;
     

--- a/src/main/java/com/ultikits/ultitools/manager/PluginDependencyResolver.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginDependencyResolver.java
@@ -14,6 +14,7 @@ import java.util.logging.Logger;
 
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.annotations.PluginDependency;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Plugin dependency resolver using Kahn's algorithm for topological sorting.
@@ -25,6 +26,7 @@ import com.ultikits.ultitools.annotations.PluginDependency;
  * @author wisdomme
  * @since 6.2.0
  */
+@ApiStatus.Internal
 public class PluginDependencyResolver {
 
     /**

--- a/src/main/java/com/ultikits/ultitools/manager/ServerMonitorManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/ServerMonitorManager.java
@@ -16,11 +16,13 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * 服务器监控管理器
  * 负责收集服务器状态信息并通过WebSocket发送
  */
+@ApiStatus.Internal
 public class ServerMonitorManager {
     private UltiPanelWebSocketClient webSocketClient;
     private final ScheduledExecutorService scheduler;

--- a/src/main/java/com/ultikits/ultitools/manager/ServerPropertiesManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/ServerPropertiesManager.java
@@ -13,11 +13,13 @@ import java.util.Set;
 
 import com.google.gson.JsonObject;
 import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Safe server.properties manager for remote editing via WebSocket.
  * Only exposes a curated whitelist of non-sensitive keys.
  */
+@ApiStatus.Internal
 public class ServerPropertiesManager {
     private final File serverRoot;
     private UltiPanelWebSocketClient webSocketClient;

--- a/src/main/java/com/ultikits/ultitools/manager/TaskManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/TaskManager.java
@@ -14,6 +14,7 @@ import org.bukkit.scheduler.BukkitTask;
 
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.annotations.Scheduled;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Manages scheduled tasks for plugin modules.
@@ -26,6 +27,7 @@ import com.ultikits.ultitools.annotations.Scheduled;
  *
  * @since 6.2.0
  */
+@ApiStatus.Internal
 public class TaskManager {
 
     private final Map<UltiToolsPlugin, List<BukkitTask>> pluginTasks = new HashMap<>();

--- a/src/main/java/com/ultikits/ultitools/manager/TriggerContext.java
+++ b/src/main/java/com/ultikits/ultitools/manager/TriggerContext.java
@@ -2,6 +2,7 @@ package com.ultikits.ultitools.manager;
 
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Immutable context describing what triggered an error.
@@ -10,6 +11,7 @@ import org.bukkit.entity.Player;
  *
  * @since 6.2.3
  */
+@ApiStatus.Internal
 public final class TriggerContext {
 
     /**

--- a/src/main/java/com/ultikits/ultitools/manager/UltiPanelLogTransmitter.java
+++ b/src/main/java/com/ultikits/ultitools/manager/UltiPanelLogTransmitter.java
@@ -17,6 +17,7 @@ import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * UltiPanel日志传输器
@@ -25,6 +26,7 @@ import lombok.Setter;
  * @author UltiKits
  * @version 1.0.0
  */
+@ApiStatus.Internal
 public class UltiPanelLogTransmitter {
 
     private static final int MAX_QUEUE_SIZE = 1000;

--- a/src/main/java/com/ultikits/ultitools/manager/UpdateManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/UpdateManager.java
@@ -13,6 +13,7 @@ import com.ultikits.ultitools.utils.VersionComparatorUtil;
 import com.ultikits.ultitools.utils.VersionUtils;
 
 import lombok.Getter;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Manages version checking and update notifications for UltiTools-API and modules.
@@ -23,6 +24,7 @@ import lombok.Getter;
  *
  * @since 6.2.0
  */
+@ApiStatus.Internal
 public class UpdateManager {
 
     private final Logger logger;

--- a/src/main/java/com/ultikits/ultitools/websocket/handlers/package-info.java
+++ b/src/main/java/com/ultikits/ultitools/websocket/handlers/package-info.java
@@ -1,0 +1,25 @@
+/**
+ * Inbound message handlers for the UltiPanel WebSocket link.
+ * <p>
+ * UltiPanel WebSocket 链路的入站消息处理器。
+ * <p>
+ * One handler per message type, registered into {@code MessageHandlerRegistry}
+ * by the framework at startup. Message types are a private contract with the
+ * panel worker and change on both sides together.
+ * <p>
+ * 每种消息类型一个处理器，由框架在启动时注册进 {@code MessageHandlerRegistry}。
+ * 消息类型是与面板 worker 之间的私有约定，两边一起改。
+ * <p>
+ * Marked separately from the parent package on purpose: package annotations in
+ * Java do not apply to sub-packages, so {@code com.ultikits.ultitools.websocket}
+ * being internal says nothing about this package.
+ * <p>
+ * 单独标注是必要的，不是重复：Java 的包注解不作用于子包，父包
+ * {@code com.ultikits.ultitools.websocket} 标了 Internal 并不覆盖这里。
+ *
+ * @since 6.2.5
+ */
+@ApiStatus.Internal
+package com.ultikits.ultitools.websocket.handlers;
+
+import org.jetbrains.annotations.ApiStatus;

--- a/src/main/java/com/ultikits/ultitools/websocket/package-info.java
+++ b/src/main/java/com/ultikits/ultitools/websocket/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * UltiPanel WebSocket client internals.
+ * <p>
+ * UltiPanel WebSocket 客户端内部实现。
+ * <p>
+ * Connection lifecycle, reconnect strategy and message dispatch for the link to
+ * UltiPanel. The whole subsystem is driven by the framework: it is created after
+ * a successful cloud login and torn down on shutdown. The wire protocol is a
+ * private contract between this client and the panel worker, and both sides
+ * change together — nothing here is a stable extension point.
+ * <p>
+ * 与 UltiPanel 之间连接的生命周期、重连策略与消息分发。整个子系统由框架驱动：
+ * 云端登录成功后创建，关服时销毁。线上协议是本客户端与面板 worker 之间的私有约定，
+ * 两边一起改——这里没有任何东西属于稳定扩展点。
+ *
+ * @since 6.2.5
+ */
+@ApiStatus.Internal
+package com.ultikits.ultitools.websocket;
+
+import org.jetbrains.annotations.ApiStatus;


### PR DESCRIPTION
Closes #227

## 做了什么

引入 `org.jetbrains:annotations:26.0.2`（`provided`），给框架内部实现打上 `@ApiStatus.Internal`，让下游模块作者的 IDE 能区分「可以依赖的 API」和「随时会动的内部实现」。

**纯标注，零签名改动**：二进制与源码兼容性影响都是零，符合 `COMPATIBILITY.md` 对 PATCH 的约束。`@ApiStatus` 全系是 `RetentionPolicy.CLASS`，运行期不需要这个 jar——所以 `provided` scope、`plugin.yml` 的 `libraries:` 不加条目、shaded JAR 里不出现 `org/jetbrains`，这三件事是一套的。

| 位置 | 方式 |
|---|---|
| `websocket`、`websocket.handlers`、`handler`、`listeners` | 包级 `package-info.java` |
| `context`（9 个类中的 6 个）、`manager`（21 个类中的 17 个） | 逐类标注 |
| `UltiToolsPlugin.setContext` | 方法级 |

## 与 issue 原方案的两处偏离

**一、`context` 和 `manager` 改成逐类标，没有整包标。**

issue 让这两个包整体标 Internal。查证下来它们不是纯内部包——里面有 dev.ultikits.com 已发布文档明确教的用法：

- `getContext().register / registerType / refresh`（`SimpleContainer`）
- `getCommandManager().register`（文档中 24 处）
- `getListenerManager().register`（18 处）
- `getConfigManager().reloadConfigs`（12 处）
- `getPluginManager().register / unregister`（24 处）

另外 `ContextHolder` 被 UltiLogin 的生产代码调用，`BeanPostProcessor` 有公开注册入口 `SimpleContainer.addBeanPostProcessor`（`AopProxyBeanPostProcessor` 的 javadoc 还演示了用法）。整包标会让框架自己文档教的写法在下游 IDE 里全部变黄——一个和文档打架的信号，只会训练人忽略它。所以这 7 个类保持不标，其余 23 个逐个标。

**二、多标了 `websocket.handlers` 一个包。**

Java 的包注解不作用于子包，父包 `websocket` 标了 Internal 并不覆盖 `websocket.handlers` 里那 5 个 handler。不单独标的话它们是漏的。

`setContext` 那一条按 issue 的判断做了：不删 Lombok `@Setter`，而是改成手写 setter 带注解。`PluginManager` 跨包调用它（`PluginManager.java:190`、`:610`），降不成 package-private；直接删是移除 public 方法，PATCH 不允许。手写是为了把这段理由写进 javadoc，生成的签名与 Lombok 完全一致。

## 验收

- [x] `mvn clean verify` 通过（4165 个测试，0 失败；animal-sniffer 一并通过）
- [x] shaded JAR 内零 `org.jetbrains` 条目：`unzip -l target/UltiTools-API-*.jar | grep -c jetbrains` → `0`
- [x] `plugin.yml` 的 `libraries:` 未新增条目（该文件本次未改动）
- [x] 四个 `package-info.class` 已进 JAR
- [x] `javap -v` 确认注解以 `RuntimeInvisibleAnnotations` 落进字节码（包级与类级各验一处）；反证：`CommandManager` 里零 `ApiStatus` 引用

## 范围

`@ApiStatus.Internal` 不产生任何运行时约束，是给人和 IDE 看的信号，不是访问控制。运行期收紧容器生命周期是另一条 issue。

本 PR 解除 #177 的阻塞（它的验收标准需要 `@ApiStatus.Experimental` 可用）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzTkgBjRdaTcLrbvkoaFkp
