### PR TITLE
fix(gui): onGuiClick 默认改为 false，声明式页面不再可被玩家掏空

### DIFF
--- a/src/main/java/com/ultikits/ultitools/abstracts/gui/declarative/core/package-info.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/gui/declarative/core/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Core types for the widget, element and render-node trees.
+ * <p>
+ * Widget / Element / RenderNode 三棵树的核心类型。
+ * <p>
+ * 状态与稳定性说明见父包 {@link com.ultikits.ultitools.abstracts.gui.declarative}——
+ * 状态驱动的重绘尚未实现，API 可能在任何版本变动。
+ * <p>
+ * See the parent package for status and stability: state-driven repaint is not implemented
+ * yet, and the API may change in any release.
+ * <p>
+ * 单独标注是必要的而非重复：Java 的包注解不作用于子包，父包标了并不覆盖这里。
+ * Marked separately on purpose: package annotations in Java do not apply to sub-packages.
+ *
+ * @since 6.2.0
+ */
+@ApiStatus.Experimental
+package com.ultikits.ultitools.abstracts.gui.declarative.core;
+
+import org.jetbrains.annotations.ApiStatus;

--- a/src/main/java/com/ultikits/ultitools/abstracts/gui/declarative/engine/DeclarativeGui.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/gui/declarative/engine/DeclarativeGui.java
@@ -236,13 +236,29 @@ public abstract class DeclarativeGui extends Gui {
      * GUI 点击时的钩子方法。
      * <p>
      * 注意：点击事件首先由声明式框架处理，然后才调用此方法。
+     * <p>
+     * <b>返回值语义与直觉相反，务必看清：</b>返回 {@code false} 表示保持事件被取消，
+     * 玩家<b>拿不走</b>格子里的物品；返回 {@code true} 表示放行，玩家<b>可以取走</b>物品。
+     * 这一层语义来自 obliviate-invs —— 其 {@code InvListener} 在 {@code Gui.onClick}
+     * 返回 true 时调用 {@code setCancelled(false)}，返回 false 时调用
+     * {@code setCancelled(true)}。默认值 {@code false} 与库基类 {@code Gui.onClick}
+     * 的默认值保持一致，也是安全的一侧。
+     * <p>
+     * The return value reads backwards, so read it carefully: returning {@code false}
+     * keeps the event cancelled and the player <b>cannot</b> take the clicked item;
+     * returning {@code true} lets the click through and the item <b>can</b> be taken.
+     * The semantics come from obliviate-invs, whose {@code InvListener} calls
+     * {@code setCancelled(false)} when {@code Gui.onClick} returns true and
+     * {@code setCancelled(true)} when it returns false. The default of {@code false}
+     * matches the library base class and is the safe side.
      *
      * @param event 点击事件
-     * @return 是否取消默认行为（true 取消）
+     * @return {@code false} 保持事件取消（默认，物品拿不走）；{@code true} 放行
      */
     protected boolean onGuiClick(@NotNull InventoryClickEvent event) {
-        // 子类重写
-        return true;
+        // 子类重写。默认保持事件取消——这是安全的一侧。
+        // Subclasses override. The default keeps the event cancelled, which is the safe side.
+        return false;
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/abstracts/gui/declarative/engine/package-info.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/gui/declarative/engine/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * The rendering engine and GUI base classes: build, diff, schedule.
+ * <p>
+ * 渲染引擎与 GUI 基类：构建、差分、调度。
+ * <p>
+ * 状态与稳定性说明见父包 {@link com.ultikits.ultitools.abstracts.gui.declarative}——
+ * 状态驱动的重绘尚未实现，API 可能在任何版本变动。
+ * <p>
+ * See the parent package for status and stability: state-driven repaint is not implemented
+ * yet, and the API may change in any release.
+ * <p>
+ * 单独标注是必要的而非重复：Java 的包注解不作用于子包，父包标了并不覆盖这里。
+ * Marked separately on purpose: package annotations in Java do not apply to sub-packages.
+ *
+ * @since 6.2.0
+ */
+@ApiStatus.Experimental
+package com.ultikits.ultitools.abstracts.gui.declarative.engine;
+
+import org.jetbrains.annotations.ApiStatus;

--- a/src/main/java/com/ultikits/ultitools/abstracts/gui/declarative/package-info.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/gui/declarative/package-info.java
@@ -4,6 +4,27 @@
  * 本框架基于 Flutter 的设计理念，提供声明式的 UI 构建方式。
  * 核心理念：<b>UI = f(state)</b>
  * <p>
+ * <h2>⚠ 当前状态（6.2.5）</h2>
+ * <p>
+ * <b>本包及其子包标记为 {@code @ApiStatus.Experimental}，API 可能在任何版本发生不兼容变动。</b>
+ * <p>
+ * <b>状态驱动的重绘尚未实现。</b>{@code UI = f(state)} 是本框架的设计目标，但渲染引擎的三个接缝
+ * 目前都还没接上：{@code build(BuildContext)} 只在 {@code onOpen} 中被调用一次；
+ * {@code Element.update()} 不置脏标记；{@code State.setState} 的信号沿 Element 树上溯到根节点后
+ * 静默终止，进不了调度器。因此下面「主要特性」中的 <i>setState 触发局部重建</i> 目前不生效，
+ * 依赖 {@code setState} 的导航子系统（{@code Navigator.push} / {@code pop}）同样惰性。
+ * 现阶段可靠可用的是<b>静态页面</b>：build 一次、渲染一次。
+ * <p>
+ * <b>State-driven repaint is not implemented yet.</b> {@code UI = f(state)} is the design
+ * goal, but all three rendering seams are still open: {@code build(BuildContext)} is called
+ * exactly once from {@code onOpen}; {@code Element.update()} never marks anything dirty; and
+ * the {@code State.setState} signal walks up the element tree and stops silently at the root
+ * without reaching the scheduler. The <i>setState triggers a partial rebuild</i> bullet below
+ * therefore does not hold today, and the navigation subsystem is inert for the same reason.
+ * What works today is the <b>static page</b>: build once, render once.
+ * <p>
+ * 修复排期见 <a href="https://github.com/UltiKits/UltiTools-Reborn/issues/200">issue #200</a>（6.3.0）。
+ *
  * <h2>主要特性：</h2>
  * <ul>
  *   <li>Widget 树描述 UI 结构</li>
@@ -108,4 +129,7 @@
  * @see com.ultikits.ultitools.abstracts.gui.declarative.core.Widget
  * @see com.ultikits.ultitools.abstracts.gui.declarative.core.StatefulWidget
  */
+@ApiStatus.Experimental
 package com.ultikits.ultitools.abstracts.gui.declarative;
+
+import org.jetbrains.annotations.ApiStatus;

--- a/src/main/java/com/ultikits/ultitools/abstracts/gui/declarative/util/package-info.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/gui/declarative/util/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Helpers such as slot arithmetic.
+ * <p>
+ * 槽位计算等工具类。
+ * <p>
+ * 状态与稳定性说明见父包 {@link com.ultikits.ultitools.abstracts.gui.declarative}——
+ * 状态驱动的重绘尚未实现，API 可能在任何版本变动。
+ * <p>
+ * See the parent package for status and stability: state-driven repaint is not implemented
+ * yet, and the API may change in any release.
+ * <p>
+ * 单独标注是必要的而非重复：Java 的包注解不作用于子包，父包标了并不覆盖这里。
+ * Marked separately on purpose: package annotations in Java do not apply to sub-packages.
+ *
+ * @since 6.2.0
+ */
+@ApiStatus.Experimental
+package com.ultikits.ultitools.abstracts.gui.declarative.util;
+
+import org.jetbrains.annotations.ApiStatus;

--- a/src/main/java/com/ultikits/ultitools/abstracts/gui/declarative/widgets/navigation/package-info.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/gui/declarative/widgets/navigation/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Page navigation widgets.
+ * <p>
+ * 页面导航组件。
+ * <p>
+ * 状态与稳定性说明见父包 {@link com.ultikits.ultitools.abstracts.gui.declarative}——
+ * 状态驱动的重绘尚未实现，API 可能在任何版本变动。
+ * <p>
+ * See the parent package for status and stability: state-driven repaint is not implemented
+ * yet, and the API may change in any release.
+ * <p>
+ * 单独标注是必要的而非重复：Java 的包注解不作用于子包，父包标了并不覆盖这里。
+ * Marked separately on purpose: package annotations in Java do not apply to sub-packages.
+ *
+ * @since 6.2.0
+ */
+@ApiStatus.Experimental
+package com.ultikits.ultitools.abstracts.gui.declarative.widgets.navigation;
+
+import org.jetbrains.annotations.ApiStatus;

--- a/src/main/java/com/ultikits/ultitools/abstracts/gui/declarative/widgets/package-info.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/gui/declarative/widgets/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * The bundled widget library.
+ * <p>
+ * 预置组件库。
+ * <p>
+ * 状态与稳定性说明见父包 {@link com.ultikits.ultitools.abstracts.gui.declarative}——
+ * 状态驱动的重绘尚未实现，API 可能在任何版本变动。
+ * <p>
+ * See the parent package for status and stability: state-driven repaint is not implemented
+ * yet, and the API may change in any release.
+ * <p>
+ * 单独标注是必要的而非重复：Java 的包注解不作用于子包，父包标了并不覆盖这里。
+ * Marked separately on purpose: package annotations in Java do not apply to sub-packages.
+ *
+ * @since 6.2.0
+ */
+@ApiStatus.Experimental
+package com.ultikits.ultitools.abstracts.gui.declarative.widgets;
+
+import org.jetbrains.annotations.ApiStatus;

--- a/src/test/java/com/ultikits/ultitools/abstracts/gui/declarative/engine/DeclarativeGuiTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/gui/declarative/engine/DeclarativeGuiTest.java
@@ -1,0 +1,60 @@
+package com.ultikits.ultitools.abstracts.gui.declarative.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import mc.obliviate.inventory.Gui;
+
+/**
+ * DeclarativeGui 的点击语义测试。
+ * <p>
+ * 这里不构造真实实例：DeclarativeGui 的构造函数会创建 GuiRenderer 与 GuiScheduler，
+ * 后者需要一个已启用的 UltiTools 实例。CALLS_REAL_METHODS 的 mock 跳过构造函数，
+ * 但仍然执行真实的方法体，正好够验证默认返回值。
+ */
+@DisplayName("DeclarativeGui Click Semantics")
+class DeclarativeGuiTest {
+
+    @Test
+    @DisplayName("onGuiClick defaults to false so the click stays cancelled")
+    void onGuiClickDefaultsToFalse() {
+        DeclarativeGui gui = mock(DeclarativeGui.class, CALLS_REAL_METHODS);
+        InventoryClickEvent event = mock(InventoryClickEvent.class);
+
+        assertFalse(gui.onGuiClick(event),
+                "onGuiClick must default to false. obliviate-invs cancels the event when "
+                        + "Gui.onClick returns false and un-cancels it when it returns true, "
+                        + "so a true default lets players take items out of every page.");
+    }
+
+    @Test
+    @DisplayName("The default matches the obliviate-invs base class")
+    void defaultMatchesLibraryBaseClass() throws Exception {
+        DeclarativeGui gui = mock(DeclarativeGui.class, CALLS_REAL_METHODS);
+        Gui libraryGui = mock(Gui.class, CALLS_REAL_METHODS);
+        InventoryClickEvent event = mock(InventoryClickEvent.class);
+
+        assertEquals(libraryGui.onClick(event), gui.onGuiClick(event),
+                "the hook default must agree with Gui.onClick's own default");
+    }
+
+    @Test
+    @DisplayName("onClick stays final so the forwarding cannot be re-inverted")
+    void onClickIsFinal() throws Exception {
+        Method onClick = DeclarativeGui.class.getDeclaredMethod("onClick", InventoryClickEvent.class);
+
+        assertTrue(Modifier.isFinal(onClick.getModifiers()),
+                "onClick must stay final: it forwards to onGuiClick, and a subclass that "
+                        + "overrode it could silently reintroduce the inverted semantics.");
+    }
+}


### PR DESCRIPTION
Closes #177

## 根因：语义反了一层，而且反在作者改不到的地方

obliviate-invs 对 `Gui.onClick` 返回值的解释与 `DeclarativeGui` 的 javadoc **完全相反**。从 `core-4.3.0.jar` 的字节码读出来是这样：

| `Gui.onClick` 返回 | `InvListener` 分支 | 结果 |
|---|---|---|
| `false` | 偏移 72 / 116 → `setCancelled(true)` | 事件取消，物品**拿不走** |
| `true` | 偏移 60 `ifne` 跳 124 → `setCancelled(false)` | 事件放行，物品**可以拿走** |

库自己的 `Gui.onClick` 默认实现是 `iconst_0; ireturn`，即返回 `false`。

而 `DeclarativeGui.onGuiClick` 的默认体是 `return true`，javadoc 却写着「是否取消默认行为（true 取消）」。**任何声明式页面的物品都能被玩家直接取走。**

要命的是它落在作者够不到的位置：`DeclarativeGui.onClick` 是 `final` 且直接转发给 `onGuiClick`，所以页面作者**无法在 `Gui` 层覆盖修正**，而唯一可覆盖的钩子默认站在危险的一侧。

## 改动

**1. 默认值改 `false`，javadoc 重写。** 新 javadoc 中英双语写明真实语义、以及它来自哪里，避免下一个人再照着「true 取消」的直觉写。

**2. 声明式子系统整体标 `@ApiStatus.Experimental`——六个包全部，不只根包。** Java 的包注解不作用于子包，只标根包的话 `engine`、`core`、`widgets`、`widgets.navigation`、`util` 全是漏的，而 `DeclarativeGui` 本身就住在 `engine` 里。

**3. 根 `package-info.java` 加状态声明。** 记录状态驱动重绘尚未实现：`build()` 只在 `onOpen` 中被调用一次、`Element.update()` 不置脏、`setState` 的信号上溯到根节点后静默终止、进不了调度器。此前该文件把「setState 触发局部重建」**无保留地列为主要特性**，与事实不符。修复排期见 #200（6.3.0）。现阶段可靠可用的是静态页面：build 一次、渲染一次。

## 影响面：今天对任何人都不改变行为

- 本仓库内 `onGuiClick` **零处覆盖**（`grep -rn onGuiClick src/` 除定义处外无命中）
- 声明式 GUI 目前**零下游消费者**

所以这是一颗未引爆的地雷，不是在产事故。改默认值不会破坏任何现存代码。

## 测试

新增 3 个测试，**其中 2 个在旧默认值上失败**（已实测：临时改回 `return true` 后 `Tests run: 3, Failures: 2`）：

- `onGuiClick` 默认返回 `false`
- 该默认值与库基类 `Gui.onClick` 的默认值一致
- `onClick` 保持 `final`（结构性断言，两种默认值下都通过——它守的是「子类不能重新把语义反过来」）

测试用 `CALLS_REAL_METHODS` 的 mock 而不是真实实例：构造 `DeclarativeGui` 会连带创建 `GuiRenderer` 与 `GuiScheduler`，而后者需要一个已启用的 `UltiTools`。

## 验收

- [x] 默认值测试通过，且在修复前失败
- [x] `package-info.java` 顶部出现状态声明
- [x] `grep -r '@ApiStatus.Experimental' src/main/java/com/ultikits/ultitools/abstracts/gui/declarative` 有命中（6 个包各 1 处）
- [x] `mvn clean verify` 通过，**4172** 个测试 0 失败（原 4169），javadoc 无新增警告

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzTkgBjRdaTcLrbvkoaFkp
