### PR TITLE
fix(deps): 把 protobuf-java 从 3.25.1 钉到 3.25.5，规避 GHSA-735f-pc8j-v9w8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -494,6 +494,18 @@
             <version>8.3.0</version>
             <scope>provided</scope>
         </dependency>
+        <!--
+            protobuf-java —— 不是本项目直接用的库，是 mysql-connector-j 的传递依赖。
+            显式声明只为把版本从 3.25.1 抬到 3.25.5，规避 GHSA-735f-pc8j-v9w8。
+            provided 作用域与 plugin.yml 的 libraries: 对应（Paper 在运行时下载）。
+            删掉这一条会静默退回 3.25.1，因为传递解析还在。见 issue #220。
+        -->
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.25.5</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Java-WebSocket - Paper libraries 自动下载 -->
         <dependency>
             <groupId>org.java-websocket</groupId>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,6 +14,12 @@ libraries:
   - com.google.code.gson:gson:2.10.1
   - commons-dbutils:commons-dbutils:1.8.1
   - com.mysql:mysql-connector-j:8.3.0
+  # 显式钉版本，不是新依赖：mysql-connector-j 8.3.0 传递引入的是 protobuf-java
+  # 3.25.1，带 GHSA-735f-pc8j-v9w8（解析畸形 protobuf 输入时 DoS，high）。
+  # 直接条目深度为 1，按 Maven 的 nearest-wins 会压过深度 2 的传递解析。
+  # 升 connector 才是根治，但 8.4.0 带的仍是 3.25.1，要跳到 9.x——那是驱动
+  # 大版本变更，需要真机 MySQL 回归，单独处理。见 issue #220。
+  - com.google.protobuf:protobuf-java:3.25.5
   - org.java-websocket:Java-WebSocket:1.5.4
   - cglib:cglib-nodep:3.3.0
   - org.slf4j:slf4j-api:1.8.0-beta4


### PR DESCRIPTION
先确认 issue 的前提成立，因为它决定了这条要不要当运行时问题处理：
protobuf-java 在 mysql-connector-j 的 pom 里是 compile 作用域、
optional=false（同一份 pom 里的 oci-java-sdk-common 才是 optional=true，
不会被拉）。所以 Paper 的 library loader 解析 plugin.yml 里那条
com.mysql:mysql-connector-j:8.3.0 时，protobuf-java 确实会跟着落到每台
服务器的运行时类路径上，不能按构建期依赖处理。

修法选了 issue 给的第二条（显式钉版本），不是第一条（升 connector）。

理由不是「暂时不能升」，是两条路的可验证性不同。8.4.0 带的仍然是
3.25.1，要根治得跳到 9.x —— 那是数据库驱动的大版本变更，issue 自己的
验收里也写了「升级 connector 时需回归真机 MySQL 读写」，而这个回归在
这里做不了。相比之下钉版本只改类路径上 protobuf 的版本，而标准 JDBC
协议根本不走 protobuf（只有 X DevAPI 走），功能影响面为零，同时能完整
关掉这条 high。

升 connector 到 9.x 是一个独立的、更大的决定，值得单开一条并配真机回归。

两处都要改，缺一不可：
- plugin.yml 的 libraries: —— 决定 Paper 运行时下载哪个版本
- pom.xml —— 决定 mvn dependency:tree 与 GitHub 依赖图看到哪个版本
两边都写了注释说明这是钉版本而不是新依赖，删掉会静默退回 3.25.1。

作用域用 provided，与 libraries: 里的其它条目一致（Paper 运行时下载，
不进 shaded JAR）。

验证：
- mvn dependency:tree 中 protobuf-java 解析为 3.25.5，深度从 2 变 1
  （nearest-wins），3.25.1 已不在树里，mysql-connector-j 下不再挂它
- 字节码 major 版本核对过，3.25.5 是 52（Java 8），与本项目的 Java 8
  字节码目标一致，不引入 Java 9+ 类文件
- shaded JAR 中无 protobuf 类（provided 不参与 shade）
- plugin.yml 仍能被 YAML 正确解析，libraries 10 条

没能验证的一条，说明白：issue 验收里「GitHub 的 Dependabot 告警关闭」
在本 PR 合入后不会发生。Dependabot 告警按默认分支的依赖图计算，本仓库
默认分支是 main，而本 PR 合入 alpha。告警要等 6.2.5 发版、alpha 合进
main 之后才会关。这与 #248 的 -P release、#242 的到期闸门是同一类约束。

另：仓库当前还有三条 open 告警（log4j-api、plexus-utils、
commons-lang3），不在本 issue 范围内，未动。
