### PR TITLE
chore(api): 给 VersionWrapper 簇补全废弃标注

### DIFF
--- a/src/main/java/com/ultikits/ultitools/UltiTools.java
+++ b/src/main/java/com/ultikits/ultitools/UltiTools.java
@@ -87,7 +87,7 @@ public final class UltiTools extends JavaPlugin implements Localized {
     /**
      * @deprecated Use {@link com.ultikits.ultitools.utils.XVersionUtils} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.2.0", forRemoval = true)
     @Getter
     private VersionWrapper versionWrapper;
     @Getter

--- a/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
@@ -265,7 +265,7 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
      * @return the version wrapper <br> 版本包装器
      * @deprecated Use {@link com.ultikits.ultitools.utils.XVersionUtils} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.2.0", forRemoval = true)
     public static VersionWrapper getVersionWrapper() {
         return UltiTools.getInstance().getVersionWrapper();
     }

--- a/src/main/java/com/ultikits/ultitools/context/UltiToolsBean.java
+++ b/src/main/java/com/ultikits/ultitools/context/UltiToolsBean.java
@@ -26,7 +26,7 @@ public class UltiToolsBean {
     /**
      * @deprecated Use {@link com.ultikits.ultitools.utils.XVersionUtils} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.2.0", forRemoval = true)
     @Bean
     public VersionWrapper getVersionWrapper() {
         return UltiTools.getInstance().getVersionWrapper();

--- a/src/main/java/com/ultikits/ultitools/interfaces/VersionWrapper.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/VersionWrapper.java
@@ -24,7 +24,7 @@ import org.bukkit.scoreboard.Scoreboard;
  *             请改用 {@link XVersionUtils} 静态方法。
  *             此接口仅为向后兼容保留，将在未来版本中移除。
  */
-@Deprecated
+@Deprecated(since = "6.2.0", forRemoval = true)
 public interface VersionWrapper {
 
     /**
@@ -36,7 +36,7 @@ public interface VersionWrapper {
      * @return Glass pane <br> 玻璃板
      * @deprecated Use {@link XVersionUtils#getColoredPlaneGlass(Colors)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.2.0", forRemoval = true)
     default ItemStack getColoredPlaneGlass(Colors plane) {
         return XVersionUtils.getColoredPlaneGlass(plane);
     }
@@ -49,7 +49,7 @@ public interface VersionWrapper {
      * @return sign <br> 告示牌
      * @deprecated Use {@link XVersionUtils#getSign()} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.2.0", forRemoval = true)
     default ItemStack getSign() {
         return XVersionUtils.getSign();
     }
@@ -62,7 +62,7 @@ public interface VersionWrapper {
      * @return End eye <br> 末影之眼
      * @deprecated Use {@link XVersionUtils#getEndEye()} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.2.0", forRemoval = true)
     default ItemStack getEndEye() {
         return XVersionUtils.getEndEye();
     }
@@ -76,7 +76,7 @@ public interface VersionWrapper {
      * @return material of the email <br> 邮件材质
      * @deprecated Use {@link XVersionUtils#getEmailMaterial(boolean)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.2.0", forRemoval = true)
     default ItemStack getEmailMaterial(boolean isRead) {
         return XVersionUtils.getEmailMaterial(isRead);
     }
@@ -90,7 +90,7 @@ public interface VersionWrapper {
      * @return player's head <br> 玩家头颅
      * @deprecated Use {@link XVersionUtils#getHead(OfflinePlayer)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.2.0", forRemoval = true)
     default ItemStack getHead(OfflinePlayer player) {
         return XVersionUtils.getHead(player);
     }
@@ -103,7 +103,7 @@ public interface VersionWrapper {
      * @return glass block <br> 玻璃块
      * @deprecated Use {@link XVersionUtils#getGrassBlock()} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.2.0", forRemoval = true)
     default ItemStack getGrassBlock() {
         return XVersionUtils.getGrassBlock();
     }
@@ -120,7 +120,7 @@ public interface VersionWrapper {
      * @return 计分板对象
      * @deprecated Use {@link XVersionUtils#registerNewObjective(Scoreboard, String, String, String)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.2.0", forRemoval = true)
     default Objective registerNewObjective(Scoreboard scoreboard, String name, String criteria, String displayName) {
         return XVersionUtils.registerNewObjective(scoreboard, name, criteria, displayName);
     }
@@ -134,7 +134,7 @@ public interface VersionWrapper {
      * @return Sound <br> 声音
      * @deprecated Use {@link XVersionUtils#getSound(Sounds)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.2.0", forRemoval = true)
     default Sound getSound(Sounds sound) {
         return XVersionUtils.getSound(sound);
     }
@@ -148,7 +148,7 @@ public interface VersionWrapper {
      * @return Bed <br> 床
      * @deprecated Use {@link XVersionUtils#getBed(Colors)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.2.0", forRemoval = true)
     default ItemStack getBed(Colors bedColor) {
         return XVersionUtils.getBed(bedColor);
     }
@@ -162,7 +162,7 @@ public interface VersionWrapper {
      * @return durability <br> 耐久度
      * @deprecated Use {@link XVersionUtils#getItemDurability(ItemStack)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.2.0", forRemoval = true)
     default int getItemDurability(ItemStack itemStack) {
         return XVersionUtils.getItemDurability(itemStack);
     }
@@ -177,7 +177,7 @@ public interface VersionWrapper {
      * @return item in player's hand <br> 玩家手中的物品
      * @deprecated Use {@link XVersionUtils#getItemInHand(Player, boolean)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.2.0", forRemoval = true)
     default ItemStack getItemInHand(Player player, boolean isMainHand) {
         return XVersionUtils.getItemInHand(player, isMainHand);
     }
@@ -191,7 +191,7 @@ public interface VersionWrapper {
      * @param message message <br> 消息
      * @deprecated Use {@link XVersionUtils#sendActionBar(Player, String)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.2.0", forRemoval = true)
     default void sendActionBar(Player player, String message) {
         XVersionUtils.sendActionBar(player, message);
     }
@@ -206,7 +206,7 @@ public interface VersionWrapper {
      * @param footer suffix <br> 后缀
      * @deprecated Use {@link XVersionUtils#sendPlayerList(Player, String, String)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.2.0", forRemoval = true)
     default void sendPlayerList(Player player, String header, String footer) {
         XVersionUtils.sendPlayerList(player, header, footer);
     }
@@ -220,7 +220,7 @@ public interface VersionWrapper {
      * @return block face <br> 方块面向
      * @deprecated Use {@link XVersionUtils#getBlockFace(Block)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.2.0", forRemoval = true)
     default BlockFace getBlockFace(Block placedBlock) {
         return XVersionUtils.getBlockFace(placedBlock);
     }

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/DefaultVersionWrapper.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/DefaultVersionWrapper.java
@@ -11,7 +11,7 @@ import com.ultikits.ultitools.interfaces.VersionWrapper;
  *
  * @deprecated Use {@link com.ultikits.ultitools.utils.XVersionUtils} directly instead.
  */
-@Deprecated
+@Deprecated(since = "6.2.0", forRemoval = true)
 public class DefaultVersionWrapper implements VersionWrapper {
     // All methods use default implementations from VersionWrapper interface
     // which delegate to XVersionUtils


### PR DESCRIPTION
Closes #226

## 做了什么

`VersionWrapper` 簇一直只挂着裸 `@Deprecated`，没有 `since` 也没有 `forRemoval`，与仓库里已经走完废弃流程的四个类型（`AbstractDataEntity`、`AbstractCommandExecutor`、`PagingPage`、`OkCancelPage`）口径不一致。本 PR 把 19 处全部补成 `@Deprecated(since = "6.2.0", forRemoval = true)`。

这不只是格式统一。没有 `forRemoval`，编译器发的是普通废弃告警（`-Xlint:-deprecation` 就能压掉），而移除策略也无从判定——一个类型要跨过一个 MINOR 且带着 `forRemoval` 才进入可移除范围。补完之后这一簇才真正落进 6.3.0 的移除窗口。

| 文件 | 处数 |
|---|---|
| `interfaces/VersionWrapper.java` | 接口 1 + 14 个 `default` 方法 = 15 |
| `interfaces/impl/DefaultVersionWrapper.java` | 1 |
| `UltiTools.java`（`versionWrapper` 字段） | 1 |
| `abstracts/UltiToolsPlugin.java`（静态 `getVersionWrapper()`） | 1 |
| `context/UltiToolsBean.java`（`@Bean` 方法） | 1 |
| **合计** | **19** |

## 为什么 since 是 6.2.0 而不是当前版本

废弃实际发生在 6.2.0——XSeries 集成时把所有实现搬进了 `XVersionUtils`，接口只剩一层转发壳（14 个 `default` 方法体全是一行 `return XVersionUtils.同名方法(...)`，唯一实现类 `DefaultVersionWrapper` 类体为空）。已发布的 javadoc 从那时起就写着「自 v6.2.0 起已弃用」，`AbstractCommandExecutor` 用的也是同一口径。

## 边界：没碰 UltiToolsPlugin:168

那五个文件里的裸 `@Deprecated` 加起来是 20 个，不是 19。多出来的一处是 `UltiToolsPlugin.java:168` 的废弃**构造函数**，跟 `VersionWrapper` 无关，属于 #229 的范围，本 PR 刻意不动。

补完之后 `src/main` 里还剩 9 处裸 `@Deprecated`——正是 #229 的清单。19 + 9 = 28，与仓库已知的裸标注总数吻合，两条 issue 的边界不重叠也无遗漏。

## 验收

- [x] 19 处全部带上完整的 `@Deprecated(since = "6.2.0", forRemoval = true)`（diff 为 19 增 19 删）
- [x] `grep -rn '@Deprecated' src/main --include=*.java | grep -v forRemoval` 结果里不再出现任何 `VersionWrapper` 相关文件（命中数 0）
- [x] `mvn clean verify` 通过，4165 个测试 0 失败
- [x] 框架自身 5 个引用点开始报 `marked for removal` 告警——这是可见性生效的证据，不是回归

## 对 #225 的影响

`COMPATIBILITY.md:58` 目前把 `VersionWrapper` 记成「废弃方法」。实际要移除的是**整个类型** + `DefaultVersionWrapper` + 三个 accessor，共上表 19 处。#225 改写移除清单时按「整个类型」重新描述。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzTkgBjRdaTcLrbvkoaFkp
