### PR TITLE
docs: 移除清单改由 forRemoval 标注生成，补行为变更章节

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -8,14 +8,40 @@
 **本项目的版本号是产品阶段信号，不是严格的 semver 契约。**
 
 - **PATCH**（例如 6.2.4 → 6.2.5）：小更新与紧急修复。不移除公开 API。
-- **MINOR**（例如 6.2.x → 6.3.0）：功能演进。**可能包含公开 API 的移除**，分两种情形：
-  - **下游引用为零的类型**——直接移除，每一项记录在下方清单中并附实测依据。
-  - **仍有下游用户的类型**——仅在满足两个条件后移除：提供书面迁移指引，
-    并至少提前一个 PATCH 版本发出移除预告。当前唯一属于此类的是
-    `AbstractCommandExecutor`，见下方专节。
+- **MINOR**（例如 6.2.x → 6.3.0）：功能演进。**可能包含公开 API 的移除**。
 - **MAJOR**：保留给框架层面的方向性变更。不会仅仅为了清理废弃 API 而发布。
 
-如果你需要严格的二进制兼容保证，请锁定具体的 PATCH 版本。
+### 一个公开 API 何时可以被移除
+
+只有同时满足以下两条，才会被列入移除清单：
+
+1. 它在代码里带有 `@Deprecated(since = "…", forRemoval = true)`；
+2. 从**首个带上这个标注的发布**算起，已经跨过至少一个 MINOR 版本。
+
+第 2 条的起算点是**警告真正发到你手里的那个版本**，不是标注里 `since` 写的值——
+`since` 表达的是「我们认为它何时该被废弃」，可以回填；起算点不行。
+下方清单为每一项标出了这个版本。
+
+这两条是移除的**全部依据**。下游引用量不再作为依据：
+清单里附带的引用量实测只是参考信息，它能告诉你哪几项的迁移成本真实存在，
+但「零引用」只证明我们能看到的仓库里没人用，证明不了组织外的第三方没在用。
+
+为什么用 `forRemoval` 而不是普通的 `@Deprecated`：javac 的 `-Xlint:removal` 自 JDK 9 起
+**默认开启**，`-Xlint:deprecation` **默认关闭**。带 `forRemoval` 的 API 会在你的构建里
+逐处点名报警；只带普通 `@Deprecated` 的则只有一句不含 API 名、不含行号的笼统提示。
+所以我们把「你确实被点名警告过」当作可以移除的前提。
+
+### 与 semver 的两处明确偏离
+
+格式是 `MAJOR.MINOR.PATCH`，容易让人套用 [semver](https://semver.org/spec/v2.0.0.html) 的预期。
+以下两点我们和 semver 原文不一致，特此点名：
+
+- **移除时机**。semver 的做法是废弃后要等到下一个 MAJOR 才移除；
+  本项目在跨过一个 MINOR 之后就会在 MINOR 移除。如果你需要严格的二进制兼容保证，
+  请锁定具体的 PATCH 版本。
+- **不采用 semver 条款 6 的宽松解读**。该条款允许把「修正错误行为」当作可以走 PATCH 的
+  bug fix。本项目不这么做：任何会改变下游运行时行为的变更，一律按下方
+  [行为变更](#行为变更) 一节处理，不会因为「这是在修 bug」就绕开迁移期。
 
 ## 依赖声明
 
@@ -44,27 +70,67 @@ flatten-maven-plugin 处理后不含依赖声明，因此把 UltiTools-API 放�
 
 ## 6.3.0 的移除清单
 
-以下类型将在 6.3.0 移除。每一项都附有移除依据——
-2026-08-10 对 UltiKits 组织下 17 个下游模块仓库的引用量实测（排除测试目录）。
-这 17 个中有 15 个是继承 `UltiToolsPlugin` 的插件模块，另两个分别是父 POM
-（`ultikits-module-parent`）与一个非插件项目；引用量统计覆盖全部 17 个。
+**这份清单按代码里的 `@Deprecated(forRemoval = true)` 标注生成，不再手工维护。**
+标注是唯一的真相来源；文档不会再列出代码里没有标注的类型。
+标为 `@ApiStatus.Internal` 的包与类型不在此列——它们本就不属于公开 API，
+移除它们不构成兼容性事件。
 
-| 类型 | 下游引用 | 替代方案 |
-|---|---|---|
-| `AbstractCommendExecutor` | 0 | `abstracts.command.BaseCommandExecutor` |
-| `AbstractDataEntity` | 0 | `abstracts.data.BaseDataEntity<ID>` |
-| `abstracts.guis.PagingPage` | 0 | `abstracts.gui.BasePaginationPage` |
-| `abstracts.guis.OkCancelPage` | 0 | `abstracts.gui.BaseConfirmationPage` |
-| `interfaces.VersionWrapper` 的废弃方法 | 0 | `utils.XVersionUtils` |
-| `utils.SecurityPolicy`（重命名） | 0 | `PluginScanFilter`（不提供运行时约束） |
+「移除预告发自」是该 API 首次带上 `forRemoval` 标注的发布版本，
+也就是你的构建第一次点名警告它的版本。
 
-若你的模块不在上述 17 个仓库中且引用了其中任何一项，
-请在 6.3.0 发布前提 issue，我们会重新评估。
+### 命令
+
+| 类型 / 成员 | 移除预告发自 | 替代方案 | 下游引用（参考） |
+|---|---|---|---|
+| `abstracts.AbstractCommandExecutor` | 6.2.1 | `abstracts.command.BaseCommandExecutor` | **15 个文件 / 6 个仓库** |
+| `abstracts.AbstractCommendExecutor`（拼写错误的空 shim） | 6.2.5 | 同上 | 0 |
+| `manager.CommandManager.register(CommandExecutor, …)` 的两个重载 | 6.2.5 | `register(UltiToolsPlugin, Class, String, String, String…)` | 0 |
+| `annotations.command.@OptionalParam` | 6.2.5 | 无替代——该注解从未实现，标注它不影响解析；改为每种可接受的参数形态各写一条 `@CmdMapping` | 0 |
+
+### 版本适配
+
+`interfaces.VersionWrapper` 整簇由 `utils.XVersionUtils` 取代，后者是前者的超集。
+
+| 类型 / 成员 | 移除预告发自 | 替代方案 | 下游引用（参考） |
+|---|---|---|---|
+| `interfaces.VersionWrapper` 接口及其 14 个 default 方法 | 6.2.5 | `utils.XVersionUtils` | 0 |
+| `interfaces.impl.DefaultVersionWrapper` | 6.2.5 | 同上 | 0 |
+| `UltiTools.getVersionWrapper()` | 6.2.5 | 同上 | 0 |
+| `abstracts.UltiToolsPlugin.getVersionWrapper()`（static） | 6.2.5 | 同上 | 0 |
+
+### 数据与界面基类
+
+| 类型 / 成员 | 移除预告发自 | 替代方案 | 下游引用（参考） |
+|---|---|---|---|
+| `abstracts.AbstractDataEntity` | 6.2.1 | `abstracts.data.BaseDataEntity<ID>` | 0 |
+| `abstracts.guis.PagingPage` | 6.2.1 | `abstracts.gui.BasePaginationPage` | 0 |
+| `abstracts.guis.OkCancelPage` | 6.2.1 | `abstracts.gui.BaseConfirmationPage` | 0 |
+
+### 监听器与注册
+
+| 类型 / 成员 | 移除预告发自 | 替代方案 | 下游引用（参考） |
+|---|---|---|---|
+| `interfaces.TempListener.player(Class)` 及 `TempListener.PlayerTempListenerBuilder` | 6.2.5 | `TempListener.common(Class)`，用 `filter(Function)` 收窄到玩家事件 | 0 |
+| `interfaces.impl.PlayerTempListener` | 6.2.5 | 同上 | 0 |
+| `manager.ListenerManager.register(UltiToolsPlugin, Listener)` | 6.2.5 | `register(UltiToolsPlugin, Class)`——旧重载接收已构造好的实例，因此不执行依赖注入 | 0 |
+
+### 插件基类
+
+| 类型 / 成员 | 移除预告发自 | 替代方案 | 下游引用（参考） |
+|---|---|---|---|
+| `abstracts.UltiToolsPlugin(String, String, List, List, int, String)` 六参数构造 | 6.2.5 | 七参数构造，显式传入 `resourceFolderPath`（六参数重载把它硬编码成 `<dataFolder>/pluginConfig/<插件名>`） | 0 |
+
+引用量口径：2026-08-14 对 UltiKits 组织下 17 个模块仓库、4 个工具项目与 Libraries
+共 310 个 Java 文件的实测，排除测试目录与构建产物，只统计 import 与 extends。
+`6.2.1` 这个起算点取自 git 标签中可验证的最早发布；标注里写的 `since = "6.2.0"`
+对应的版本发布到了 Maven Central 但未打标签，无法从仓库历史核对。
+
+**若你的模块引用了其中任何一项，请在 6.3.0 发布前提 issue，我们会重新评估。**
+上表的引用量不是移除依据，也不构成「没人在用」的结论。
 
 ## `AbstractCommandExecutor` 的迁移
 
-`abstracts.AbstractCommandExecutor` 标记为 `@Deprecated(since = "6.2.0", forRemoval = true)`，
-是唯一有真实下游用户的废弃类型（实测 14 个文件）。
+`abstracts.AbstractCommandExecutor` 是清单里唯一有真实下游用户的类型（实测 15 个文件）。
 它将在 6.3.0 移除，**下游迁移会与移除在同一个版本周期内协调完成**。
 
 迁移到 `abstracts.command.BaseCommandExecutor`：
@@ -75,20 +141,78 @@ flatten-maven-plugin 处理后不含依赖声明，因此把 UltiTools-API 放�
 4. 通过 `@CmdExecutor` 包扫描注册的命令需要改为显式注册——
    扫描路径会把新基类强转为旧基类。走 IoC 路由的主加载路径不受影响。
 
-新基类目前有两个已知缺口，修复排期**不同**：
+拼写错误的空壳 `AbstractCommendExecutor` 继承自 `AbstractCommandExecutor`，
+因此它**必须与父类在同一个版本移除**，不存在单独保留的选项。
+
+新基类目前有一个已知缺口：
 
 | 缺口 | 排期 |
 |---|---|
-| `@CmdMapping(format = "")` 的裸命令不可执行 | **6.2.5** |
-| 参数级 tab 补全尚未接线 | **6.3.0**（排在维护者对下述 17 个仓库的迁移之前） |
+| 参数级 tab 补全尚未接线 | **6.3.0**（排在维护者对下游仓库的迁移之前） |
+
+（`@CmdMapping(format = "")` 的裸命令不可执行，此前排期 6.2.5，**已在 6.2.5 修复**。）
 
 迁移时机取决于你是谁：
 
-- **上述 17 个仓库内的模块**由维护者在 6.3.0 周期内统一迁移，你不需要自己动手。
-- **仓库外的第三方模块**应当在 **6.2.5 期间**就完成迁移。这样做要接受一个代价：
+- **UltiKits 组织内的模块**由维护者在 6.3.0 周期内统一迁移，你不需要自己动手。
+- **组织外的第三方模块**应当在 **6.2.5 期间**就完成迁移。这样做要接受一个代价：
   参数级 tab 补全要到 6.3.0 才接线，在此之前迁移过去的命令只在第一个参数位补全字面量。
   但这是唯一能给你留出真实过渡期的做法——补齐 tab 补全的版本（6.3.0）
   同时也是移除旧基类的版本，等到那时再迁移就没有缓冲了。
+
+## 行为变更
+
+有一类变更方法签名一动不动，却会改变你的模块在运行时的表现：
+某个方法从静默返回改成抛异常、某个默认值翻转、缺少可选依赖时从降级运行改成加载失败。
+签名比对工具查不出这类变更，上面的移除清单也覆盖不到它们。本节说明我们怎么处理。
+
+### 三类兼容性
+
+沿用 [OpenJDK CSR](https://wiki.openjdk.org/display/csr/Kinds+of+Compatibility) 与
+[dotnet/runtime](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/breaking-change-definitions.md)
+的划分：
+
+- **源码兼容（source）**——你的代码还能不能通过编译。移除类型、改方法签名、
+  给接口加抽象方法都会破坏它。
+- **二进制兼容（binary）**——你**已经编译好**的 JAR 还能不能在新框架上加载和运行。
+  破坏它的典型表现是 `NoSuchMethodError` / `NoClassDefFoundError`。
+- **行为兼容（behavioral）**——编译过了、也加载起来了，但**做的事情变了**。
+
+前两类由上面的移除清单和版本号规则管。本节管第三类。
+
+### 哪些行为变更可以在 MINOR 直接做
+
+不需要迁移期：
+
+- 修正明确违反文档的行为（文档说返回 `Optional.empty()`，实际抛了 NPE）。
+- 收紧此前未定义的输入的处理方式（此前传 `null` 是未定义行为，现在明确抛 `IllegalArgumentException`）。
+- 性能、内存占用、日志文案、异常消息文本的变化。
+- 修复安全问题。这一类可能在 PATCH 就发生，恕不预告。
+
+### 哪些需要迁移期
+
+需要迁移期：
+
+- 有文档记载的默认值翻转。
+- 从静默降级改成失败（例如可选依赖缺失时，此前跳过、之后拒绝加载）。
+- 返回值语义变化（此前返回空集合、之后返回 `null`，反之亦然）。
+- 副作用的时机或线程变化（此前同步、之后异步）。
+
+迁移期走两步：
+
+- **版本 N**：保持旧行为，但在触发该路径时打**一次性** WARNING。
+  警告文本必须写明具体的目标版本号和反馈 issue 链接，例如：
+
+  ```
+  [UltiTools] 模块 <name> 依赖了 X 的旧行为（<旧行为的一句话描述>）。
+  该行为将在 6.4.0 改为 <新行为>。迁移方式见 <issue 链接>。
+  本警告每次启动只打一次。
+  ```
+
+- **版本 N+1**：真正切换到新行为，并移除该警告。
+
+这一节的写法参考了 [PEP 387](https://peps.python.org/pep-0387/)，
+核心是同一条：**先让人知道自己踩在了哪块地板上，再抽走它。**
 
 ## 支持范围
 

--- a/src/main/java/com/ultikits/ultitools/UltiTools.java
+++ b/src/main/java/com/ultikits/ultitools/UltiTools.java
@@ -88,8 +88,30 @@ public final class UltiTools extends JavaPlugin implements Localized {
      * @deprecated Use {@link com.ultikits.ultitools.utils.XVersionUtils} instead.
      */
     @Deprecated(since = "6.2.0", forRemoval = true)
-    @Getter
     private VersionWrapper versionWrapper;
+
+    /**
+     * 手写而不是用 Lombok 的 {@code @Getter}。Lombok 会把 {@code @Deprecated} 复制到生成的
+     * accessor 上，但<b>丢掉 {@code since} 与 {@code forRemoval} 两个元素</b>，编译产物里只剩一个
+     * 裸 {@code @Deprecated}。而 javac 的 {@code -Xlint:removal} 自 JDK 9 起默认开启、
+     * {@code -Xlint:deprecation} 默认关闭，所以下游用默认参数编译时收不到点名的移除警告，
+     * 只会看到一句不含 API 名的笼统提示。字段上标了 {@code forRemoval} 不解决问题 ——
+     * 对外的入口是这个 getter，标注必须落在它身上。改回 {@code @Getter} 会让
+     * COMPATIBILITY.md 的移除清单对这一项失真。
+     *
+     * <p>Hand-written rather than Lombok's {@code @Getter}: Lombok copies
+     * {@code @Deprecated} onto the generated accessor but drops the {@code since}
+     * and {@code forRemoval} elements, so downstream compiling with default flags
+     * never sees the named {@code [removal]} warning for this API.
+     *
+     * @return the version wrapper <br> 版本适配器
+     * @deprecated Use {@link com.ultikits.ultitools.utils.XVersionUtils} instead.
+     */
+    @Deprecated(since = "6.2.0", forRemoval = true)
+    public VersionWrapper getVersionWrapper() {
+        return versionWrapper;
+    }
+
     @Getter
     private Language language;
     @Getter


### PR DESCRIPTION
Closes #225

## 依据的改变

移除的唯一依据从「下游引用为零」改成：

1. 代码里带 `@Deprecated(since = …, forRemoval = true)`；
2. 从**首个带上这个标注的发布**算起，已跨过至少一个 MINOR。

第 2 条的起算点是**警告真正发到下游手里的版本**，不是注解里 `since` 写的值——`since` 表达的是「我们认为它何时该被废弃」，可以回填；起算点不行。清单为每一项标出了这个版本。

引用量降级为参考信息：它能说明哪几项的迁移成本真实存在，但「零引用」只证明我们能看到的仓库里没人用。

## 为什么起算点必须是发布版本而不是 `since`

上一个发布 `v6.2.4` 里只有 4 处带 `forRemoval`：

```
$ git grep -c forRemoval v6.2.4 -- src/main/java
合计 4 处
```

其余 28 处是 6.2.5 开发期由 #226 / #229 补的，`since` 值（6.0.5…6.2.1）全是回填。好消息是这 28 处在 v6.2.4 **已经都是 `@Deprecated`**，没有一处是「完全没标废弃就要删」。

但这个差别不是形式上的。javac 默认参数实测：

```
warning: [removal] marked() in Lib has been deprecated and marked for removal
    public static void main(String[] a) { Lib.bare(); Lib.marked(); }
                                                         ^
Note: User.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
1 warning
```

`-Xlint:removal` 自 JDK 9 起**默认开启**，`-Xlint:deprecation` **默认关闭**。带 `forRemoval` 的逐处点名；裸 `@Deprecated` 只给一句不含 API 名、不含行号的笼统提示。所以那 28 个 API 的使用者在 6.2.4 上知道「我用了某个废弃的东西」，但不知道是哪个。

按本文件**自己现行的规则**——对更难的情形（仍有下游用户的类型）也只要求「书面迁移指引 + 至少提前一个 PATCH 发出移除预告」——6.2.5 正是那个预告版本。所以 6.3.0 全删站得住，前提是**逐项写明预告版本**。这份 PR 做的就是把那一列补上。

## 清单的变化

| | 改前 | 改后 |
|---|---|---|
| 条目数 | 7 个类型（6 行 + 1 个专节） | 15 个条目 / 33 个标注站点 |
| 生成方式 | 手工维护 | 按代码标注生成 |
| 分组 | 无 | 命令 · 版本适配 · 数据与界面基类 · 监听器与注册 · 插件基类 |
| 每项预告版本 | 无 | 有（档一 4 项发自 6.2.1，其余发自 6.2.5） |

删掉的三项及原因：

- **`utils.SecurityPolicy`（重命名）** —— 这条最严重：该类连 `@Deprecated` 都没有，而它声明的替代方案 **`PluginScanFilter` 在代码库里根本不存在**。等于对外承诺移除一个从未标记废弃的类，还把用户指向一个不存在的迁移出路。整行下架，归 #207。
- **`AbstractCommendExecutor`** 与 **`VersionWrapper` 的废弃方法** —— 当时只有裸 `@Deprecated`，未走完整废弃流程。#226 / #229 补齐标注后重新列入，且 `VersionWrapper` 的实际移除面比原来写的「废弃方法」大，是整个接口 + `DefaultVersionWrapper` + 两个 accessor。

`@ApiStatus.Internal` 覆盖的包与类型不列入——它们本就不属于公开 API，移除不构成兼容性事件。`context.UltiToolsBean.getVersionWrapper()` 因此排除（该类由 #227 标注）。

## 附带的代码修复

`UltiTools.versionWrapper` 是 private 字段，对外入口是 Lombok `@Getter` 生成的 `public getVersionWrapper()`。Lombok 会把 `@Deprecated` 复制到生成的 accessor 上，**但丢掉 `since` 与 `forRemoval` 两个元素**：

```
Lombok 生成的 UltiTools.getVersionWrapper()
  RuntimeVisibleAnnotations:
    0: #834()
      java.lang.Deprecated                    ← 空的，没有元素

手写的 UltiToolsPlugin.getVersionWrapper()
  RuntimeVisibleAnnotations:
    0: #583(#584=s#593,#586=Z#587)
      java.lang.Deprecated(
        since="6.2.0"
        forRemoval=true
      )
```

后果：源码里这一处有 `forRemoval=true`，清单会把它算作「已警告」，而下游调 `UltiTools.getInstance().getVersionWrapper()` 时**永远收不到 `[removal]` 警告**。字段上标注不解决问题——对外入口是 getter。

改为手写 getter 并带全标注，注释里写明了为什么不能改回 `@Getter`。修改后的字节码已用 `javap -v` 核对：

```
0: #834(#835=s#836,#837=Z#838)
   java.lang.Deprecated(since="6.2.0", forRemoval=true)
```

这是让「清单按代码生成」这句话真正成立的必要条件，否则文档在这一项上会撒谎。

## 新增：行为变更章节

签名一动不动、却会改变下游运行时表现的变更（静默返回改成抛异常、默认值翻转、可选依赖缺失时从降级改成失败），签名比对工具查不出来，移除清单也覆盖不到。新增一节：

- **source / binary / behavioral 三分法**，沿用 [OpenJDK CSR](https://wiki.openjdk.org/display/csr/Kinds+of+Compatibility) 与 [dotnet/runtime](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/breaking-change-definitions.md) 的划分
- **可在 MINOR 直接做的**：修正明确违反文档的行为、收紧此前未定义的输入、性能与日志文案、安全修复
- **需要迁移期的**：有文档记载的默认值翻转、从静默降级改成失败、返回值语义变化、副作用时机或线程变化
- **迁移期两步走**：版本 N 保持旧行为但打一次性 WARNING（文本必须含目标版本号与反馈 issue 链接，给了模板），N+1 才切换。写法参考 [PEP 387](https://peps.python.org/pep-0387/)

## 其余

- 版本号语义补两处 semver 偏离说明：移除时机（semver 原文要求等到 MAJOR）；不采用条款 6 的宽松解读（不因为「这是在修 bug」就绕开迁移期）
- 统一了此前同一节里三种互相打架的移除条件表述
- `AbstractCommandExecutor` 迁移节：裸命令不可执行已由 #178（PR #247）在 6.2.5 修复，改为记录；补充说明拼写错误的 `AbstractCommendExecutor` 继承自 `AbstractCommandExecutor`，**必须与父类同版本移除**，不存在单独保留的选项

## 验证

- `mvn -B clean verify` 通过：**4173 tests, 0 failures, 0 errors**
- `mvn javadoc:javadoc` 通过（新增的手写 getter 带完整 javadoc）
- `javap -v` 核对字节码，确认 `since` / `forRemoval` 已落到 accessor 上
- 交叉核对：源码里 33 个 `@Deprecated(…forRemoval)` 站点全部能在文档里找到落点，`context.UltiToolsBean` 是唯一按 `@ApiStatus.Internal` 规则明确排除的
- `PluginScanFilter` 与 `SecurityPolicy` 在文档中出现次数均为 **0**

引用量口径：2026-08-14 对 Modules 17 仓 + Tooling 4 + Libraries 共 310 个 Java 文件实测，排除测试目录与构建产物，只统计 import 与 extends。`AbstractCommandExecutor` 是唯一有真实下游用户的类型（15 个文件 / 6 个仓库）。
