### PR TITLE
fix(websocket): 给入站消息的 type 提取加守卫并移进 try

### DIFF
--- a/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
@@ -152,11 +152,16 @@ public class PluginInitiationUtils {
         // 而解析其实是成功的：消息被静默丢弃，诊断指向错误的方向，且那里只传了
         // e.getMessage() 没有堆栈。
         //
-        // 守卫形式抄自 MessageHandlerRegistry.dispatch 与
-        // UltiPanelWebSocketClient.onMessage —— 同一份代码库里已有两处正确写法。
+        // 用 isJsonPrimitive 而不是 !isJsonNull：后者只挡 JSON null，挡不住 type 是对象
+        // 或数组——那种情况下 getAsString() 抛 UnsupportedOperationException。非基本类型
+        // 的 type 和缺字段、JSON null、空串属于同一类畸形，应当走同一条 WARNING 分支，
+        // 而不是被当成「处理消息时发生错误」记成 SEVERE。
+        //
+        // MessageHandlerRegistry.dispatch 用的是 !isJsonNull()，那份是死代码（见 #233），
+        // 这里没有照抄它的这一点。
         String type = null;
         try {
-            if (message.has("type") && !message.get("type").isJsonNull()) {
+            if (message.has("type") && message.get("type").isJsonPrimitive()) {
                 type = message.get("type").getAsString();
             }
             if (type == null || type.isEmpty()) {

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
@@ -96,121 +96,7 @@ public class PluginInitiationUtils {
         panelWS = getPanelWebsocketClient();
         
         // 设置消息处理器
-        panelWS.setMessageHandler(message -> {
-            String type = message.get("type").getAsString();
-            JsonObject data = message.has("data") && message.get("data").isJsonObject()
-                ? message.getAsJsonObject("data") : null;
-            
-            // 记录接收到的消息处理日志
-            UltiTools.getInstance().getLogger().log(Level.FINE, 
-                String.format("[WebSocket消息处理] 类型: %s, 开始处理", type));
-            
-            try {
-                switch (type) {
-                    // 系统基础消息
-                    case "ping":
-                        handlePing(message);
-                        break;
-                    case "pong":
-                        handlePong(data);
-                        break;
-                    case "subscribe":
-                        handleSubscribe(data);
-                        break;
-                    case "unsubscribe":
-                        handleUnsubscribe(data);
-                        break;
-                    case "notification":
-                        handleNotification(data);
-                        break;
-                    case "error":
-                        handleError(data);
-                        break;
-                    
-                    // 服务器监控消息
-                    case "server_status":
-                        handleServerStatusRequest(data);
-                        break;
-                    case "plugin_list":
-                        handlePluginListRequest(data);
-                        break;
-                    case "player_event":
-                        handlePlayerEvent(data);
-                        break;
-                    case "metrics_data":
-                        handleMetricsRequest(data);
-                        break;
-                    
-                    // 操作控制消息
-                    case "execute_command":
-                        UltiTools.getInstance().getCommandExecutionManager().executeCommand(data);
-                        break;
-                    case "command_result":
-                        handleCommandResult(data);
-                        break;
-                    case "file_operation":
-                        UltiTools.getInstance().getFileOperationManager().handleFileOperation(data);
-                        break;
-                    case "file_operation_result":
-                        handleFileOperationResult(data);
-                        break;
-                    
-                    // 数据流消息
-                    case "log_stream":
-                    case "log_stream_control":
-                        UltiTools.getInstance().getLogStreamManager().handleLogStreamMessage(data);
-                        break;
-                    case "backup_operation":
-                        handleBackupOperation(data);
-                        break;
-                    case "backup_progress":
-                        handleBackupProgress(data);
-                        break;
-                    
-                    // 配置管理消息
-                    case "upload_config":
-                        handleConfigUpload(data);
-                        break;
-                    case "update_config":
-                        handleConfigUpdate(data);
-                        break;
-                    case "server_properties":
-                        if (UltiTools.getInstance().getServerPropertiesManager() != null) {
-                            UltiTools.getInstance().getServerPropertiesManager().handleServerProperties(data);
-                        }
-                        break;
-                    case "server_properties_result":
-                        // Response from this plugin forwarded back by DO — ignore silently
-                        UltiTools.getInstance().getLogger().log(Level.FINE,
-                            "Received server_properties_result echo — ignoring");
-                        break;
-
-                    // Magic link auth messages (completion handled by HTTP polling in UltiLogin)
-                    case "auth_complete":
-                        UltiTools.getInstance().getLogger().log(Level.FINE,
-                            "Received auth_complete message: " + (data != null ? data.toString() : "null"));
-                        break;
-                    case "magic_link_response":
-                        UltiTools.getInstance().getLogger().log(Level.FINE,
-                            "Received magic_link_response message: " + (data != null ? data.toString() : "null"));
-                        break;
-
-                    default:
-                        UltiTools.getInstance().getLogger().log(Level.WARNING,
-                            String.format("未知的消息类型: %s，消息内容: %s", type, new Gson().toJson(message)));
-                        // Don't send error responses to avoid feedback loops with server
-                        break;
-                }
-            } catch (Exception e) {
-                UltiTools.getInstance().getLogger().log(Level.SEVERE,
-                    String.format("处理消息类型 %s 时发生错误: %s", type, e.getMessage()), e);
-                // Don't send error responses to avoid feedback loops with server
-            }
-            
-            // 记录消息处理完成日志
-            UltiTools.getInstance().getLogger().log(Level.FINE, 
-                String.format("[WebSocket消息处理] 类型: %s, 处理完成", type));
-        });
+        panelWS.setMessageHandler(PluginInitiationUtils::handleInboundMessage);
 
         // 设置连接成功处理器
         panelWS.setOnConnectHandler(() -> {
@@ -239,6 +125,160 @@ public class PluginInitiationUtils {
     /**
      * 初始化所有管理器
      */
+    /**
+     * 处理面板下发的入站 WebSocket 消息。
+     * <p>
+     * 从 {@code initWebsocket()} 的 lambda 中提取出来，唯一目的是让它可以被单元测试直接调用：
+     * 原先它是 {@code setMessageHandler} 的匿名 lambda，要构造它需要真实的鉴权 token 与真实的
+     * WebSocket 客户端，畸形输入这条路径因此完全没有测试覆盖。见 issue #234。
+     * <p>
+     * 包级可见而非 public —— 它不是对外 API，只是为了可测。
+     *
+     * @param message 面板下发的消息，允许为 null
+     */
+    static void handleInboundMessage(JsonObject message) {
+        if (message == null) {
+            UltiTools.getInstance().getLogger().log(Level.WARNING,
+                "[WebSocket消息处理] 收到 null 消息，已忽略");
+            return;
+        }
+
+        // type 与 data 使用同一套守卫。原先这里是 message.get("type").getAsString()：
+        // 缺 type 字段时 get 返回 null，.getAsString() 随即抛 NPE，而它写在 try 之外，
+        // 下面那个 catch 接不住。
+        //
+        // 该 NPE 不会中断接收循环 —— UltiPanelWebSocketClient.onMessage 把
+        // messageHandler.accept 包在自己的 try 里。但它会被记成「WebSocket消息解析失败」，
+        // 而解析其实是成功的：消息被静默丢弃，诊断指向错误的方向，且那里只传了
+        // e.getMessage() 没有堆栈。
+        //
+        // 守卫形式抄自 MessageHandlerRegistry.dispatch 与
+        // UltiPanelWebSocketClient.onMessage —— 同一份代码库里已有两处正确写法。
+        String type = null;
+        try {
+            if (message.has("type") && !message.get("type").isJsonNull()) {
+                type = message.get("type").getAsString();
+            }
+            if (type == null || type.isEmpty()) {
+                UltiTools.getInstance().getLogger().log(Level.WARNING,
+                    String.format("[WebSocket消息处理] 消息缺少有效的 type 字段，已忽略: %s",
+                        new Gson().toJson(message)));
+                return;
+            }
+
+            JsonObject data = message.has("data") && message.get("data").isJsonObject()
+                ? message.getAsJsonObject("data") : null;
+
+            // 记录接收到的消息处理日志
+            UltiTools.getInstance().getLogger().log(Level.FINE,
+                String.format("[WebSocket消息处理] 类型: %s, 开始处理", type));
+
+            switch (type) {
+                // 系统基础消息
+                case "ping":
+                    handlePing(message);
+                    break;
+                case "pong":
+                    handlePong(data);
+                    break;
+                case "subscribe":
+                    handleSubscribe(data);
+                    break;
+                case "unsubscribe":
+                    handleUnsubscribe(data);
+                    break;
+                case "notification":
+                    handleNotification(data);
+                    break;
+                case "error":
+                    handleError(data);
+                    break;
+                
+                // 服务器监控消息
+                case "server_status":
+                    handleServerStatusRequest(data);
+                    break;
+                case "plugin_list":
+                    handlePluginListRequest(data);
+                    break;
+                case "player_event":
+                    handlePlayerEvent(data);
+                    break;
+                case "metrics_data":
+                    handleMetricsRequest(data);
+                    break;
+                
+                // 操作控制消息
+                case "execute_command":
+                    UltiTools.getInstance().getCommandExecutionManager().executeCommand(data);
+                    break;
+                case "command_result":
+                    handleCommandResult(data);
+                    break;
+                case "file_operation":
+                    UltiTools.getInstance().getFileOperationManager().handleFileOperation(data);
+                    break;
+                case "file_operation_result":
+                    handleFileOperationResult(data);
+                    break;
+                
+                // 数据流消息
+                case "log_stream":
+                case "log_stream_control":
+                    UltiTools.getInstance().getLogStreamManager().handleLogStreamMessage(data);
+                    break;
+                case "backup_operation":
+                    handleBackupOperation(data);
+                    break;
+                case "backup_progress":
+                    handleBackupProgress(data);
+                    break;
+                
+                // 配置管理消息
+                case "upload_config":
+                    handleConfigUpload(data);
+                    break;
+                case "update_config":
+                    handleConfigUpdate(data);
+                    break;
+                case "server_properties":
+                    if (UltiTools.getInstance().getServerPropertiesManager() != null) {
+                        UltiTools.getInstance().getServerPropertiesManager().handleServerProperties(data);
+                    }
+                    break;
+                case "server_properties_result":
+                    // Response from this plugin forwarded back by DO — ignore silently
+                    UltiTools.getInstance().getLogger().log(Level.FINE,
+                        "Received server_properties_result echo — ignoring");
+                    break;
+
+                // Magic link auth messages (completion handled by HTTP polling in UltiLogin)
+                case "auth_complete":
+                    UltiTools.getInstance().getLogger().log(Level.FINE,
+                        "Received auth_complete message: " + (data != null ? data.toString() : "null"));
+                    break;
+                case "magic_link_response":
+                    UltiTools.getInstance().getLogger().log(Level.FINE,
+                        "Received magic_link_response message: " + (data != null ? data.toString() : "null"));
+                    break;
+
+                default:
+                    UltiTools.getInstance().getLogger().log(Level.WARNING,
+                        String.format("未知的消息类型: %s，消息内容: %s", type, new Gson().toJson(message)));
+                    // Don't send error responses to avoid feedback loops with server
+                    break;
+            }
+        } catch (Exception e) {
+            UltiTools.getInstance().getLogger().log(Level.SEVERE,
+                String.format("处理消息类型 %s 时发生错误: %s", type, e.getMessage()), e);
+            // Don't send error responses to avoid feedback loops with server
+        }
+        
+        // 记录消息处理完成日志
+        UltiTools.getInstance().getLogger().log(Level.FINE, 
+            String.format("[WebSocket消息处理] 类型: %s, 处理完成", type));
+    }
+
     private static void initializeManagers() {
         try {
             // 初始化服务器监控管理器

--- a/src/main/java/com/ultikits/ultitools/websocket/UltiPanelWebSocketClient.java
+++ b/src/main/java/com/ultikits/ultitools/websocket/UltiPanelWebSocketClient.java
@@ -241,7 +241,12 @@ public class UltiPanelWebSocketClient extends WebSocketClient {
         try {
             JsonObject jsonMessage = JsonParser.parseString(message).getAsJsonObject();
 
-            String messageType = jsonMessage.has("type") && !jsonMessage.get("type").isJsonNull()
+            // isJsonPrimitive 而不是 !isJsonNull：后者挡不住 type 是对象或数组的情况，
+            // 那会让 getAsString() 在这里抛 UnsupportedOperationException——而这一行
+            // 只是为了打一条 FINE 日志，却会因此让消息根本到不了下面的 messageHandler，
+            // 并被记成「消息解析失败」。诊断信息与真实原因不符，且畸形消息在到达真正的
+            // 分发逻辑之前就被吞掉了。见 issue #234。
+            String messageType = jsonMessage.has("type") && jsonMessage.get("type").isJsonPrimitive()
                 ? jsonMessage.get("type").getAsString() : null;
             UltiTools.getInstance().getLogger().log(Level.FINE,
                 String.format("[WebSocket接收] 类型: %s", messageType != null ? messageType : "未知"));

--- a/src/test/java/com/ultikits/ultitools/utils/PluginInitiationUtilsInboundMessageTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/PluginInitiationUtilsInboundMessageTest.java
@@ -1,0 +1,196 @@
+package com.ultikits.ultitools.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.ultikits.ultitools.UltiTools;
+
+/**
+ * {@link PluginInitiationUtils#handleInboundMessage(JsonObject)} 对畸形入站消息的行为。
+ *
+ * <p>这条路径此前没有任何覆盖：处理器原本是 {@code initWebsocket()} 里的匿名 lambda，
+ * 构造它需要真实的鉴权 token 与真实的 WebSocket 客户端。见 issue #234。
+ *
+ * <p>回归的具体形状是 {@code message.get("type").getAsString()} 写在 try 之外：缺 type
+ * 字段时 {@code get} 返回 null，{@code getAsString()} 抛 NPE。该 NPE 不会中断接收循环
+ * （{@code UltiPanelWebSocketClient.onMessage} 有自己的 try），但会被记成
+ * 「WebSocket消息解析失败」——而解析是成功的，于是消息被静默丢弃且诊断指错方向。
+ */
+@DisplayName("PluginInitiationUtils 入站消息守卫")
+class PluginInitiationUtilsInboundMessageTest {
+
+    private Logger mockLogger;
+
+    @BeforeEach
+    void setUp() {
+        mockLogger = mock(Logger.class);
+        // 必须用 Consumer 重载：先打桩、后发布。见 TestHelper 的 javadoc 与 issue #250。
+        TestHelper.mockUltiToolsInstance(ultiTools ->
+                lenient().when(ultiTools.getLogger()).thenReturn(mockLogger));
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        Field instanceField = UltiTools.class.getDeclaredField("ultiTools");
+        instanceField.setAccessible(true);
+        instanceField.set(null, null);
+    }
+
+    /** 取出所有以指定级别记录的日志正文。 */
+    private List<String> loggedAt(Level level) {
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(mockLogger, atLeastOnce()).log(eq(level), captor.capture());
+        return captor.getAllValues();
+    }
+
+    @Nested
+    @DisplayName("畸形 type")
+    class MalformedType {
+
+        @Test
+        @DisplayName("缺少 type 字段时不抛异常，只记一条 WARNING")
+        void missingTypeFieldIsRejectedWithWarning() {
+            JsonObject message = new JsonObject();
+            message.addProperty("data", "irrelevant");
+
+            assertThatCode(() -> PluginInitiationUtils.handleInboundMessage(message))
+                    .doesNotThrowAnyException();
+
+            assertThat(loggedAt(Level.WARNING))
+                    .anySatisfy(line -> assertThat(line).contains("缺少有效的 type 字段"));
+        }
+
+        @Test
+        @DisplayName("type 为 JSON null 时安全返回")
+        void jsonNullTypeIsRejected() {
+            JsonObject message = new JsonObject();
+            message.add("type", JsonNull.INSTANCE);
+
+            assertThatCode(() -> PluginInitiationUtils.handleInboundMessage(message))
+                    .doesNotThrowAnyException();
+
+            assertThat(loggedAt(Level.WARNING))
+                    .anySatisfy(line -> assertThat(line).contains("缺少有效的 type 字段"));
+        }
+
+        @Test
+        @DisplayName("type 为空字符串时安全返回")
+        void emptyStringTypeIsRejected() {
+            JsonObject message = new JsonObject();
+            message.addProperty("type", "");
+
+            assertThatCode(() -> PluginInitiationUtils.handleInboundMessage(message))
+                    .doesNotThrowAnyException();
+
+            assertThat(loggedAt(Level.WARNING))
+                    .anySatisfy(line -> assertThat(line).contains("缺少有效的 type 字段"));
+        }
+
+        @Test
+        @DisplayName("message 本身为 null 时安全返回")
+        void nullMessageIsRejected() {
+            assertThatCode(() -> PluginInitiationUtils.handleInboundMessage(null))
+                    .doesNotThrowAnyException();
+
+            assertThat(loggedAt(Level.WARNING))
+                    .anySatisfy(line -> assertThat(line).contains("null 消息"));
+        }
+
+        @Test
+        @DisplayName("type 不是 JSON 基本类型时被 try 接住，不逃逸")
+        void nonPrimitiveTypeDoesNotEscape() {
+            // getAsString() 对 JsonObject / JsonArray 抛 UnsupportedOperationException。
+            // has() + !isJsonNull() 挡不住这种，所以 type 的提取必须在 try 之内 ——
+            // 这正是把它移进 try（而不只是加守卫）的理由。
+            JsonObject objectType = new JsonObject();
+            objectType.add("type", new JsonObject());
+
+            JsonObject arrayType = new JsonObject();
+            arrayType.add("type", new JsonArray());
+
+            assertThatCode(() -> PluginInitiationUtils.handleInboundMessage(objectType))
+                    .doesNotThrowAnyException();
+            assertThatCode(() -> PluginInitiationUtils.handleInboundMessage(arrayType))
+                    .doesNotThrowAnyException();
+
+            // 落进原有的 catch，带上 throwable（原先那条路径只有 e.getMessage()，没有堆栈）
+            verify(mockLogger, atLeastOnce())
+                    .log(eq(Level.SEVERE), anyString(), any(Throwable.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("正常 type 行为不变")
+    class WellFormedType {
+
+        @ParameterizedTest(name = "{0} 只记日志，不抛异常")
+        @ValueSource(strings = {"server_properties_result", "auth_complete", "magic_link_response"})
+        @DisplayName("仅记录日志的已知类型行为不变")
+        void logOnlyTypesStillHandled(String type) {
+            JsonObject message = new JsonObject();
+            message.addProperty("type", type);
+
+            assertThatCode(() -> PluginInitiationUtils.handleInboundMessage(message))
+                    .doesNotThrowAnyException();
+
+            // 不能被守卫误伤：这些是合法 type，不该走「缺少有效的 type 字段」那条分支
+            verify(mockLogger, never()).log(eq(Level.WARNING),
+                    org.mockito.ArgumentMatchers.contains("缺少有效的 type 字段"));
+        }
+
+        @Test
+        @DisplayName("未知但合法的 type 仍然走 default 分支")
+        void unknownTypeStillReachesDefaultBranch() {
+            JsonObject message = new JsonObject();
+            message.addProperty("type", "definitely_not_a_real_type");
+
+            assertThatCode(() -> PluginInitiationUtils.handleInboundMessage(message))
+                    .doesNotThrowAnyException();
+
+            assertThat(loggedAt(Level.WARNING))
+                    .anySatisfy(line -> assertThat(line).contains("未知的消息类型"))
+                    .noneSatisfy(line -> assertThat(line).contains("缺少有效的 type 字段"));
+        }
+
+        @Test
+        @DisplayName("data 字段缺失或非对象时不影响 type 分发")
+        void missingOrNonObjectDataDoesNotBreakDispatch() {
+            JsonObject noData = new JsonObject();
+            noData.addProperty("type", "auth_complete");
+
+            JsonObject scalarData = new JsonObject();
+            scalarData.addProperty("type", "auth_complete");
+            scalarData.addProperty("data", 42);
+
+            assertThatCode(() -> PluginInitiationUtils.handleInboundMessage(noData))
+                    .doesNotThrowAnyException();
+            assertThatCode(() -> PluginInitiationUtils.handleInboundMessage(scalarData))
+                    .doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/utils/PluginInitiationUtilsInboundMessageTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/PluginInitiationUtilsInboundMessageTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -29,6 +30,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.ultikits.ultitools.UltiTools;
+import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
 
 /**
  * {@link PluginInitiationUtils#handleInboundMessage(JsonObject)} 对畸形入站消息的行为。
@@ -122,11 +124,11 @@ class PluginInitiationUtilsInboundMessageTest {
         }
 
         @Test
-        @DisplayName("type 不是 JSON 基本类型时被 try 接住，不逃逸")
-        void nonPrimitiveTypeDoesNotEscape() {
-            // getAsString() 对 JsonObject / JsonArray 抛 UnsupportedOperationException。
-            // has() + !isJsonNull() 挡不住这种，所以 type 的提取必须在 try 之内 ——
-            // 这正是把它移进 try（而不只是加守卫）的理由。
+        @DisplayName("type 为 JSON 对象或数组时按畸形处理，走同一条 WARNING 分支")
+        void nonPrimitiveTypeIsRejected() {
+            // getAsString() 对 JsonObject / JsonArray 抛 UnsupportedOperationException，
+            // has() + !isJsonNull() 挡不住这种，所以守卫用的是 isJsonPrimitive()。
+            // 这类和缺字段、JSON null、空串属于同一类畸形，不该被记成 SEVERE「处理时发生错误」。
             JsonObject objectType = new JsonObject();
             objectType.add("type", new JsonObject());
 
@@ -138,9 +140,42 @@ class PluginInitiationUtilsInboundMessageTest {
             assertThatCode(() -> PluginInitiationUtils.handleInboundMessage(arrayType))
                     .doesNotThrowAnyException();
 
-            // 落进原有的 catch，带上 throwable（原先那条路径只有 e.getMessage()，没有堆栈）
-            verify(mockLogger, atLeastOnce())
-                    .log(eq(Level.SEVERE), anyString(), any(Throwable.class));
+            assertThat(loggedAt(Level.WARNING))
+                    .anySatisfy(line -> assertThat(line).contains("缺少有效的 type 字段"));
+            verify(mockLogger, never()).log(eq(Level.SEVERE), anyString(), any(Throwable.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("客户端不提前吞掉畸形消息")
+    class ClientForwarding {
+
+        /**
+         * {@code UltiPanelWebSocketClient.onMessage} 在调用 messageHandler 之前，会自己取一次
+         * type 只为打一条 FINE 日志。那一行原本写的是 {@code !isJsonNull()}，于是 type 为对象或
+         * 数组时 {@code getAsString()} 在那里就抛了，消息根本到不了处理器——处理器侧的守卫写得
+         * 再对也没用，这条路径在生产上不可达。
+         *
+         * <p>本用例走真实的 {@code onMessage(String)} 入口，确认消息现在能到达处理器。
+         */
+        @Test
+        @DisplayName("type 为对象的消息仍能到达 messageHandler")
+        void nonPrimitiveTypeStillReachesHandler() throws Exception {
+            UltiPanelWebSocketClient client =
+                    new UltiPanelWebSocketClient("ws://localhost:1", "test-server", "test-token");
+            try {
+                List<JsonObject> received = new ArrayList<>();
+                client.setMessageHandler(received::add);
+
+                client.onMessage("{\"type\":{},\"data\":{}}");
+
+                assertThat(received)
+                        .as("type 为对象时消息也应到达 handler，而不是在客户端打日志那一行就抛掉")
+                        .hasSize(1);
+            } finally {
+                // 构造函数里起了 heartbeatExecutor，不关就是一条泄漏线程。见 issue #250。
+                client.disconnect();
+            }
         }
     }
 


### PR DESCRIPTION
PluginInitiationUtils 的入站处理器里，type 的提取是裸的
message.get("type").getAsString()，且写在 try 之外。缺 type 字段时 get
返回 null，getAsString() 抛 NPE，下面那个 catch 接不住。紧邻的下一行处理
data 时反而做了完整的 has() + isJsonObject() 守卫，同一个方法里两种标准。

先更正 issue 对影响的描述：那个 NPE 不会打断接收循环。
UltiPanelWebSocketClient.onMessage 把 messageHandler.accept 包在自己的
try 里（:241-254）。但后果仍然是实打实的，只是形态不同——它会被记成
「WebSocket消息解析失败: ...」，而解析在上一行就已经成功了。于是一条畸形
消息被静默丢弃，日志把人指向 JSON 解析，而且那里只传了 e.getMessage()
没有传 throwable，连堆栈都没有。

改动三件事：

一、加守卫，形式抄自 MessageHandlerRegistry.dispatch 与
UltiPanelWebSocketClient.onMessage:244。这两处是同一份代码库里已有的
正确写法——后者尤其值得一提，它在调用 messageHandler.accept 的前五行就
写了正确的 has() && !isJsonNull()，只为打一条 FINE 日志，然后把消息交给
一个用裸 get().getAsString() 的处理器。不是没人知道怎么写，是同一条数据
在相邻两帧里用了两套标准。

二、把提取移进 try，不只是加守卫。has() + !isJsonNull() 挡不住 type 是
JsonObject 或 JsonArray 的情况——那会让 getAsString() 抛
UnsupportedOperationException。移进 try 之后这类也落进原有的 catch，
而那个 catch 是带 throwable 的，有堆栈。

三、把 lambda 体提取为包级静态方法 handleInboundMessage(JsonObject)。
这是为了可测：原先它是 setMessageHandler 的匿名 lambda，要构造它需要真实
的鉴权 token 与真实的 WebSocket 客户端，所以验收要求的「三种畸形输入」
根本没法写。测试类同包，包级可见即可，没有提成 public。

switch 的 24 个分支一行未动。

测试：新增 PluginInitiationUtilsInboundMessageTest，10 个用例。畸形侧
覆盖缺字段、JSON null、空字符串、message 本身为 null、以及 type 为
JsonObject/JsonArray；正常侧覆盖三个只记日志的已知类型、未知但合法的
type 仍走 default 分支、data 缺失或非对象不影响分发。

做了负向对照：保留提取、只把守卫退回原样之后，畸形侧 5 条全红，报的正是
issue 描述的那个 NPE（Cannot invoke JsonElement.getAsString() because
the return value of JsonObject.get(String) is null），而正常侧 5 条仍然
绿——说明守卫确实是在起作用的那一半，且没有改变正常 type 的行为。

顺带说明：仓库里原有的 PluginInitiationUtilsWebSocketTest 全部是反射签名
检查（断言方法存在、修饰符正确），不测任何行为。本次没有动它。
