### PR TITLE
fix(test): 修掉 LogStreamManagerTest 的间歇性 ClassCastException

### DIFF
--- a/src/test/java/com/ultikits/ultitools/manager/LogStreamManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/LogStreamManagerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -41,7 +42,6 @@ import org.mockito.ArgumentCaptor;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.handler.SystemLogHandler;
 import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
 
@@ -68,15 +68,21 @@ class LogStreamManagerTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         server = MockBukkit.mock();
         MockBukkit.createMockPlugin();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
 
         // Mock logger
         mockLogger = mock(Logger.class);
-        when(UltiTools.getInstance().getLogger()).thenReturn(mockLogger);
 
         // Mock config with detailed configuration
         mockConfig = mock(FileConfiguration.class);
-        when(UltiTools.getInstance().getConfig()).thenReturn(mockConfig);
+
+        // getLogger()/getConfig() 的桩必须在 mock 被写进 UltiTools 的静态单例字段之前打完。
+        // 一旦发布出去，任何还活着的后台线程都能通过 UltiTools.getInstance() 调到它，
+        // 而 Mockito 的 invocationForStubbing 是 per-mock 的共享可变状态，被插一脚就会
+        // 把 answer 绑到别的方法上。见 issue #250。
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            lenient().when(ultiTools.getLogger()).thenReturn(mockLogger);
+            lenient().when(ultiTools.getConfig()).thenReturn(mockConfig);
+        });
 
         // Mock WebSocket client
         mockWebSocketClient = mock(UltiPanelWebSocketClient.class);
@@ -127,8 +133,35 @@ class LogStreamManagerTest {
 
     @AfterEach
     void tearDown() throws Exception {
+        // 必须调 shutdown()。initialize() 做了两件会活过本测试的事：
+        //   1. 把 SystemLogHandler 挂到 JVM 的 root logger 上（Logger.getLogger("")）
+        //   2. 起一条 "UltiPanel-LogTransmitter" 调度线程
+        // 只 resetSingleton() 是把静态引用置 null，被丢掉的那个实例带着这两样继续活着。
+        // surefire 这里是单 fork 跑全部 4172 个测试，于是之后每个测试类打的每一条日志
+        // 都会重新进到 UltiTools 的代码里，可能在别人打桩的中途调到那个 mock。见 issue #250。
+        if (logStreamManager != null) {
+            try {
+                logStreamManager.shutdown();
+            } catch (Exception ignored) {
+                // shutdown 自己会写日志，mock 环境下失败无所谓；关键是下面把 handler 摘干净
+            }
+        }
+        removeLeakedSystemLogHandlers();
         resetSingleton();
         com.ultikits.ultitools.utils.MockBukkitHelper.safeUnmock();
+    }
+
+    /**
+     * 兜底清理：shutdown() 只摘得掉它自己字段里记着的那一个 handler 实例。
+     * root logger 是 JVM 全局的，漏一个就污染整个 fork，所以这里按类型全扫一遍。
+     */
+    private void removeLeakedSystemLogHandlers() {
+        Logger rootLogger = Logger.getLogger("");
+        for (java.util.logging.Handler handler : rootLogger.getHandlers()) {
+            if (handler instanceof SystemLogHandler) {
+                rootLogger.removeHandler(handler);
+            }
+        }
     }
 
     // ==================== 单例模式测试 ====================

--- a/src/test/java/com/ultikits/ultitools/manager/UltiPanelLogTransmitterTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/UltiPanelLogTransmitterTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -26,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import com.google.gson.JsonObject;
-import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
 
 import org.mockbukkit.mockbukkit.MockBukkit;
@@ -45,27 +45,63 @@ class UltiPanelLogTransmitterTest {
     private UltiPanelWebSocketClient mockWebSocketClient;
     private Logger mockLogger;
 
+    /**
+     * 本测试里造出来的所有 transmitter，tearDown 统一关掉。
+     *
+     * <p>UltiPanelLogTransmitter 的构造函数就会起一条 "UltiPanel-LogTransmitter" 守护
+     * 调度线程（{@code scheduleWithFixedDelay}，5 秒一次），只有 shutdown() 停得掉。
+     * 这个类有 55 个用例，直接 new 而不关的话，跑完就有几十条线程活到 fork 结束——
+     * surefire 这里没配 forkCount/reuseForks，是单个 JVM 跑完整个测试套件。这些线程会周期性调
+     * {@code UltiTools.getInstance().getLogger()}，撞上别的测试类正在给静态 mock 打桩，
+     * 就把 answer 抢走了。issue #250 里 LogStreamManagerTest 的间歇性
+     * ClassCastException 就是这么来的：失败那次运行里本类排在它前面 250 个类。
+     */
+    private final java.util.List<UltiPanelLogTransmitter> createdTransmitters =
+            java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+
+    /**
+     * 统一的创建入口。不要在用例里直接 {@code new UltiPanelLogTransmitter(...)}，
+     * 那样造出来的线程没人关。
+     */
+    private UltiPanelLogTransmitter newTransmitter(UltiPanelWebSocketClient client, String serverId) {
+        UltiPanelLogTransmitter transmitter = new UltiPanelLogTransmitter(client, serverId);
+        createdTransmitters.add(transmitter);
+        return transmitter;
+    }
+
     @BeforeEach
     void setUp() {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         server = MockBukkit.mock();
         MockBukkit.createMockPlugin();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
 
         // Mock logger
         mockLogger = mock(Logger.class);
-        when(UltiTools.getInstance().getLogger()).thenReturn(mockLogger);
+
+        // 这个桩要在 mock 发布到静态单例之前打完，否则别的线程可能在打桩中途调进来
+        // 把 answer 抢走。见 issue #250。
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(
+                ultiTools -> lenient().when(ultiTools.getLogger()).thenReturn(mockLogger));
 
         // Mock WebSocket client
         mockWebSocketClient = mock(UltiPanelWebSocketClient.class);
         when(mockWebSocketClient.isConnected()).thenReturn(true);
         when(mockWebSocketClient.getServerId()).thenReturn("test-server");
 
-        logTransmitter = new UltiPanelLogTransmitter(mockWebSocketClient, "test-server");
+        logTransmitter = newTransmitter(mockWebSocketClient, "test-server");
     }
 
     @AfterEach
     void tearDown() {
+        // 关掉本用例造出来的每一条调度线程。漏一条就活到 fork 结束，见上面 createdTransmitters 的注释。
+        for (UltiPanelLogTransmitter transmitter : createdTransmitters) {
+            try {
+                transmitter.shutdown();
+            } catch (Exception ignored) {
+                // shutdown 内部自己吞异常，这里只是兜底；重点是每条都调到
+            }
+        }
+        createdTransmitters.clear();
         com.ultikits.ultitools.utils.MockBukkitHelper.safeUnmock();
     }
 
@@ -77,7 +113,7 @@ class UltiPanelLogTransmitterTest {
         @DisplayName("应该使用提供的 serverId")
         void shouldUseProvidedServerId() throws Exception {
             // Arrange & Act
-            UltiPanelLogTransmitter transmitter = new UltiPanelLogTransmitter(mockWebSocketClient, "custom-server-id");
+            UltiPanelLogTransmitter transmitter = newTransmitter(mockWebSocketClient, "custom-server-id");
 
             // Assert
             Field serverIdField = UltiPanelLogTransmitter.class.getDeclaredField("serverId");
@@ -89,7 +125,7 @@ class UltiPanelLogTransmitterTest {
         @DisplayName("serverId 为 null 时应该使用默认值")
         void shouldUseDefaultServerIdWhenNull() throws Exception {
             // Arrange & Act
-            UltiPanelLogTransmitter transmitter = new UltiPanelLogTransmitter(mockWebSocketClient, null);
+            UltiPanelLogTransmitter transmitter = newTransmitter(mockWebSocketClient, null);
 
             // Assert
             Field serverIdField = UltiPanelLogTransmitter.class.getDeclaredField("serverId");
@@ -101,7 +137,7 @@ class UltiPanelLogTransmitterTest {
         @DisplayName("应该初始化日志队列")
         void shouldInitializeLogQueue() throws Exception {
             // Arrange & Act
-            UltiPanelLogTransmitter transmitter = new UltiPanelLogTransmitter(mockWebSocketClient, "test");
+            UltiPanelLogTransmitter transmitter = newTransmitter(mockWebSocketClient, "test");
 
             // Assert
             Field queueField = UltiPanelLogTransmitter.class.getDeclaredField("logQueue");
@@ -113,7 +149,7 @@ class UltiPanelLogTransmitterTest {
         @DisplayName("应该初始化批量调度器")
         void shouldInitializeBatchScheduler() throws Exception {
             // Arrange & Act
-            UltiPanelLogTransmitter transmitter = new UltiPanelLogTransmitter(mockWebSocketClient, "test");
+            UltiPanelLogTransmitter transmitter = newTransmitter(mockWebSocketClient, "test");
 
             // Assert
             Field schedulerField = UltiPanelLogTransmitter.class.getDeclaredField("batchScheduler");
@@ -140,7 +176,7 @@ class UltiPanelLogTransmitterTest {
         @DisplayName("WebSocket 为 null 时不应该抛出异常")
         void shouldNotThrowWhenWebSocketNull() {
             // Arrange
-            UltiPanelLogTransmitter transmitter = new UltiPanelLogTransmitter(null, "test");
+            UltiPanelLogTransmitter transmitter = newTransmitter(null, "test");
 
             // Act & Assert - 不应该抛出异常
             assertDoesNotThrow(() -> transmitter.sendLog("info", "test message", "server", null));
@@ -730,7 +766,7 @@ class UltiPanelLogTransmitterTest {
         @DisplayName("webSocketClient 为 null 时应该安全处理")
         void shouldHandleNullWebSocketClient() {
             // Arrange
-            UltiPanelLogTransmitter transmitter = new UltiPanelLogTransmitter(null, "test");
+            UltiPanelLogTransmitter transmitter = newTransmitter(null, "test");
 
             // Act - 不应该抛出异常
             transmitter.sendLog("info", "test", "server", null);
@@ -874,7 +910,7 @@ class UltiPanelLogTransmitterTest {
             // Arrange - 使用 null serverId 创建新的 transmitter
             // 在正常情况下，getDefaultServerId 会尝试获取 UUID
             // 我们验证即使有异常也能正常工作
-            UltiPanelLogTransmitter transmitter = new UltiPanelLogTransmitter(mockWebSocketClient, null);
+            UltiPanelLogTransmitter transmitter = newTransmitter(mockWebSocketClient, null);
 
             // Assert
             Field serverIdField = UltiPanelLogTransmitter.class.getDeclaredField("serverId");
@@ -911,7 +947,7 @@ class UltiPanelLogTransmitterTest {
         @DisplayName("shutdown 超时应该强制关闭")
         void shouldForceShutdownOnTimeout() throws Exception {
             // Arrange
-            UltiPanelLogTransmitter transmitter = new UltiPanelLogTransmitter(mockWebSocketClient, "test");
+            UltiPanelLogTransmitter transmitter = newTransmitter(mockWebSocketClient, "test");
             
             // 添加一些日志来确保有数据
             when(mockWebSocketClient.isConnected()).thenReturn(true);
@@ -928,7 +964,7 @@ class UltiPanelLogTransmitterTest {
         @DisplayName("多次 shutdown 不应该抛出异常")
         void multipleShutdownShouldNotThrow() {
             // Arrange
-            UltiPanelLogTransmitter transmitter = new UltiPanelLogTransmitter(mockWebSocketClient, "test");
+            UltiPanelLogTransmitter transmitter = newTransmitter(mockWebSocketClient, "test");
 
             // Act - 多次 shutdown
             transmitter.shutdown();

--- a/src/test/java/com/ultikits/ultitools/utils/TestHelper.java
+++ b/src/test/java/com/ultikits/ultitools/utils/TestHelper.java
@@ -1,6 +1,7 @@
 package com.ultikits.ultitools.utils;
 
 import java.lang.reflect.Field;
+import java.util.function.Consumer;
 
 import org.mockito.Mockito;
 
@@ -8,12 +9,43 @@ import com.ultikits.ultitools.UltiTools;
 
 @SuppressWarnings("PMD.AvoidAccessibilityAlteration") // Test helper requires reflection for mocking
 public class TestHelper {
-    public static void mockUltiToolsInstance() {
+
+    /**
+     * 创建一个 UltiTools mock 并把它装进静态单例字段。
+     *
+     * @return 已经发布出去的 mock，方便调用方继续 verify
+     */
+    public static UltiTools mockUltiToolsInstance() {
+        return mockUltiToolsInstance(null);
+    }
+
+    /**
+     * 同上，但允许调用方在 mock 被发布到静态字段**之前**补充自己的打桩。
+     *
+     * <p>为什么必须提供这个回调，而不是让调用方拿到返回值之后再打桩：
+     * {@code UltiTools.ultiTools} 是全局静态字段，写进去的瞬间整个 JVM 里所有还活着的
+     * 线程（泄漏的调度线程、挂在 root logger 上的 handler、Bukkit 调度器……）都能通过
+     * {@code UltiTools.getInstance()} 拿到它并开始调用。而 Mockito 的
+     * {@code InvocationContainerImpl.invocationForStubbing} 是 per-mock 的共享可变字段，
+     * 既不是 volatile 也没有加锁：只要在 {@code when(...)} 和 {@code thenReturn(...)}
+     * 之间有别的线程调了这个 mock 一次，answer 就会被绑到那次调用上去。
+     *
+     * <p>后果就是把 {@code isEnabled()} 的 {@code true} 挂到了 {@code getLogger()} 上，
+     * 之后再调 {@code getLogger()} 就抛
+     * {@code ClassCastException: Boolean cannot be cast to Logger}，
+     * 堆栈还指在 {@code JavaPlugin.getLogger} 上（inline mock maker 织入的 checkcast
+     * 沿用了原方法的行号），看着像 Bukkit 出了问题。见 issue #250。
+     *
+     * <p>所以规矩是：<b>先打完所有的桩，最后一步才发布</b>。不要先发布再补桩。
+     *
+     * @param extraStubbing 发布前执行的额外打桩，可为 null
+     * @return 已经发布出去的 mock
+     */
+    public static UltiTools mockUltiToolsInstance(Consumer<UltiTools> extraStubbing) {
         try {
             UltiTools mock = Mockito.mock(UltiTools.class);
-            Field instanceField = UltiTools.class.getDeclaredField("ultiTools");
-            instanceField.setAccessible(true);
-            instanceField.set(null, mock);
+
+            // ---- 以下全部发生在 mock 被发布之前，此时没有任何别的线程能拿到它 ----
 
             // Mock i18n(String)
             Mockito.lenient().when(mock.i18n(Mockito.anyString())).thenAnswer(invocation -> invocation.getArgument(0));
@@ -27,6 +59,17 @@ public class TestHelper {
             // Mock getPluginLoader()
             org.bukkit.plugin.PluginLoader pluginLoader = Mockito.mock(org.bukkit.plugin.PluginLoader.class);
             Mockito.lenient().when(mock.getPluginLoader()).thenReturn(pluginLoader);
+
+            if (extraStubbing != null) {
+                extraStubbing.accept(mock);
+            }
+
+            // ---- 发布。这一步必须是最后一步 ----
+            Field instanceField = UltiTools.class.getDeclaredField("ultiTools");
+            instanceField.setAccessible(true);
+            instanceField.set(null, mock);
+
+            return mock;
         } catch (Exception e) {
             // If mocking final class fails, we might need another approach,
             // but let's try this first.

--- a/src/test/java/com/ultikits/ultitools/utils/TestHelperTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/TestHelperTest.java
@@ -1,0 +1,93 @@
+package com.ultikits.ultitools.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import com.ultikits.ultitools.UltiTools;
+
+/**
+ * TestHelper 自身的回归测试。
+ *
+ * <p>守的是 issue #250：{@code mockUltiToolsInstance()} 曾经先把 mock 写进
+ * {@code UltiTools.ultiTools} 静态字段、之后才打桩，于是任何还活着的后台线程都能在
+ * 打桩进行到一半时调到这个 mock。Mockito 的
+ * {@code InvocationContainerImpl.invocationForStubbing} 是 per-mock 的共享可变字段，
+ * 被插一脚就会把 answer 绑到那次调用的方法上——{@code isEnabled()} 的 {@code true}
+ * 因此挂到了 {@code getLogger()} 上，之后再调 {@code getLogger()} 抛
+ * {@code ClassCastException: Boolean cannot be cast to Logger}。
+ */
+@DisplayName("TestHelper 测试")
+class TestHelperTest {
+
+    /**
+     * 回归前这个 bug 极易触发：本地用一条热循环线程施压时，头几轮就必炸。
+     * 300 轮留了很大余量，同时保证这个用例本身跑得够快。
+     */
+    private static final int ROUNDS = 300;
+
+    @Test
+    @DisplayName("发布出去的 mock 必须已经打完桩：并发调用不得污染 stubbing")
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void shouldOnlyPublishFullyStubbedMock() throws Exception {
+        Logger stubbedLogger = mock(Logger.class);
+
+        // 先占住静态字段，免得下面那条线程在第一轮之前碰到别的测试类留下的 mock。
+        TestHelper.mockUltiToolsInstance(
+                ultiTools -> lenient().when(ultiTools.getLogger()).thenReturn(stubbedLogger));
+
+        AtomicBoolean stop = new AtomicBoolean(false);
+        AtomicReference<Throwable> strayFailure = new AtomicReference<>();
+        CountDownLatch started = new CountDownLatch(1);
+
+        // 模拟现实里的污染源：泄漏的 UltiPanel-LogTransmitter 调度线程、挂在 root logger
+        // 上的 SystemLogHandler，都会在任意时刻通过 UltiTools.getInstance() 调进来。
+        Thread stray = new Thread(() -> {
+            started.countDown();
+            while (!stop.get()) {
+                try {
+                    UltiTools instance = UltiTools.getInstance();
+                    if (instance != null) {
+                        instance.getLogger();
+                        instance.isEnabled();
+                    }
+                } catch (Throwable t) {
+                    strayFailure.compareAndSet(null, t);
+                }
+            }
+        }, "issue-250-stray-thread");
+        stray.setDaemon(true);
+        stray.start();
+        assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
+
+        try {
+            for (int i = 0; i < ROUNDS; i++) {
+                TestHelper.mockUltiToolsInstance(
+                        ultiTools -> lenient().when(ultiTools.getLogger()).thenReturn(stubbedLogger));
+
+                // 修复前这里就是 LogStreamManagerTest:75 的现场：getLogger() 返回的
+                // 可能是 isEnabled() 的 Boolean，inline mock maker 织入的 checkcast
+                // 会抛 ClassCastException，堆栈指在 JavaPlugin.getLogger 上。
+                assertThat(UltiTools.getInstance().getLogger()).isSameAs(stubbedLogger);
+                assertThat(UltiTools.getInstance().isEnabled()).isTrue();
+            }
+        } finally {
+            stop.set(true);
+            stray.join(TimeUnit.SECONDS.toMillis(5));
+        }
+
+        // 这个用例自己不许泄漏线程——那正是它在防的病。
+        assertThat(stray.isAlive()).isFalse();
+        assertThat(strayFailure.get()).isNull();
+    }
+}


### PR DESCRIPTION
Closes #250

## 根因

**不是静态状态残留，是泄漏的活线程撞上正在进行的 Mockito 打桩。**

`TestHelper.mockUltiToolsInstance()` 先把 mock 写进全局静态字段 `UltiTools.ultiTools`，**之后**才打桩：

```java
UltiTools mock = Mockito.mock(UltiTools.class);
instanceField.set(null, mock);                       // ← 先发布
Mockito.lenient().when(mock.isEnabled()).thenReturn(true);   // ← 后打桩
```

mock 一旦发布出去，JVM 里任何还活着的线程都能通过 `UltiTools.getInstance()` 调到它。而 Mockito 的 `InvocationContainerImpl.invocationForStubbing` 是 per-mock 的共享可变字段，既非 `volatile` 也无锁——只要在 `when(...)` 和 `thenReturn(...)` 之间有别的线程调这个 mock 一次，answer 就被绑到那次调用的方法上。

于是 `isEnabled()` 的 `true` 挂到了 `getLogger()` 上，之后再调 `getLogger()` 就抛 `ClassCastException: Boolean cannot be cast to Logger`。

### 为什么堆栈指在 `JavaPlugin.getLogger(:469)`

那一行的字节码只有 `aload_0 / getfield logger / areturn`，**没有任何 checkcast**，纯 JVM 语义下抛不出 CCE。抛异常的是 Mockito inline mock maker（Mockito 5 默认，本仓库没有 `mockito-extensions` 配置）织进方法入口的 advice：它调 `MockMethodAdvice.handle(...)`（返回 `Object`）再 `checkcast` 成声明返回类型，织入代码沿用原方法行号。负向对照里直接打出了这个栈：

```
at org.mockito.internal.creation.bytebuddy.MockMethodAdvice.handle(MockMethodAdvice.java:134)
at org.bukkit.plugin.java.JavaPlugin.isEnabled(JavaPlugin.java:118)
```

### 为什么 CI 报的是 CCE 而不是 Mockito 自己的 `WrongTypeOfReturnValue`

Mockito 5.5.0 `InvocationContainerImpl.addAnswer()` 有个 TOCTOU 窗口：

```java
Invocation invocation = invocationForStubbing.getInvocation();   // L61 读进局部变量
if (answer instanceof ValidableAnswer) {
    ((ValidableAnswer) answer).validateFor(invocation);           // L64 用局部变量校验
}
synchronized (stubbed) {
    stubbed.addFirst(new StubbedInvocationMatcher(
            answer, invocationForStubbing, effectiveStrictness));  // L75 却重读字段
}
```

宽窗口（L61 之前被抢）→ 校验用的就是被劫持的 invocation → 抛 `WrongTypeOfReturnValue`。
窄窗口（L64 与 L75 之间被抢）→ **绕过校验**，静默装上 `getLogger() -> Boolean`，等下次调用才炸成 CCE。CI 命中的是后者。

### 撞进来的线程从哪来

两处 `tearDown` 都没关掉自己造的东西：

| 位置 | 泄漏的东西 |
|---|---|
| `LogStreamManagerTest` | `initialize()` 把 `SystemLogHandler` 挂到 JVM root logger（`Logger.getLogger("")`）并起传输线程；`tearDown` 只 `resetSingleton()`，被丢掉的实例带着这两样继续活着 |
| `UltiPanelLogTransmitterTest` | 55 个用例各 `new` 一个真实 `UltiPanelLogTransmitter`，构造函数就起一条 5 秒周期的 `UltiPanel-LogTransmitter` 调度线程，大部分从不 `shutdown()` |

surefire 没配 `forkCount`/`reuseForks`，整个套件跑在**一个 JVM** 里，所以这些线程一直活到 fork 结束。它们周期性调 `UltiTools.getInstance().getLogger()`。

### 为什么同一个 commit 重跑结果不同

从两次运行的日志提取真实执行顺序：

| 运行 | `UltiPanelLogTransmitterTest` 位置 | `LogStreamManagerTest` 位置 | 结果 |
|---|---|---|---|
| 31784856235 attempt 1 | **199** | 446（`$StatusQueryTests` 在 460） | ❌ CCE |
| 31784816817 | 534 | 508 | ✅ |

失败那次里 transmitter 测试排在前面约 250 个类，它泄漏的几十条线程在 `LogStreamManagerTest` 打桩时正在跑；通过那次里它排在后面。issue 原来猜「顺序相关」是对的，但机制猜成了静态状态残留。

> 附带一提：run 31784856235 现在显示为 success，因为它被**重跑**成了 attempt 2，失败证据只能通过 `gh api .../attempts/1/logs` 取到。这正是 issue 里说的「间歇性失败会训练维护者把红灯当噪音」的实例。

## 改动

- **`TestHelper`**：打完所有桩**最后一步才发布**；新增 `mockUltiToolsInstance(Consumer<UltiTools>)` 重载，让调用方也能在发布前补桩
- **`LogStreamManagerTest`**：`tearDown` 调 `shutdown()`，并按类型扫掉 root logger 上残留的 `SystemLogHandler`；`getLogger()`/`getConfig()` 的桩移到发布前
- **`UltiPanelLogTransmitterTest`**：10 处 `new UltiPanelLogTransmitter(...)` 收归统一入口 `newTransmitter(...)`，`tearDown` 逐个 `shutdown()`
- **新增 `TestHelperTest`**：回归测试，守住「发布出去的 mock 必须已打完桩」

## 验证

**本地连续 10 次 `mvn -B clean test`，10/10 全绿：**

| | Tests run | Failures | Errors | Skipped |
|---|---|---|---|---|
| CI attempt-1（失败基线） | 4172 | 0 | **1** | 5 |
| 本地 ×10（本 PR） | 4173 | 0 | **0** | 5 |

4173 = 4172 + 新增的回归测试；Skipped 5 是既有的，未改动。

**压力对照**（一条热循环线程持续调 `UltiTools.getInstance().getLogger()`，主线程反复走 `mockUltiToolsInstance()`）：

| | 正常 | WrongTypeOfReturnValue | ClassCastException | stray 调用数 |
|---|---|---|---|---|
| 修复前 | 0 | 4 | **1** | 1,222 |
| 修复后 | **20,000** | 0 | 0 | **386,080** |

修复前 5 轮内必炸，修复后在 38 万次并发调用下跑满 2 万轮零失败。

**回归测试做过负向对照**：把 `TestHelper` 改回「先发布后打桩」（保留新 API）后，`TestHelperTest` 立刻失败，说明它不是装饰。

同一机制在验证过程中打出过三种不同症状，取决于哪个桩被劫持到哪个方法上：

| 被劫持的桩 | 挂到了 | 症状 |
|---|---|---|
| `isEnabled() → true` | `getLogger()` | `CCE: Boolean → Logger`（CI #250） |
| `getPluginLoader() → mock` | `getLogger()` | `CCE: PluginLoader → Logger` |
| `i18n(String) → arg0` | `isEnabled()`（零参数） | `AIOOBE: Index 0 / length 0` |

没有用放宽断言、`@Disabled` 或重试插件。

## 本 PR 未处理

还有 **19 个测试类、36 处**同样是「先发布 mock 再补打桩」（`PlayerEventManagerTest`、`CommandManagerTest`、`ConfigManagerTest` 等）。触发源清掉后它们暂时炸不了，但形状与本 issue 完全一致。这是一次机械但面很广的重构，建议另开 issue 单独做，不塞进这个 PR。
