### PR TITLE
chore(api): 补全剩余 9 处裸 @Deprecated 的 since / forRemoval

### DIFF
--- a/src/main/java/com/ultikits/ultitools/abstracts/AbstractCommendExecutor.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/AbstractCommendExecutor.java
@@ -10,7 +10,7 @@ package com.ultikits.ultitools.abstracts;
  * @see AbstractCommandExecutor
  * @deprecated Use {@link AbstractCommandExecutor} instead.
  */
-@Deprecated
+@Deprecated(since = "6.2.1", forRemoval = true)
 public abstract class AbstractCommendExecutor extends AbstractCommandExecutor {
 
     /**

--- a/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
@@ -164,8 +164,14 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
      * @param loadAfter           the plugins which should be loaded before this plugin <br> 在这个插件之前加载的插件
      * @param minUltiToolsVersion the minimum version of UltiTools required by this plugin <br> 这个插件所需的UltiTools最低版本
      * @param mainClass           the main class of the plugin <br> 插件的主类
+     * @deprecated Use the seven-argument constructor and pass {@code resourceFolderPath}
+     *             explicitly. This overload hard-codes it to
+     *             {@code <dataFolder>/pluginConfig/<pluginName>}.
+     *             <p>
+     *             请改用七参数构造函数并显式传入 {@code resourceFolderPath}。
+     *             此重载把它硬编码成了 {@code <dataFolder>/pluginConfig/<插件名>}。
      */
-    @Deprecated
+    @Deprecated(since = "6.0.8", forRemoval = true)
     public UltiToolsPlugin(String pluginName, String version, List<String> authors, List<String> loadAfter, int minUltiToolsVersion, String mainClass) {
         this(pluginName, version, authors, loadAfter, minUltiToolsVersion, mainClass,
              UltiTools.getInstance().getDataFolder().getAbsolutePath() + "/pluginConfig/" + pluginName);

--- a/src/main/java/com/ultikits/ultitools/annotations/command/OptionalParam.java
+++ b/src/main/java/com/ultikits/ultitools/annotations/command/OptionalParam.java
@@ -11,8 +11,15 @@ import java.lang.annotation.Target;
  * <p>
  * 请勿使用！
  * 可选参数注解。
+ *
+ * @deprecated Never implemented — no code reads this annotation, so applying it has no
+ *             effect on command parsing. There is no replacement: declare a separate
+ *             {@code @CmdMapping} format for each accepted argument shape.
+ *             <p>
+ *             从未实现——没有任何代码读取该注解，标注它对指令解析不产生任何影响。
+ *             没有替代品：请为每种可接受的参数形态各声明一个 {@code @CmdMapping} 格式。
  */
-@Deprecated
+@Deprecated(since = "6.0.7", forRemoval = true)
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface OptionalParam {

--- a/src/main/java/com/ultikits/ultitools/interfaces/TempListener.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/TempListener.java
@@ -63,7 +63,7 @@ public interface TempListener extends Listener {
      * @param <E>        PlayerEvent type <br> 玩家事件类型
      * @return Builder <br> 构建器
      */
-    @Deprecated
+    @Deprecated(since = "6.1.0", forRemoval = true)
     static <E extends PlayerEvent> PlayerTempListenerBuilder<E> player(Class<E> eventClass) {
         return new PlayerTempListenerBuilder<E>().eventClass(eventClass);
     }
@@ -176,7 +176,19 @@ public interface TempListener extends Listener {
         }
     }
 
-    @Deprecated
+    /**
+     * Builder for player-scoped temporary listeners.
+     * <p>
+     * 玩家维度临时监听器的构建器。
+     *
+     * @param <E> PlayerEvent type <br> 玩家事件类型
+     * @deprecated Use {@link #common(Class)} instead, narrowing with
+     *             {@link DefaultTempListenerBuilder#filter(Function)}.
+     *             <p>
+     *             请改用 {@link #common(Class)}，并用
+     *             {@link DefaultTempListenerBuilder#filter(Function)} 收窄范围。
+     */
+    @Deprecated(since = "6.1.0", forRemoval = true)
     class PlayerTempListenerBuilder<E extends PlayerEvent> {
         private Class<E> eventClass;
         private TempEventHandler<E> eventHandler;

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/PlayerTempListener.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/PlayerTempListener.java
@@ -16,8 +16,11 @@ import org.bukkit.event.player.PlayerEvent;
  *
  * @param <E> PlayerEvent type
  * @see <a href="https://dev.ultikits.com/en/guide/essentials/event-listener.html#temporary-listener">Temporary Listener</a>
+ * @deprecated Use {@link TempListener#common(Class)} and filter by player instead.
+ *             <p>
+ *             请改用 {@link TempListener#common(Class)} 并按玩家过滤。
  */
-@Deprecated
+@Deprecated(since = "6.1.0", forRemoval = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @Setter

--- a/src/main/java/com/ultikits/ultitools/manager/CommandManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/CommandManager.java
@@ -205,8 +205,11 @@ public class CommandManager {
      * @param permission      Permission <br> 权限
      * @param description     Description <br> 描述
      * @param aliases         Aliases <br> 别名
+     * @deprecated Use {@link #register(UltiToolsPlugin, Class, String, String, String...)} instead.
+     *             <p>
+     *             请改用 {@link #register(UltiToolsPlugin, Class, String, String, String...)}。
      */
-    @Deprecated
+    @Deprecated(since = "6.0.5", forRemoval = true)
     public void register(CommandExecutor commandExecutor, String permission, String description, String... aliases) {
         PluginCommand command = getCommand(aliases[0], UltiTools.getInstance());
         command.setAliases(Arrays.asList(aliases));
@@ -222,8 +225,11 @@ public class CommandManager {
      * 不要使用此方法注册命令，使用{@link #register(UltiToolsPlugin, Class)}代替。
      *
      * @param commandExecutor Command executor instance <br> 命令执行器实例
+     * @deprecated Use {@link #register(UltiToolsPlugin, Class)} instead.
+     *             <p>
+     *             请改用 {@link #register(UltiToolsPlugin, Class)}。
      */
-    @Deprecated
+    @Deprecated(since = "6.0.5", forRemoval = true)
     public void register(CommandExecutor commandExecutor) {
         Class<? extends CommandExecutor> clazz = commandExecutor.getClass();
 

--- a/src/main/java/com/ultikits/ultitools/manager/ListenerManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/ListenerManager.java
@@ -42,8 +42,13 @@ public class ListenerManager {
      *
      * @param plugin   UltiTools plugin instance <br> UltiTools模块实例
      * @param listener Listener <br> 监听器
+     * @deprecated Use {@link #register(UltiToolsPlugin, Class)} instead; this overload takes an
+     *             already-constructed instance and therefore performs no dependency injection.
+     *             <p>
+     *             请改用 {@link #register(UltiToolsPlugin, Class)}；此重载接收已经构造好的实例，
+     *             因此不会执行任何依赖注入。
      */
-    @Deprecated
+    @Deprecated(since = "6.0.5", forRemoval = true)
     public void register(UltiToolsPlugin plugin, Listener listener) {
         List<Listener> listeners = listenerListMap.computeIfAbsent(plugin, k -> new ArrayList<>());
         Bukkit.getServer().getPluginManager().registerEvents(listener, UltiTools.getInstance());


### PR DESCRIPTION
Closes #229

#226 处理掉 `VersionWrapper` 簇的 19 处之后，`src/main` 里还剩 9 处裸 `@Deprecated`。本 PR 把它们补全，`grep -rn '@Deprecated' src/main/java | grep -v 'since'` 现在零命中。

## since 取值与证据

| API | since | 依据 |
|---|---|---|
| `CommandManager.register` ×2 | **6.0.5** | v6.0.4 该文件 0 处标注，v6.0.5 起为 2 处 |
| `ListenerManager.register(UltiToolsPlugin, Listener)` | **6.0.5** | v6.0.4 为 0，v6.0.5 起为 1 |
| `OptionalParam` | **6.0.7** | v6.0.6 为 0，v6.0.7 起为 1 |
| `UltiToolsPlugin` 六参构造器 | **6.0.8** | v6.0.7 为 0，v6.0.8 起为 1 |
| `TempListener.player()` · `PlayerTempListenerBuilder` · `PlayerTempListener` | **6.1.0** | v6.0.9 为 0，v6.1.0 起为 2 / 1 |
| `AbstractCommendExecutor` | **6.2.1** | v6.1.1 为 0，v6.2.1 起为 1 |

取证方式是**逐个 v6.x tag 在该 tag 自己的目录树里定位文件再数标注**。这里有三条更省事的路，全都给出错误答案：

- **`git blame`** 把大部分行归给 `a697e1c`「格式化代码，统一缩进和空格」——106 个文件、只改空白。加 `-w` 才能绕开。
- **`git describe --contains`** 对所有 9 处都报 v6.2.1。因为老 tag 早于框架从旧 monorepo 布局中抽出的那次迁移，那时源码在 `UltiTools-API/` 子目录下，按当前路径查会一路查空。
- **老 tag 里提交进仓库的 javadoc HTML** 也不能 grep「Deprecated」——javadoc 每一页导航栏都有这个固定链接，v6.0.4 源码 0 处标注却能数出 2 次命中。

## javadoc

7 处补了 `@deprecated` 标签并写明替代方案（另外 2 处 `AbstractCommendExecutor` 和 `TempListener.player()` 本来就有）。`PlayerTempListenerBuilder` 此前**连 javadoc 都没有**，补了完整的一段。

`OptionalParam` 按 issue 里「确无替代方案的写明为什么不该再用」处理——框架内零消费方，从来没有任何代码读取过它，标注它对指令解析不产生任何影响。

## 移除排期不在本 PR 决定

`since` 早于 6.2.5 意味着这 9 项**具备** 6.3.0 移除资格而非 6.4.0。但「具备资格」不等于「决定移除」——#225 改写移除清单时逐项裁定。`since` 记录的是废弃发生在哪个版本（Java 官方语义），移除排期是另一个问题；把两者绑死，正是「为了赶窗口而倒填 since」这种压力的来源。

补充事实：这 9 个 API 在 `Modules/` 与 `Plugins/` 下**零引用**。

## 验收

- [x] 9 处全部带完整 `@Deprecated(since = "...", forRemoval = true)`
- [x] 每一处 javadoc 有 `@deprecated` 标签并写明替代方案；确无替代的写明原因
- [x] `grep -rn '@Deprecated' src/main/java | grep -v 'since'` 零命中
- [x] `mvn clean verify` 通过，4165 个测试 0 失败
- [x] javadoc 无 `reference not found`（doclint 未关闭，8 条警告全部是既有的，无一指向本次改动的 7 个文件）

## 与 #225 的耦合已解除

`COMPATIBILITY.md:54` 的 `AbstractCommendExecutor` 现在带上了 `forRemoval=true`，#225 按 `forRemoval` 生成清单时不会再把它漏成孤儿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzTkgBjRdaTcLrbvkoaFkp
