### PR TITLE
fix(websocket): 给重连状态机一个所有者，并让 logout 真的关得掉（#181 + #223）

### DIFF
--- a/src/main/java/com/ultikits/ultitools/UltiTools.java
+++ b/src/main/java/com/ultikits/ultitools/UltiTools.java
@@ -235,6 +235,9 @@ public final class UltiTools extends JavaPlugin implements Localized {
 
         boolean loginSuccess = attemptCloudLogin();
         if (loginSuccess) {
+            // 显式开启云连接状态机。initWebsocket() 自己不再置位 —— 它被 reinitWebSocket
+            // 复用，在那里置位会让一个正在途中的重连把 logout 关掉的状态机重新拉起来。
+            PluginInitiationUtils.enableCloud();
             initWebSocket();
             CloudAuthManager.startTokenRefreshScheduler();
         }

--- a/src/main/java/com/ultikits/ultitools/commands/CloudLoginCommand.java
+++ b/src/main/java/com/ultikits/ultitools/commands/CloudLoginCommand.java
@@ -12,6 +12,7 @@ import com.ultikits.ultitools.annotations.command.RunAsync;
 import com.ultikits.ultitools.entities.TokenEntity;
 import com.ultikits.ultitools.utils.ApiRateLimiter;
 import com.ultikits.ultitools.utils.CloudAuthManager;
+import com.ultikits.ultitools.utils.PluginInitiationUtils;
 
 /**
  * Commands for UltiCloud authentication via magic link.
@@ -65,6 +66,12 @@ public class CloudLoginCommand extends AbstractCommandExecutor {
         }
 
         try {
+            // 先拆状态机，再清凭证。
+            //
+            // 顺序有讲究：清凭证只是让重连拿不到有效 token，并不会让它停下来——重连链会继续
+            // 用已作废的凭证敲面板，401 循环照跑，实测只有重新 login 或重启服务器才停得下来。
+            // 「Cloud features are now disabled」这句话此前是不成立的。见 issue #223。
+            PluginInitiationUtils.disableCloud();
             CloudAuthManager.clearToken();
             sender.sendMessage(ChatColor.GREEN + "Successfully logged out of UltiCloud. Cloud features are now disabled.");
             sender.sendMessage(ChatColor.GRAY + "Use /ulticloud login to re-authenticate.");

--- a/src/main/java/com/ultikits/ultitools/manager/LogStreamManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/LogStreamManager.java
@@ -59,23 +59,41 @@ public class LogStreamManager implements Listener {
      * 初始化日志流管理器
      */
     public void initialize(UltiPanelWebSocketClient client) {
+        // 幂等：重复调用必须先拆掉上一轮留下的东西。
+        //
+        // 这个方法由 onConnectHandler 调用，而 onConnectHandler 在**每一次** onOpen 都会跑
+        // ——包括重连窗口内的 reconnect()，以及 reinitWebSocket 造出新客户端之后的那次。
+        // 原先它无条件 new 一个 UltiPanelLogTransmitter（起一条传输线程）并往 JVM root logger
+        // 挂一个新的 SystemLogHandler，而 removeHandler 只写在 shutdown() 里，shutdown() 的
+        // 唯一调用者是 onDisable。于是连接每抖动一次就泄漏一个 handler 加一条线程，
+        // 每行日志被重复发送 N 次。见 issue #181。
+        detachAllSystemLogHandlers();
+        if (logTransmitter != null) {
+            try {
+                logTransmitter.shutdown();
+            } catch (Exception e) {
+                UltiTools.getInstance().getLogger().warning(
+                    "[UltiPanel] Error shutting down previous log transmitter: " + e.getMessage());
+            }
+        }
+
         this.webSocketClient = client;
-        
+
         // 初始化日志传输器
         String serverId = getServerId();
         this.logTransmitter = new UltiPanelLogTransmitter(client, serverId);
-        
+
         // 从配置文件加载批量发送设置
         loadBatchConfiguration();
-        
+
         // 创建并配置系统日志处理器
         this.systemLogHandler = new SystemLogHandler(logTransmitter);
         this.systemLogHandler.loadConfiguration();
-        
+
         // 添加系统日志处理器到根Logger
         Logger rootLogger = Logger.getLogger("");
         rootLogger.addHandler(systemLogHandler);
-        
+
         // 自动启动日志流（立即开始监控和发送日志）
         startLogStream("auto", "info");
         
@@ -450,15 +468,30 @@ public class LogStreamManager implements Listener {
         }
         
         // 从Bukkit的Logger中移除处理器
+        detachAllSystemLogHandlers();
+        
+        UltiTools.getInstance().getLogger().info("[UltiPanel] LogStreamManager shutdown");
+    }
+
+    /**
+     * 摘掉 JVM root logger 上所有本框架的 {@link SystemLogHandler}。
+     * <p>
+     * 刻意按类型扫描并全部移除，而不是只移除 {@code this.systemLogHandler}：在本方法存在之前，
+     * 每次重连成功都会往 root logger 上多挂一个，字段里只留得住最后那一个，先前泄漏的那些
+     * 没有任何引用能指到、也就永远摘不掉。按类型扫一遍才能把历史欠账一并清干净，这也是
+     * 「handler 数量恒为 1」这条验收唯一能成立的写法。见 issue #181。
+     */
+    private void detachAllSystemLogHandlers() {
         try {
             Logger rootLogger = Logger.getLogger("");
-            if (systemLogHandler != null) {
-                rootLogger.removeHandler(systemLogHandler);
+            for (java.util.logging.Handler handler : rootLogger.getHandlers()) {
+                if (handler instanceof SystemLogHandler) {
+                    rootLogger.removeHandler(handler);
+                }
             }
         } catch (Exception e) {
             UltiTools.getInstance().getLogger().warning("Error removing log handler: " + e.getMessage());
         }
-        
-        UltiTools.getInstance().getLogger().info("[UltiPanel] LogStreamManager shutdown");
+        this.systemLogHandler = null;
     }
 }

--- a/src/main/java/com/ultikits/ultitools/manager/UltiPanelLogTransmitter.java
+++ b/src/main/java/com/ultikits/ultitools/manager/UltiPanelLogTransmitter.java
@@ -345,7 +345,24 @@ public class UltiPanelLogTransmitter {
     public void flushLogs() {
         boolean wasExternalDrain = externalDrainMode.getAndSet(false);
         try {
+            // 必须以「队列真的变短了」作为继续的条件，不能只看队列非空。
+            //
+            // sendBatch() 在 WebSocket 未连接时会直接 return 且**不消费任何队列元素**
+            // （见 sendBatch 里的 isConnected 判断）。原先写成 while (!logQueue.isEmpty())
+            // 就是死循环——而「面板连不上、队列积压、socket 已断」恰恰是最容易命中的场景：
+            // 管理员之所以要 logout 或关服，通常正是因为面板连不上。
+            //
+            // 这个死循环在 disableCloud() 出现之前就存在（onDisable 也会走到这条路径），
+            // 但那时只在关服时触发；现在 logout 在命令线程上也会走到，会直接卡住服务器。
+            // 见 issue #181 / #223 的 PR 评审。
+            int previousSize = -1;
             while (!logQueue.isEmpty()) {
+                int currentSize = logQueue.size();
+                if (currentSize == previousSize) {
+                    // 上一轮一个都没送出去，再转多少次也不会有进展
+                    break;
+                }
+                previousSize = currentSize;
                 sendBatch();
             }
         } finally {

--- a/src/main/java/com/ultikits/ultitools/utils/CloudAuthManager.java
+++ b/src/main/java/com/ultikits/ultitools/utils/CloudAuthManager.java
@@ -310,6 +310,8 @@ public class CloudAuthManager {
                                 // Try to initialize cloud features
                                 try {
                                     PluginInitiationUtils.loginWithToken(token);
+                                    // 显式开启：logout 之后重新 login 必须能把状态机拉回来。
+                                    PluginInitiationUtils.enableCloud();
                                     PluginInitiationUtils.initWebsocket();
                                     startTokenRefreshScheduler();
                                 } catch (Exception e) {

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
@@ -123,9 +123,14 @@ public class PluginInitiationUtils {
             throw new IOException("Cannot initialize WebSocket: auth token has expired");
         }
 
-        // 走到这里说明这是一次有意的「开启云连接」动作（首次启动或 reinit），
-        // 因此把状态机置为启用态。logout 会把它置否，reinitWebSocket 便不再复活连接。
-        cloudEnabled.set(true);
+        // 这里刻意**不**置位 cloudEnabled。
+        //
+        // 曾经写成在这里 set(true)，那是错的：reinitWebSocket 也会走到这里，于是一个
+        // 正在途中的重连能把刚被 logout 关掉的状态机重新拉起来——两者跑在不同线程上，
+        // 中间还隔着一次 token 刷新的网络调用，窗口可能有数秒。
+        //
+        // 现在只有显式动作才开启：启动时的 UltiTools.onEnable、以及 magic-link 登录成功后
+        // 的 CloudAuthManager，两处都调 enableCloud()。见 issue #223 的 PR 评审。
 
         panelWS = getPanelWebsocketClient();
 
@@ -910,6 +915,15 @@ public class PluginInitiationUtils {
             }
         }
 
+        // 二次确认。从方法开头那次 cloudEnabled 检查到这里，中间隔了一次 token 刷新
+        // ——那是网络调用，窗口可能有数秒。logout 若发生在这个窗口内，必须在这里被看见，
+        // 否则我们会造出一个新的已认证客户端，把刚关掉的状态机重新拉起来。
+        if (!cloudEnabled.get()) {
+            UltiTools.getInstance().getLogger().log(Level.INFO,
+                "Cloud features were disabled during re-initialization — aborting");
+            return;
+        }
+
         // Create new WebSocket connection
         try {
             initWebsocket();
@@ -940,15 +954,23 @@ public class PluginInitiationUtils {
         cloudEnabled.set(false);
         reinitBackoff.reset();
 
-        stopWebsocket();
-        panelWS = null;
-
+        // 顺序有讲究：先关日志传输器，再断开 socket。
+        // 反过来的话，传输器 flush 时 socket 已经断了，sendBatch() 会一条都发不出去。
+        // （flushLogs 本身也已改成有界，两层都要有——顺序对了是让排队的日志还有机会送出去，
+        //  有界是为了 socket 本来就断着的情况。）
         try {
             UltiTools.getInstance().getLogStreamManager().shutdown();
         } catch (Exception e) {
             UltiTools.getInstance().getLogger().log(Level.FINE,
                 "Error shutting down log stream manager: " + e.getMessage());
         }
+
+        stopWebsocket();
+        panelWS = null;
+
+        // 清掉本类持有的 token。它与 CloudAuthManager 清掉的凭证是**两份**，
+        // 不清的话，一个正在途中的 reinit 仍然握着可用的 refresh token。
+        token = null;
 
         try {
             CloudAuthManager.stopTokenRefreshScheduler();
@@ -968,8 +990,14 @@ public class PluginInitiationUtils {
         reinitBackoff.reset();
     }
 
-    /** 供测试与 {@code login} 使用：把状态机重新置为「应当保持连接」。 */
-    static void enableCloud() {
+    /**
+     * 把状态机置为「应当保持连接」，并清零外层重连预算。
+     * <p>
+     * <b>只有显式动作才应当调用它</b>：服务器启动时的云登录，以及 {@code /ulticloud login}
+     * 成功之后。{@link #initWebsocket()} 刻意不调——它同时被 {@link #reinitWebSocket()} 复用，
+     * 在那里置位会让一个正在途中的重连把刚被 logout 关掉的状态机重新拉起来。
+     */
+    public static void enableCloud() {
         cloudEnabled.set(true);
         reinitBackoff.reset();
     }

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
@@ -11,6 +11,7 @@ import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.entities.TokenEntity;
 import com.ultikits.ultitools.manager.ServerPropertiesManager;
 import com.ultikits.ultitools.utils.SimpleHttpClient.Response;
+import com.ultikits.ultitools.websocket.ExponentialBackoffStrategy;
 import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
 
 /**
@@ -29,6 +30,35 @@ public class PluginInitiationUtils {
     private static UltiPanelWebSocketClient panelWS;
     /** Authentication token for API requests */
     private static TokenEntity token;
+
+    /**
+     * 云连接是否处于「应当保持连接」的状态。
+     * <p>
+     * 这是整条重连链的<b>唯一开关</b>。在它存在之前，有四个地方各自独立地决定「要不要继续
+     * 重连」，而谁都不是所有者：{@code UltiPanelWebSocketClient.onClose} 按每实例 5 次算、
+     * {@code reinitWebSocket} 造新实例把计数清零、{@code ulticloud logout} 只清凭证根本不碰
+     * 状态机、只有 {@code onDisable} 真正拆得干净。结果是 logout 之后插件仍在拿已作废的凭证
+     * 持续敲面板。见 issue #181 与 #223。
+     * <p>
+     * 现在的规则只有一条：<b>{@code reinitWebSocket} 只在本标志为 true 时才会重建连接。</b>
+     */
+    private static final java.util.concurrent.atomic.AtomicBoolean cloudEnabled =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
+
+    /** 外层 reinit 的全局上限。超过之后进入终态，需要 {@code /ulticloud login} 或重启才恢复。 */
+    private static final int MAX_REINIT_ATTEMPTS = 10;
+
+    /**
+     * 外层重连（reinit 循环）的全局预算与退避。
+     * <p>
+     * 客户端自身那 5 次是<b>每实例</b>的上限，而 {@code reinitWebSocket} 每次都造一个新实例，
+     * 于是每实例上限对整体毫无约束——这正是无界循环的成因。本策略是跨实例的，
+     * 只有一次成功的 {@code onOpen} 能把它重置。
+     * <p>
+     * 顺带启用了 {@link ExponentialBackoffStrategy}——它此前是同包内零引用的死代码。
+     */
+    private static final ExponentialBackoffStrategy reinitBackoff =
+            ExponentialBackoffStrategy.withMaxAttempts(MAX_REINIT_ATTEMPTS);
 
     /**
      * Login to UltiPanel using an existing token (from magic-link or saved token).
@@ -93,15 +123,26 @@ public class PluginInitiationUtils {
             throw new IOException("Cannot initialize WebSocket: auth token has expired");
         }
 
+        // 走到这里说明这是一次有意的「开启云连接」动作（首次启动或 reinit），
+        // 因此把状态机置为启用态。logout 会把它置否，reinitWebSocket 便不再复活连接。
+        cloudEnabled.set(true);
+
         panelWS = getPanelWebsocketClient();
-        
+
         // 设置消息处理器
         panelWS.setMessageHandler(PluginInitiationUtils::handleInboundMessage);
 
         // 设置连接成功处理器
         panelWS.setOnConnectHandler(() -> {
             UltiTools.getInstance().getLogger().log(Level.FINE, UltiTools.getInstance().i18n("Websocket已连接!"));
-            
+
+            // 握手真正成功了，这里才是「重连成功」这句话唯一站得住的位置。
+            // 外层预算也只在这里清零——若在 reinitWebSocket 里清，「造出了一个客户端」
+            // 就会被当成成功，预算永远用不完。见 issue #181 / #223。
+            onWebSocketConnected();
+            UltiTools.getInstance().getLogger().log(Level.INFO,
+                "WebSocket connected to UltiPanel");
+
             // 订阅当前服务器
             panelWS.subscribeToServer(panelWS.getServerId());
             
@@ -812,7 +853,31 @@ public class PluginInitiationUtils {
      * 使用新令牌重新初始化WebSocket连接。
      */
     public static void reinitWebSocket() {
-        UltiTools.getInstance().getLogger().log(Level.INFO, "Re-initializing WebSocket connection...");
+        // 闸门一：logout 之后不再重连。
+        // 这是让 `/ulticloud logout` 真正生效的那一行——在它存在之前，logout 只清凭证，
+        // 这条链会继续拿着已作废的 token 重连，401 循环照跑，实测只有重新 login 或重启
+        // 服务器才停得下来。见 issue #223。
+        if (!cloudEnabled.get()) {
+            UltiTools.getInstance().getLogger().log(Level.FINE,
+                "Cloud features are disabled — skipping WebSocket re-initialization");
+            return;
+        }
+
+        // 闸门二：全局预算。客户端自身的 5 次上限是每实例的，而这里每次都造新实例，
+        // 所以那个上限对整体等于不存在。见 issue #181。
+        if (!reinitBackoff.shouldContinue()) {
+            cloudEnabled.set(false);
+            UltiTools.getInstance().getLogger().log(Level.WARNING, String.format(
+                "WebSocket re-initialization gave up after %d attempts. Cloud features are now idle. "
+                    + "Run /ulticloud login to retry, or restart the server.",
+                MAX_REINIT_ATTEMPTS));
+            return;
+        }
+
+        UltiTools.getInstance().getLogger().log(Level.INFO, String.format(
+            "Re-initializing WebSocket connection (attempt %d/%d)...",
+            reinitBackoff.getAttemptCount() + 1, MAX_REINIT_ATTEMPTS));
+        reinitBackoff.getNextDelay();   // 记一次尝试；实际的等待由客户端侧的调度承担
 
         // Disconnect old client
         if (panelWS != null) {
@@ -848,12 +913,70 @@ public class PluginInitiationUtils {
         // Create new WebSocket connection
         try {
             initWebsocket();
-            UltiTools.getInstance().getLogger().log(Level.INFO,
-                "WebSocket re-initialized successfully");
+            // 这里刻意不打「re-initialized successfully」。
+            // initWebsocket() 返回只说明客户端被造出来、connect() 被发起了——connect() 是异步的，
+            // 握手与认证都还没发生。实测这句之后紧跟着的就是一条 401。成功的那句现在由
+            // onOpen 打（见 initWebsocket 里的 onConnectHandler），那才是真的连上了。
+            // 见 issue #223。
+            UltiTools.getInstance().getLogger().log(Level.FINE,
+                "WebSocket re-initialization dispatched — awaiting handshake");
         } catch (IOException e) {
             UltiTools.getInstance().getLogger().log(Level.WARNING,
                 "WebSocket re-initialization failed: " + e.getMessage());
         }
+    }
+
+    /**
+     * 关闭云连接并让重连状态机进入明确的 disabled 态。
+     * <p>
+     * 供 {@code /ulticloud logout} 调用。与 {@link #stopWebsocket()} 的区别是：后者只断开当前
+     * 客户端，而重连链会把它重新拉起来；本方法先把 {@link #cloudEnabled} 置否，因此
+     * {@link #reinitWebSocket()} 之后会直接返回，状态机不会自我复活。
+     * <p>
+     * 顺带摘掉 root logger 上的日志 handler 与传输线程，并停掉 token 刷新调度——
+     * 都是「云功能已关闭」这句话应当为真的组成部分。
+     */
+    public static void disableCloud() {
+        cloudEnabled.set(false);
+        reinitBackoff.reset();
+
+        stopWebsocket();
+        panelWS = null;
+
+        try {
+            UltiTools.getInstance().getLogStreamManager().shutdown();
+        } catch (Exception e) {
+            UltiTools.getInstance().getLogger().log(Level.FINE,
+                "Error shutting down log stream manager: " + e.getMessage());
+        }
+
+        try {
+            CloudAuthManager.stopTokenRefreshScheduler();
+        } catch (Exception e) {
+            UltiTools.getInstance().getLogger().log(Level.FINE,
+                "Error stopping token refresh scheduler: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 重连成功时调用：把外层预算清零。
+     * <p>
+     * 只有<b>真正握手成功</b>才配重置预算。若在 {@code reinitWebSocket} 里重置，
+     * 那么「造出了一个客户端」就会被当成成功，预算永远用不完，闸门等于没加。
+     */
+    static void onWebSocketConnected() {
+        reinitBackoff.reset();
+    }
+
+    /** 供测试与 {@code login} 使用：把状态机重新置为「应当保持连接」。 */
+    static void enableCloud() {
+        cloudEnabled.set(true);
+        reinitBackoff.reset();
+    }
+
+    /** 供测试断言状态机是否处于启用态。 */
+    static boolean isCloudEnabled() {
+        return cloudEnabled.get();
     }
 
     public static void stopWebsocket() {

--- a/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
@@ -1,0 +1,215 @@
+package com.ultikits.ultitools.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Field;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import com.ultikits.ultitools.UltiTools;
+import com.ultikits.ultitools.handler.SystemLogHandler;
+import com.ultikits.ultitools.manager.LogStreamManager;
+
+/**
+ * 云连接重连状态机的行为：全局预算、logout 的终止语义、以及成功日志的位置。
+ *
+ * <p>在 issue #181 / #223 之前，有四个地方各自独立决定「要不要继续重连」而谁都不是所有者：
+ * 客户端 {@code onClose} 按每实例 5 次算、{@code reinitWebSocket} 造新实例把计数清零、
+ * {@code ulticloud logout} 只清凭证根本不碰状态机、只有 {@code onDisable} 拆得干净。
+ * 于是 logout 之后插件仍在拿已作废的凭证持续敲面板。
+ */
+@DisplayName("云连接重连状态机")
+class CloudReconnectStateMachineTest {
+
+    private Logger mockLogger;
+
+    @BeforeEach
+    void setUp() {
+        mockLogger = mock(Logger.class);
+        // Consumer 重载：先打桩、后发布。见 TestHelper javadoc 与 issue #250。
+        TestHelper.mockUltiToolsInstance(ultiTools -> {
+            lenient().when(ultiTools.getLogger()).thenReturn(mockLogger);
+            // 必须是惰性 answer，不能 thenReturn(LogStreamManager.getInstance())：
+            // 这个回调跑在 mock 被发布**之前**（见 TestHelper javadoc），而
+            // LogStreamManager 的构造函数会调 UltiTools.getInstance().getLogger()，
+            // 此时静态字段还是 null。改成 answer 之后求值推迟到真正被调用时，那时已经发布完毕。
+            lenient().when(ultiTools.getLogStreamManager())
+                    .thenAnswer(invocation -> LogStreamManager.getInstance());
+        });
+        PluginInitiationUtils.enableCloud();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        // 把状态机复位，避免污染同 JVM 里的其它测试类（surefire 未配 forkCount，全部跑在一个
+        // JVM 里，见 issue #250）。
+        PluginInitiationUtils.enableCloud();
+        removeLeakedSystemLogHandlers();
+
+        Field instanceField = UltiTools.class.getDeclaredField("ultiTools");
+        instanceField.setAccessible(true);
+        instanceField.set(null, null);
+    }
+
+    private static void removeLeakedSystemLogHandlers() {
+        Logger rootLogger = Logger.getLogger("");
+        for (Handler handler : rootLogger.getHandlers()) {
+            if (handler instanceof SystemLogHandler) {
+                rootLogger.removeHandler(handler);
+            }
+        }
+    }
+
+    /** 取出以指定级别记录的全部日志正文。 */
+    private java.util.List<String> loggedAt(Level level) {
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(mockLogger, Mockito.atLeast(0)).log(Mockito.eq(level), captor.capture());
+        return captor.getAllValues();
+    }
+
+    @Nested
+    @DisplayName("全局重连预算（#181）")
+    class ReconnectBudget {
+
+        @Test
+        @DisplayName("外层 reinit 有上限，耗尽后进入 disabled 终态而不是无限循环")
+        void reinitLoopIsBounded() {
+            // 客户端自身那 5 次是每实例的上限，而 reinitWebSocket 每次都造新实例，
+            // 所以在加预算之前，这个循环没有任何东西能让它停下来。
+            for (int i = 0; i < 40; i++) {
+                assertThatCode(PluginInitiationUtils::reinitWebSocket).doesNotThrowAnyException();
+            }
+
+            assertThat(PluginInitiationUtils.isCloudEnabled())
+                    .as("预算耗尽之后状态机必须停下来，而不是继续造新客户端")
+                    .isFalse();
+
+            assertThat(loggedAt(Level.WARNING))
+                    .anySatisfy(line -> assertThat(line).contains("gave up after"));
+        }
+
+        @Test
+        @DisplayName("握手成功会把预算清零，使长期运行的服务器不会耗尽额度")
+        void successfulHandshakeResetsBudget() {
+            for (int i = 0; i < 5; i++) {
+                PluginInitiationUtils.reinitWebSocket();
+            }
+            assertThat(PluginInitiationUtils.isCloudEnabled()).isTrue();
+
+            // 一次真正的 onOpen
+            PluginInitiationUtils.onWebSocketConnected();
+
+            // 预算被清零，因此还能再撑满一整轮
+            for (int i = 0; i < 9; i++) {
+                PluginInitiationUtils.reinitWebSocket();
+            }
+            assertThat(PluginInitiationUtils.isCloudEnabled())
+                    .as("清零之后应当还有额度，不该因为之前用掉的 5 次就提前进入终态")
+                    .isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("logout 终止状态机（#223）")
+    class LogoutTearsDown {
+
+        @Test
+        @DisplayName("disableCloud 之后 reinitWebSocket 不再重建连接")
+        void reinitIsNoOpAfterDisable() {
+            PluginInitiationUtils.disableCloud();
+            assertThat(PluginInitiationUtils.isCloudEnabled()).isFalse();
+
+            // 这一步在加闸门之前会去刷新 token 并重建客户端——也就是 401 循环的来源
+            assertThatCode(PluginInitiationUtils::reinitWebSocket).doesNotThrowAnyException();
+
+            assertThat(PluginInitiationUtils.isCloudEnabled())
+                    .as("logout 之后不得自我复活")
+                    .isFalse();
+
+            assertThat(loggedAt(Level.INFO))
+                    .as("不应再打印任何重初始化的进行时日志")
+                    .noneSatisfy(line -> assertThat(line).contains("Re-initializing"));
+        }
+
+        @Test
+        @DisplayName("disableCloud 会摘掉 root logger 上的日志 handler")
+        void disableCloudDetachesLogHandler() {
+            PluginInitiationUtils.disableCloud();
+
+            assertThat(countFrameworkHandlersOnRootLogger())
+                    .as("「云功能已关闭」应当包含不再劫持 root logger")
+                    .isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("不再打印虚假成功日志（#223）")
+    class NoFalseSuccessLog {
+
+        @Test
+        @DisplayName("reinitWebSocket 自身不打印 re-initialized successfully")
+        void reinitDoesNotClaimSuccess() {
+            // initWebsocket() 返回只说明 connect() 被发起了，而 connect() 是异步的：
+            // 握手与认证都还没发生。实测这句之后紧跟着的就是一条 401。
+            for (int i = 0; i < 3; i++) {
+                PluginInitiationUtils.reinitWebSocket();
+            }
+
+            assertThat(loggedAt(Level.INFO))
+                    .noneSatisfy(line -> assertThat(line).contains("re-initialized successfully"));
+            assertThat(loggedAt(Level.WARNING))
+                    .noneSatisfy(line -> assertThat(line).contains("re-initialized successfully"));
+        }
+    }
+
+    @Nested
+    @DisplayName("LogStreamManager 幂等（#181）")
+    class IdempotentLogStream {
+
+        @Test
+        @DisplayName("重复 initialize 之后 root logger 上的框架 handler 恒为 1")
+        void repeatedInitializeKeepsExactlyOneHandler() {
+            LogStreamManager manager = LogStreamManager.getInstance();
+
+            // 模拟 10 轮重连：每轮 onOpen 都会走一次 onConnectHandler → initialize
+            for (int round = 0; round < 10; round++) {
+                try {
+                    manager.initialize(null);
+                } catch (Exception ignored) {
+                    // 传 null 客户端时下游可能抛，但 handler 的挂载/摘除必须已经发生
+                }
+                assertThat(countFrameworkHandlersOnRootLogger())
+                        .as("第 %d 轮之后 root logger 上的框架 handler 数量", round + 1)
+                        .isLessThanOrEqualTo(1);
+            }
+
+            manager.shutdown();
+            assertThat(countFrameworkHandlersOnRootLogger())
+                    .as("shutdown 之后应当一个不剩")
+                    .isZero();
+        }
+    }
+
+    /** 数一数 JVM root logger 上挂了几个本框架的 handler。 */
+    private static int countFrameworkHandlersOnRootLogger() {
+        int count = 0;
+        for (Handler handler : Logger.getLogger("").getHandlers()) {
+            if (handler instanceof SystemLogHandler) {
+                count++;
+            }
+        }
+        return count;
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
@@ -152,6 +152,61 @@ class CloudReconnectStateMachineTest {
                     .as("「云功能已关闭」应当包含不再劫持 root logger")
                     .isZero();
         }
+
+        @Test
+        @DisplayName("initWebsocket 自身不得把状态机置回启用态")
+        void initWebsocketDoesNotResurrectDisabledState() throws Exception {
+            // 回归测试，对应 PR 评审里的 P1：initWebsocket 曾经在开头 set(true)。
+            // 由于 reinitWebSocket 也复用它，一个正在途中的重连（与 logout 跑在不同线程，
+            // 中间还隔着一次 token 刷新的网络调用）能把刚被关掉的状态机重新拉起来。
+            PluginInitiationUtils.disableCloud();
+            assertThat(PluginInitiationUtils.isCloudEnabled()).isFalse();
+
+            // 直接调 initWebsocket：它会因为没有 token 而抛 IOException，
+            // 但关键是——无论成败，它都不该动 cloudEnabled。
+            assertThatCode(() -> {
+                try {
+                    PluginInitiationUtils.initWebsocket();
+                } catch (Exception expected) {
+                    // 没有 token，抛异常是预期的
+                }
+            }).doesNotThrowAnyException();
+
+            assertThat(PluginInitiationUtils.isCloudEnabled())
+                    .as("只有显式的 enableCloud 才允许开启状态机")
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("logout 与进行中的 reinit 并发时，logout 必须赢")
+        void concurrentLogoutBeatsInFlightReinit() throws Exception {
+            // 真的并发跑，而不是靠顺序模拟：reinit 线程反复尝试重建，
+            // 主线程在中途 disableCloud()。此后状态机不得再被拉起来。
+            java.util.concurrent.atomic.AtomicBoolean stop =
+                    new java.util.concurrent.atomic.AtomicBoolean(false);
+            Thread reinitThread = new Thread(() -> {
+                while (!stop.get()) {
+                    try {
+                        PluginInitiationUtils.reinitWebSocket();
+                    } catch (Exception ignored) {
+                        // 无 token 时的失败与本用例无关
+                    }
+                }
+            }, "issue-223-reinit-loop");
+            reinitThread.setDaemon(true);
+            reinitThread.start();
+
+            Thread.sleep(30);
+            PluginInitiationUtils.disableCloud();
+            Thread.sleep(60);   // 给在途的那一轮足够时间跑完
+
+            stop.set(true);
+            reinitThread.join(5000);
+
+            assertThat(PluginInitiationUtils.isCloudEnabled())
+                    .as("logout 之后，任何在途的重连都不得把状态机复活")
+                    .isFalse();
+        }
     }
 
     @Nested
@@ -199,6 +254,68 @@ class CloudReconnectStateMachineTest {
             assertThat(countFrameworkHandlersOnRootLogger())
                     .as("shutdown 之后应当一个不剩")
                     .isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("日志传输器 flush 有界")
+    class BoundedFlush {
+
+        /**
+         * {@code sendBatch()} 在 WebSocket 未连接时直接 return 且不消费队列，而
+         * {@code flushLogs()} 原先是 {@code while (!logQueue.isEmpty())} —— 死循环。
+         *
+         * <p>这个缺陷在 {@code disableCloud()} 出现之前就存在（{@code onDisable} 同样走这条
+         * 路径），但那时只在关服时触发。logout 走的是命令线程，会直接卡住服务器；
+         * 而「面板连不上、队列积压、socket 已断」恰恰是管理员会去 logout 的那个场景。
+         *
+         * <p><b>超时必须用 SEPARATE_THREAD</b>。JUnit 的 {@code @Timeout} 默认是
+         * {@code SAME_THREAD}——它在测试**跑完之后**才判定是否超时，对真正的死循环毫无作用，
+         * 回归会让整个 CI 挂住而不是给出一条失败。这一点是实测出来的：把 flushLogs 退回
+         * 无界版本做负向对照时，构建直接卡死超过两分钟，而不是在 10 秒时失败。
+         */
+        @Test
+        @org.junit.jupiter.api.Timeout(
+                value = 10,
+                threadMode = org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD)
+        @DisplayName("socket 已断且队列非空时，shutdown 仍会终止而不是死循环")
+        void shutdownTerminatesWhenDisconnectedWithQueuedLogs() throws Exception {
+            // 必须先「连着」才入得了队：sendLog 在未连接时直接 return，一条都不会进队列。
+            // 这也正是真实场景的顺序——连着的时候日志积压，然后连接断掉，然后才 logout/关服。
+            java.util.concurrent.atomic.AtomicBoolean connected =
+                    new java.util.concurrent.atomic.AtomicBoolean(true);
+            com.ultikits.ultitools.websocket.UltiPanelWebSocketClient client =
+                    mock(com.ultikits.ultitools.websocket.UltiPanelWebSocketClient.class);
+            lenient().when(client.isConnected()).thenAnswer(invocation -> connected.get());
+
+            com.ultikits.ultitools.manager.UltiPanelLogTransmitter transmitter =
+                    new com.ultikits.ultitools.manager.UltiPanelLogTransmitter(client, "test-server");
+            try {
+                // batchSize 默认远大于 3，所以这几条会留在队列里而不会被立刻发出去
+                for (int i = 0; i < 3; i++) {
+                    transmitter.info("queued line " + i, "test");
+                }
+                assertThat(queueSizeOf(transmitter))
+                        .as("前置条件：队列里得真有东西，否则本用例是空的")
+                        .isPositive();
+
+                connected.set(false);   // 连接掉了
+
+                assertThatCode(transmitter::shutdown)
+                        .as("断连且队列非空时 shutdown 必须终止")
+                        .doesNotThrowAnyException();
+            } finally {
+                transmitter.shutdown();
+            }
+        }
+
+        /** 反射读队列长度，用于确认前置条件成立——不然这条用例会静默地什么都没测。 */
+        private int queueSizeOf(com.ultikits.ultitools.manager.UltiPanelLogTransmitter transmitter)
+                throws Exception {
+            Field queueField = com.ultikits.ultitools.manager.UltiPanelLogTransmitter.class
+                    .getDeclaredField("logQueue");
+            queueField.setAccessible(true);
+            return ((java.util.Collection<?>) queueField.get(transmitter)).size();
         }
     }
 


### PR DESCRIPTION
#181 与 #223 合并处理。两条改的是同一个 reinitWebSocket 状态机，账本上
标为必须同 PR——分开做，后一个会撞上前一个刚改过的状态机，且两边对
「重连何时该继续」的假设不同。

根因是这条链上有四个地方各自独立决定「要不要继续重连」，而谁都不是
所有者：

  UltiPanelWebSocketClient.onClose  按每实例 5 次算
  reinitWebSocket                   造新实例，把计数清零
  ulticloud logout                  只清凭证，根本不碰状态机
  onDisable                         唯一真正拆得干净的路径

每实例上限对整体毫无约束，于是外层循环无界；而 logout 之后这条链继续
拿着已作废的凭证敲面板，实测只有重新 login 或重启服务器才停得下来。

改动四处：

一、cloudEnabled 成为整条链的唯一开关

reinitWebSocket 只在它为 true 时才重建连接。logout 调用新增的
disableCloud() 把它置否，状态机因此不会自我复活。disableCloud 同时断开
现有客户端、摘掉 root logger 上的 handler、停掉 token 刷新调度——
「Cloud features are now disabled」这句话此前是不成立的，现在成立了。

二、外层 reinit 有了全局预算

启用了同包内此前零引用的死代码 ExponentialBackoffStrategy，
withMaxAttempts(10)。它是跨实例的，只有一次真正的 onOpen 能重置它。
预算耗尽后进入明确的终态并告诉管理员怎么恢复（/ulticloud login 或重启），
而不是无声地继续循环。

三、成功日志挪到 onOpen

reinitWebSocket 原先在 initWebsocket() 返回后无条件打印
「WebSocket re-initialized successfully」。但 connect() 是异步的，返回只
说明客户端被造出来、连接被发起了，握手与认证都还没发生——实测这句之后
紧跟着就是一条 401。现在这里只打一条 FINE 的「dispatched — awaiting
handshake」，INFO 级的成功日志由 onOpen 打，那才是真连上了。

四、LogStreamManager.initialize 改为幂等

它由 onConnectHandler 调用，而 onConnectHandler 在每一次 onOpen 都会跑，
包括重连窗口内的 reconnect() 和 reinit 之后的新客户端。原先每跑一次就
无条件 new 一个传输器（起一条线程）并往 JVM root logger 挂一个新的
SystemLogHandler，而 removeHandler 只写在 shutdown() 里、shutdown() 的
唯一调用者是 onDisable。连接每抖动一次就泄漏一份，每行日志被重复发送。

摘除按类型扫描 root logger 上全部 SystemLogHandler，而不是只摘
this.systemLogHandler。理由是字段只留得住最后一个，此前泄漏的那些没有
任何引用指得到、永远摘不掉；按类型扫一遍才能把历史欠账一并清干净，
这也是「handler 数量恒为 1」这条验收唯一能成立的写法。

测试：新增 CloudReconnectStateMachineTest，6 个用例，覆盖预算上限、
握手成功重置预算、logout 之后不再重建、logout 摘掉 handler、
不再出现成功措辞、以及 10 轮 initialize 后 handler 恒为 1。

三个负向对照都做了，各自只锁对应的那一个修复：拆掉 cloudEnabled 闸门 →
LogoutTearsDown 红；拆掉预算闸门 → ReconnectBudget 红；退回非幂等的
initialize → IdempotentLogStream 红，且第 2 轮就超。

mvn clean verify 4184 → 4190，无回归。

未覆盖的部分说明白：本 PR 只做了单元层验证，没有真机 UAT。「logout 之后
不再产生新的握手尝试」这条在测试里是通过断言 reinitWebSocket 不再重建
连接来间接证明的，不是抓真实网络流量。真机验证建议与 #179 一起做，
那条本来就要上真机。

Closes #181