### PR TITLE
fix(command): 让 BaseCommandExecutor 能执行 @CmdMapping(format = "") 的裸命令

### DIFF
--- a/src/main/java/com/ultikits/ultitools/abstracts/command/BaseCommandExecutor.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/command/BaseCommandExecutor.java
@@ -424,6 +424,26 @@ public abstract class BaseCommandExecutor implements TabExecutor {
      * 验证参数数量。
      */
     protected boolean validateParameterCount(String[] args, String format, CommandSender sender, Command command) {
+        // 空 format 代表裸命令，期望零参数，必须在 split 之前短路。
+        // Java 的 "".split(" ") 返回长度为 1 的数组（内含一个空字符串），
+        // 因此下面两条比较都会读错：零参数时 1 != 0 判为参数不足，裸命令的方法体
+        // 一次也执行不到；带一个参数时 1 == 1 反而判为合法。
+        //
+        // An empty format is a bare command taking no arguments, and must short-circuit
+        // before the split: "".split(" ") returns a length-1 array holding one empty
+        // string, so both comparisons below read the wrong thing -- with no arguments it
+        // sees 1 != 0 and rejects, and with one argument it sees 1 == 1 and accepts.
+        // AbstractCommandExecutor.checkParameters carries the equivalent guard.
+        if (format.isEmpty()) {
+            if (args.length == 0) {
+                return true;
+            }
+            sender.sendMessage(String.format(
+                    UltiTools.getInstance().i18n("正确用法"),
+                    command.getName(), format));
+            return false;
+        }
+
         String[] formatArgs = format.split(" ");
         
         boolean hasVarargs = formatArgs.length > 0 && formatArgs[formatArgs.length - 1].endsWith("...>");

--- a/src/test/java/com/ultikits/ultitools/abstracts/command/BaseCommandExecutorTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/command/BaseCommandExecutorTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -970,6 +972,49 @@ class BaseCommandExecutorTest {
         }
     }
 
+    @Nested
+    @DisplayName("Bare Command Tests")
+    class BareCommandTests {
+
+        @Test
+        @DisplayName("Should run the body of @CmdMapping(format = \"\") when invoked with no arguments")
+        void shouldExecuteBareCommandBody() {
+            BareCommandExecutor executor = new BareCommandExecutor();
+
+            boolean result = executor.onCommand(mockPlayer, mockCommand, "bare", new String[]{});
+
+            assertTrue(result);
+            assertTrue(executor.bareCalled, "the body of the bare command should have been invoked");
+            assertFalse(executor.actionCalled);
+        }
+
+        @Test
+        @DisplayName("Should not send a usage message for a bare command")
+        void shouldNotSendUsageForBareCommand() {
+            BareCommandExecutor executor = new BareCommandExecutor();
+
+            executor.onCommand(mockPlayer, mockCommand, "bare", new String[]{});
+
+            verify(mockPlayer, never()).sendMessage(anyString());
+        }
+
+        @Test
+        @DisplayName("Should accept an empty format when no arguments are given")
+        void shouldValidateEmptyFormatWithNoArgs() {
+            BareCommandExecutor executor = new BareCommandExecutor();
+
+            assertTrue(executor.validateParameterCount(new String[]{}, "", mockPlayer, mockCommand));
+        }
+
+        @Test
+        @DisplayName("Should reject an empty format when arguments are supplied")
+        void shouldRejectEmptyFormatWithArgs() {
+            BareCommandExecutor executor = new BareCommandExecutor();
+
+            assertFalse(executor.validateParameterCount(new String[]{"extra"}, "", mockPlayer, mockCommand));
+        }
+    }
+
     // Test implementations
     
     @CmdTarget(CmdTarget.CmdTargetType.BOTH)
@@ -997,6 +1042,47 @@ class BaseCommandExecutorTest {
         
         @CmdMapping(format = "multi <a> <b>")
         public void doMultiParam(Player player, @CmdParam("a") String a, @CmdParam("b") String b) {
+        }
+    }
+
+    /**
+     * Fixture for the bare-command path.
+     * <p>
+     * onCommand defers a synchronous command body by one tick through BukkitRunnable,
+     * and this test class runs on plain Mockito with no Bukkit scheduler. Dispatch is
+     * overridden to invoke inline, so the whole path is still exercised -- onCommand,
+     * matchMethod, the validator chain, validateParameterCount -- minus the hop through
+     * the scheduler.
+     */
+    @CmdTarget(CmdTarget.CmdTargetType.BOTH)
+    @CmdExecutor(alias = {"bare"})
+    static class BareCommandExecutor extends BaseCommandExecutor {
+        boolean bareCalled = false;
+        boolean actionCalled = false;
+
+        @Override
+        protected void handleHelp(CommandSender sender) {
+            // Test stub - not exercised by the bare command tests
+        }
+
+        @Override
+        protected void executeCommand(CommandContext context, Method method, Object[] params) {
+            try {
+                method.setAccessible(true);
+                method.invoke(this, params);
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        @CmdMapping(format = "")
+        public void doBare(Player player) {
+            bareCalled = true;
+        }
+
+        @CmdMapping(format = "action <param>")
+        public void doAction(Player player, @CmdParam("param") String param) {
+            actionCalled = true;
         }
     }
     

--- a/src/test/java/com/ultikits/ultitools/abstracts/command/BaseCommandExecutorTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/command/BaseCommandExecutorTest.java
@@ -1067,8 +1067,9 @@ class BaseCommandExecutorTest {
 
         @Override
         protected void executeCommand(CommandContext context, Method method, Object[] params) {
+            // No setAccessible here: the invocation happens inside this class on its own
+            // public methods, so the access check already passes.
             try {
-                method.setAccessible(true);
                 method.invoke(this, params);
             } catch (ReflectiveOperationException e) {
                 throw new IllegalStateException(e);


### PR DESCRIPTION
Closes #178

## 根因

`validateParameterCount` 在判空之前就按空格 split 了 format。Java 的 `"".split(" ")` 返回**长度为 1** 的数组（内含一个空字符串），于是下游两条比较都读错：

| 输入 | `formatArgs.length` | `args.length` | 判定 | 实际应为 |
|---|---|---|---|---|
| 裸命令，零参数 | 1 | 0 | `1 != 0` → 发用法提示，**方法体永不执行** | 通过 |
| 裸命令，给了一个参数 | 1 | 1 | `1 == 1` → **接受** | 拒绝 |

也就是说这是同一个 bug 的两面：该跑的不跑，该拦的不拦。issue 里描述了前一面，后一面是写测试时暴露的。

## 为什么只有这一处坏

`BaseCommandExecutor` 里有 4 处 `format.split(" ")`，只有这一处有问题：

- **`matchMethod`（L307）**——顶部有 `if (args.length == 0) return mappings.getOrDefault("", null);`，零参数时**根本不走 split**。这正是「现有夹具覆盖了 `matchMethod` 却一直是绿的，而命令本身是死的」的原因。
- **`parseParameters`（L383）**——已有 `format.isEmpty()` 守卫。
- **`suggest`（L582）**——空首段永远匹配不上任何前缀，不产生错误建议。
- **`validateParameterCount`（L427）**——本次修复处。

## 修法

在 split 之前对空 format 短路，写法对齐已废弃基类的 `AbstractCommandExecutor.checkParameters`（它一直有这个守卫）；区别是新基类的约定要发用法提示，所以给了参数的情况会提示后返回 false，而不是静默拒绝。

## 测试

新增 `BareCommandTests` 4 个测试，**在父提交上 4 个全红，在本提交上 4 个全绿**：

- 裸命令的方法体确实被调用（`bareCalled` 为 true，且没有误触 `actionCalled`）
- 裸命令不会收到用法提示（`verify(mockPlayer, never()).sendMessage(anyString())`）
- `validateParameterCount([], "")` 为 true
- `validateParameterCount(["extra"], "")` 为 false

按验收要求走的是 `onCommand` 端到端而不是只测 `matchMethod`。夹具重写了 `executeCommand` 改为原地调用——因为这个测试类跑在纯 Mockito 上、没有 Bukkit 调度器，而 `onCommand` 会把同步命令体通过 `BukkitRunnable` 推到下一 tick。重写只省掉调度那一跳，`onCommand → matchMethod → 校验链 → validateParameterCount → executeCommand` 整条路径仍然被走到。

## 验收

- [x] 新增端到端 `onCommand` 测试，断言 `@CmdMapping(format = "")` 的方法体被实际调用
- [x] 该测试在修复前失败、修复后通过（已实测两次）
- [x] `mvn clean verify` 通过，**4169** 个测试 0 失败（原 4165）

## 为什么这条不能顺延

`COMPATIBILITY.md:82` 把这个缺口的修复排期写死在 **6.2.5**，同一份文档还建议**仓库外的第三方模块在 6.2.5 期间就迁移到 `BaseCommandExecutor`**——第三方作者会按这个承诺安排自己的迁移时间。6.2.5 发出去而本条没修，那份文档就在撒谎。本 PR 落地后 #225 不需要再改这条承诺。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzTkgBjRdaTcLrbvkoaFkp
