### PR TITLE
build: 把 GPG 签名移进 release profile，让无私钥者能跑 mvn verify / install

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -28,9 +28,8 @@ jobs:
     - name: 🧪 Build & Test with Coverage
       # verify 而不是 test：shade 过滤器、资源过滤、jar 打包与 javadoc 生成都绑定在
       # package 阶段，只跑 test 的话这些在合并之后才第一次执行。
-      # gpg.skip：maven-gpg-plugin 绑在 verify 上，签名只在发布时需要，
-      # 这里没有也不应该有私钥（与 publish-packages.yml 的 GitHub Packages 构建一致）。
-      run: mvn -B clean verify -Dgpg.skip=true
+      # 不需要关签名：maven-gpg-plugin 只在 release profile 里，默认不激活。
+      run: mvn -B clean verify
       
     - name: 📊 Generate JaCoCo Coverage Report
       run: mvn -B jacoco:report

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -36,7 +36,8 @@ jobs:
       run: mvn versions:set -DnewVersion="${VERSION}" -DgenerateBackupPoms=false
 
     - name: 🔨 Build package
-      run: mvn -B clean package -Dgpg.skip=true -Dmaven.test.skip=true
+      # GitHub Packages 不要求签名，因此不激活 release profile。
+      run: mvn -B clean package -Dmaven.test.skip=true
 
     - name: 📦 Publish to GitHub Packages
       id: publish-ghp
@@ -125,4 +126,6 @@ jobs:
         SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
         SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-      run: mvn -B deploy -Dmaven.test.skip=true -Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}"
+      # -P release：GPG 签名只在这个 profile 里，唯独 Maven Central 需要签名产物。
+      # 漏掉它不会静默发出未签名产物，Central 的校验会直接拒绝。
+      run: mvn -B deploy -P release -Dmaven.test.skip=true -Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}"

--- a/pom.xml
+++ b/pom.xml
@@ -353,20 +353,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.6.3</version>
                 <configuration>
@@ -635,4 +621,43 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <!--
+            发布 profile：GPG 签名只在这里激活，别处一律不签。
+            只有 Maven Central 需要签名产物，而私钥只存在于发布环境。
+            把 maven-gpg-plugin 无条件绑在 verify 上，会让任何没有私钥的人
+            跑 mvn verify 或 mvn install 都失败，CI 也得处处传 gpg.skip 才能绕开。
+            发布时漏掉 -P release 的后果是产物没有签名、被 Central 的校验直接拒绝，
+            是一次响亮的失败，而不是静默发出未签名产物。
+
+            Release-only profile: GPG signing is activated here and nowhere else.
+            Only Maven Central needs signed artifacts, and the private key exists
+            only in the release environment. Binding maven-gpg-plugin to verify
+            unconditionally breaks mvn verify and mvn install for everyone without
+            a key. Forgetting -P release fails loudly at Central's validation
+            instead of silently publishing unsigned artifacts.
+        -->
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
把 GPG 签名从默认构建移进 `release` profile。

`maven-gpg-plugin` 的 `sign` 目标原本无条件绑在 `verify` 阶段，而这个 pom 全文没有 `<profiles>` 段，所以签名对所有人、所有场景都生效。后果是没有 GPG 私钥的人跑 `mvn verify` 或 `mvn install` 一律失败——而 `mvn install` 正是把框架装进本地仓库、供模块工程依赖 SNAPSHOT 的标准做法。

仓库自己的 CI 就是证据：四个 job 里三个要么靠 `-Dgpg.skip=true` 绕过，要么根本走不到 `verify`，只有 Maven Central 那一个真的需要签名。一个默认开启、绝大多数场景都要显式关掉的插件，默认值是反的。

## 改动

`pom.xml` 里 `sign-artifacts` 的 execution 原样搬进新的 `release` profile，绑定阶段仍是 `verify`，插件版本仍是 1.6，没有任何配置改动。配套地：

- `maven-ci.yml` 的 `mvn -B clean verify` 去掉 `-Dgpg.skip=true`
- `publish-packages.yml` 的 GitHub Packages 构建去掉 `-Dgpg.skip=true`
- `publish-packages.yml` 的 Maven Central 发布加上 `-P release`

没有采用「在 `<properties>` 里设 `<gpg.skip>true</gpg.skip>`、发布时传 `-Dgpg.skip=false`」的写法：那等于把「是否签名」这个发布约束藏进一个布尔属性的双重否定，改 workflow 时容易被无意翻转，且翻转后是静默发出未签名产物。profile 方案漏加 `-P release` 的后果是产物没有签名、被 Central 的校验直接拒绝，是响亮的失败。

## 验证

全部在 `GNUPGHOME` 指向空目录的「无私钥」环境下执行，与本机 keyring 状态无关：

| 检查 | 结果 |
|---|---|
| 修复前 `mvn clean verify` | 退出码 1，`gpg: no default secret key` |
| 修复后 `mvn clean verify`（完整测试） | 退出码 0 |
| 修复后 `mvn install`（覆盖 verify+install 两阶段绑定） | 退出码 0 |
| 修复后 `mvn clean verify -P release` | 退出码 1，`gpg: no default secret key` —— 负对照，证明 profile 确实会激活签名 |

另外用 `help:effective-pom` 做了结构核对：默认构建的 `build/plugins` 有 17 个插件、不含 gpg；`-P release` 时变 18 个、含 gpg，且 `phase` 仍是 `verify`、`goal` 仍是 `sign`。

注意 `help:effective-pom` 会把**未激活的 profile 定义本身**也打印出来，所以直接 `grep -c 'maven-gpg-plugin'` 在两种情况下都非零——那个数字数的是「文档里出现几次」而不是「构建里生效几次」。上面的结论是按 XPath 分别取 `/project/build/plugins` 与 `/project/profiles/profile/build/plugins` 得到的。

Closes #248
