### PR TITLE
ci: 给 GPG 签名密钥加到期预警（发布闸门 + 每月定时检查）

### DIFF
--- a/.github/scripts/check-gpg-expiry.sh
+++ b/.github/scripts/check-gpg-expiry.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# 检查 GPG 签名密钥的剩余有效期。
+#
+# 为什么需要它：密钥过期是静默的。日常 mvn test / mvn package 都不签名，
+# 只有发版当天真正执行 gpg:sign 时才会失败，而那时报的是
+#     gpg: no default secret key: No secret key
+# ——说的是「找不到私钥」，不是「密钥已过期」。私钥其实好端端在钥匙串里，
+# 只是 GPG 挑默认密钥时会跳过已过期的。照那条报错排查很容易误判为密钥丢失
+# 而去重新生成，正确处置是延长有效期。
+#
+# 用法：
+#   check-gpg-expiry.sh --mode secret [--warn-days N] [--fail-on-warn]
+#   check-gpg-expiry.sh --mode public [--warn-days N] [--fail-on-warn]
+#
+# 退出码：0 = 有效期充足；1 = 已过期 / 钥匙串里没有可签名的密钥 /
+#         剩余不足且指定了 --fail-on-warn
+#
+set -euo pipefail
+
+MODE=secret
+WARN_DAYS=30
+FAIL_ON_WARN=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --mode)         MODE="$2"; shift 2 ;;
+        --warn-days)    WARN_DAYS="$2"; shift 2 ;;
+        --fail-on-warn) FAIL_ON_WARN=1; shift ;;
+        *) echo "未知参数：$1" >&2; exit 64 ;;
+    esac
+done
+
+case "$MODE" in
+    secret) LIST_CMD=(gpg --list-secret-keys --with-colons); WANT="sec|ssb" ;;
+    public) LIST_CMD=(gpg --list-keys        --with-colons); WANT="pub|sub" ;;
+    *) echo "--mode 只能是 secret 或 public" >&2; exit 64 ;;
+esac
+
+# --with-colons 的字段：1=记录类型 5=key id 7=到期时间戳 12=能力
+# 能力字段里小写字母描述「这一把钥匙自己」的能力，大写描述「整把密钥」的。
+# 所以要找真正能签名的，看的是小写 s。
+# 到期时间戳为空 = 永不过期。
+RECORDS=$("${LIST_CMD[@]}" 2>/dev/null | awk -F: -v want="$WANT" '
+    $1 ~ "^(" want ")$" && $12 ~ /s/ { print $5 ":" $7 }
+') || true
+
+if [ -z "$RECORDS" ]; then
+    echo "::error::钥匙串里没有任何可签名的 GPG 密钥（mode=$MODE）。"
+    echo "        如果这是发布流程，说明密钥根本没导入成功，而不是密钥过期。"
+    exit 1
+fi
+
+NOW=$(date -u +%s)
+BEST_TS=-1      # 所有可签名密钥里最晚的到期时间；-1 = 还没找到
+BEST_ID=""
+NEVER=0
+
+while IFS=: read -r kid expire; do
+    if [ -z "$expire" ]; then
+        NEVER=1; BEST_ID="$kid"; break
+    fi
+    if [ "$expire" -gt "$BEST_TS" ]; then
+        BEST_TS="$expire"; BEST_ID="$kid"
+    fi
+done <<< "$RECORDS"
+
+SHORT_ID="${BEST_ID: -16}"
+
+if [ "$NEVER" = 1 ]; then
+    echo "密钥 ${SHORT_ID} 未设置到期时间，无需预警。"
+    exit 0
+fi
+
+EXPIRE_DATE=$(date -u -d "@${BEST_TS}" +%Y-%m-%d)
+DAYS_LEFT=$(( (BEST_TS - NOW) / 86400 ))
+
+# 这里刻意只打印 key id 与日期，不打印 uid——uid 里有维护者邮箱，
+# 而这是公开仓库的公开日志。
+RENEW_HINT="延期办法：gpg --quick-set-expire <指纹> 2y，然后 gpg --armor --export-secret-keys <指纹>
+        重新写入 MAVEN_GPG_PRIVATE_KEY secret，并把公钥重新上传到 keyserver
+        （gpg --keyserver keyserver.ubuntu.com --send-keys <指纹>）。不要重新生成密钥。"
+
+if [ "$BEST_TS" -le "$NOW" ]; then
+    echo "::error::GPG 签名密钥 ${SHORT_ID} 已于 ${EXPIRE_DATE} 过期。"
+    echo "        注意：这不是密钥丢失。GPG 挑默认密钥时会跳过已过期的，所以真正签名时"
+    echo "        报的是 no default secret key，容易被误判成密钥没导入。"
+    echo "        ${RENEW_HINT}"
+    exit 1
+fi
+
+if [ "$DAYS_LEFT" -lt "$WARN_DAYS" ]; then
+    echo "::warning::GPG 签名密钥 ${SHORT_ID} 将于 ${EXPIRE_DATE} 过期，仅剩 ${DAYS_LEFT} 天。"
+    echo "        ${RENEW_HINT}"
+    if [ "$FAIL_ON_WARN" = 1 ]; then
+        exit 1
+    fi
+    exit 0
+fi
+
+echo "GPG 签名密钥 ${SHORT_ID} 有效期至 ${EXPIRE_DATE}，剩余 ${DAYS_LEFT} 天。"
+exit 0

--- a/.github/workflows/gpg-key-expiry.yml
+++ b/.github/workflows/gpg-key-expiry.yml
@@ -1,0 +1,65 @@
+name: 🔑 GPG Key Expiry
+
+# 提前预警 Maven Central 发布用的 GPG 签名密钥到期。
+#
+# 密钥过期是静默的：日常 mvn test / mvn package 不签名，PR 上的 mvn clean verify
+# 也不签名（签名只在 release profile 里），所以只有发版当天真正跑 gpg:sign 才会暴露。
+# 这个 job 每月查一次，剩余不足 30 天就变红。
+#
+# 只用公钥，不碰任何 secret。公钥从 keyserver 按指纹取——指纹是公开信息，
+# 它随每一个发到 Maven Central 的 .asc 签名一起分发，本来就是给使用者验签用的。
+#
+# ⚠ schedule 触发器只对**默认分支**上的 workflow 生效。这个仓库默认分支是 main，
+#   开发在 alpha，所以定时预警要等 alpha 合进 main 之后才真正开始跑。
+#   在那之前，发布路径上的实时闸门（publish-packages.yml 里的密钥有效期检查）
+#   才是主要防线。
+
+on:
+  schedule:
+    # 每月 1 号 09:00 UTC
+    - cron: '0 9 1 * *'
+  workflow_dispatch:
+  # 检查脚本自己被改动时自测一次，免得这套预警本身悄悄坏掉。
+  pull_request:
+    paths:
+      - '.github/workflows/gpg-key-expiry.yml'
+      - '.github/scripts/check-gpg-expiry.sh'
+
+permissions:
+  contents: read
+
+jobs:
+  check-expiry:
+    name: GPG key expiry check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+
+      - name: 🔎 Fetch public key from keyserver
+        env:
+          # 换签名密钥时这里要同步改。这是公钥指纹，不是凭据。
+          KEY_FPR: 2334303E84CA28D14B6A0746C27654300A2E94D6
+        run: |
+          set -euo pipefail
+
+          # 用 keyserver.ubuntu.com。不要换成 keys.openpgp.org：后者对未验证的密钥
+          # 会剥掉 uid，返回的确实是 HTTP 200 加一个合法的 PGP 块，但 gpg 导入时会以
+          # "contains no user ID - skipped" 跳过，钥匙串是空的。HTTP 成功不等于拿到了密钥。
+          curl -sSf --retry 3 --retry-delay 5 --max-time 30 \
+            -o pubkey.asc \
+            "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x${KEY_FPR}&options=mr"
+
+          # 导入输出里带 uid（维护者邮箱），这是公开仓库的公开日志，丢掉不打印。
+          gpg --batch --import pubkey.asc > /dev/null 2>&1 || true
+
+          # 断言真的导入到了这把密钥，而不是拿到一坨解析不了的东西。
+          if ! gpg --list-keys --with-colons "${KEY_FPR}" > /dev/null 2>&1; then
+            echo "::error::从 keyserver 取到了响应，但 ${KEY_FPR: -16} 没有成功导入钥匙串。"
+            echo "        检查这把密钥是否还在 keyserver 上，或者指纹是否已经变了。"
+            exit 1
+          fi
+
+      - name: ⏳ Check remaining validity
+        run: .github/scripts/check-gpg-expiry.sh --mode public --warn-days 30 --fail-on-warn

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -110,6 +110,18 @@ jobs:
         echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
         gpg-connect-agent reloadagent /bye || true
 
+    - name: 🔑 Check GPG key expiry
+      # 放在导入密钥之后、mvn deploy 之前。密钥此时已在 runner 的钥匙串里，
+      # 不需要额外 secret 也不需要联网。
+      #
+      # 已过期就在这里失败，并明说是过期而不是密钥丢失——GPG 挑默认密钥时会跳过
+      # 已过期的，所以 gpg:sign 报的是 "no default secret key"，很容易被误判成
+      # 密钥没导入成功而去重新生成，正确处置是延长有效期。
+      #
+      # 剩余不足 30 天只告警、不拦发版：用一把还有三周有效期的密钥签名完全合法，
+      # 签名在密钥过期之后依然可验证。这里没有传 --fail-on-warn 就是这个意思。
+      run: .github/scripts/check-gpg-expiry.sh --mode secret --warn-days 30
+
     - name: 🏷️ Extract version from tag
       id: version
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 *.iws
 
 *.sh
+# 但 CI 用的脚本是仓库的一部分，必须跟着 workflow 一起走。
+# 上面那条 *.sh 挡的是 bin/ 里那些本机开发脚本。
+!.github/scripts/*.sh
 
 # IntelliJ
 out/


### PR DESCRIPTION
给 GPG 签名密钥加到期预警。

密钥过期是静默的：日常 `mvn test` / `mvn package` 不签名，PR 上的 `mvn clean verify` 也不签名（#248 之后签名只在 `release` profile 里），所以只有发版当天真正跑 `gpg:sign` 才会暴露。密钥曾在 2026-07-23 过期，三周后才被发现，期间没有任何信号。

而且报错是误导性的。密钥过期后 GPG 挑默认密钥时会跳过它，报的是 `no default secret key: No secret key`——说的是「找不到私钥」而不是「密钥已过期」，私钥其实好端端在钥匙串里。照这条报错排查很容易误判为密钥丢失去重新生成，正确处置是延长有效期。

## 改动

检查逻辑抽成 `.github/scripts/check-gpg-expiry.sh`，两处共用，也能在本机直接跑（这也是它被测出来的方式）。它按 `--with-colons` 的第 12 字段筛出**真正能签名**的密钥（小写 `s` 描述这把钥匙自己的能力，大写描述整把密钥的），取其中最晚的到期时间。

**第一层，发布路径上的实时闸门。** `publish-packages.yml` 的 Maven Central job 在导入密钥之后、`mvn deploy` 之前检查。已过期就在这里失败，日志里明写到期日期并说明「这不是密钥丢失」。剩余不足 30 天只告警、不拦发版——用一把还有三周有效期的密钥签名是完全合法的，签名在密钥过期之后依然可验证，为此拦住发版是误伤。

**第二层，每月一次的定时预警**，只用公钥、不碰任何 secret，剩余不足 30 天就变红。

## 两个坑

**keys.openpgp.org 用不了。** 它对未验证的密钥会剥掉 uid，`curl` 拿到的是 HTTP 200 加一个合法的 PGP 块，但 `gpg --import` 会以 `contains no user ID - skipped` 跳过，钥匙串是空的。HTTP 成功不等于拿到了密钥，所以这一步显式断言密钥真的进了钥匙串，而不是只看 `curl` 的退出码。改用 keyserver.ubuntu.com（实测可用）。

**`schedule` 只对默认分支上的 workflow 生效。** 本仓库默认分支是 `main`、开发在 `alpha`，所以定时预警要等 `alpha` 合进 `main`（即 6.2.5 发版）之后才真正开始跑。写在 workflow 的注释里了。在那之前，发布路径上的闸门是主要防线——而它本来就是随 release 事件触发的，同样从默认分支取 workflow 文件，时机一致。

为了不让这套预警自己悄悄坏掉，定时 workflow 额外挂了 `pull_request` + `paths` 触发器：只要检查脚本或它自己被改动，就在 PR 上自测一次。这条 PR 就会触发它。

## 验证

`check-gpg-expiry.sh` 在本机跑了六个场景，全部符合预期：

| 场景 | 期望 | 实际 |
|---|---|---|
| 真实私钥（secret 模式） | 0 | 0，报「有效期至 2028-08-13，剩余 729 天」 |
| keyserver 公钥（public 模式） | 0 | 0，同上 |
| 空钥匙串 | 1 | 1，报「没有可签名的密钥」——不误报成过期 |
| 真造一把已过期的测试密钥 | 1 | 1，报出到期日期与「这不是密钥丢失」 |
| 阈值抬到 99999 天 + `--fail-on-warn` | 1 | 1，走告警分支 |
| 同上不加 `--fail-on-warn` | 0 | 0，告警但放行 |

第三个场景是特意加的：钥匙串里没有密钥和密钥已过期，必须报不同的话。前者说明密钥压根没导入成功，后者说明该延期了——混为一谈就等于把 #242 抱怨的那个误导性报错换个地方重演一遍。

定时 workflow 的两个步骤也按原样在本机跑通了（keyserver 拉取 + 断言 + 检查）。

## 没验到的部分

**「用一把已过期的测试密钥跑 Central job」这条没有在真实的 Central job 里跑过**——那需要发一个 release 并动真实的发布凭据。这里证到的是：检查脚本本身在真造的过期密钥上正确失败（上表第四行），以及同一个脚本在本 PR 的定时 workflow 里真实执行成功。job 接线本身只由 YAML 校验和步骤顺序保证。

Closes #242
