### PR TITLE
feat(websocket): 把延迟测量与存活判定并进心跳路径，并接上静默失效重连

### DIFF
--- a/src/main/java/com/ultikits/ultitools/websocket/UltiPanelWebSocketClient.java
+++ b/src/main/java/com/ultikits/ultitools/websocket/UltiPanelWebSocketClient.java
@@ -49,6 +49,32 @@ public class UltiPanelWebSocketClient extends WebSocketClient {
     private int reconnectAttempts = 0;
     private boolean intentionalDisconnect = false;
 
+    /** 心跳间隔（秒）。 */
+    private static final long HEARTBEAT_INTERVAL_SECONDS = 60;
+
+    /**
+     * 判定「静默失效」的阈值：两个心跳周期没收到 pong。
+     * <p>
+     * 取两个周期而不是一个，是为了容忍单次丢包或一次调度抖动 —— 误判的代价是把一条好连接
+     * 踢掉重连，而漏判只是晚一个周期发现。
+     */
+    private static final long PONG_TIMEOUT_MS = HEARTBEAT_INTERVAL_SECONDS * 2 * 1000;
+
+    /** 最近一次发出 ping 的时间。 */
+    private volatile long lastPingTime = 0;
+    /** 最近一次收到 pong 的时间。0 表示从未收到过。 */
+    private volatile long lastPongTime = 0;
+    /** 最近一次测得的往返延迟，毫秒。 */
+    private volatile long latencyMs = -1;
+
+    /**
+     * 时钟。生产环境就是 {@code System::currentTimeMillis}，测试可以替换成假时钟。
+     * <p>
+     * 存在的唯一理由是让「超过阈值未收到 pong」这条判定可以被单元测试覆盖而不用
+     * {@code Thread.sleep} —— 真等两个心跳周期是 120 秒，那种测试没人会留着。
+     */
+    private volatile java.util.function.LongSupplier clock = System::currentTimeMillis;
+
     /**
      * 构造函数
      *
@@ -127,9 +153,11 @@ public class UltiPanelWebSocketClient extends WebSocketClient {
      * 发送Ping消息
      */
     public void sendPing() {
+        // 记录发出时间，供 recordPong() 算往返延迟
+        lastPingTime = clock.getAsLong();
         JsonObject pingMessage = new JsonObject();
         pingMessage.addProperty("type", "ping");
-        pingMessage.addProperty("timestamp", System.currentTimeMillis());
+        pingMessage.addProperty("timestamp", lastPingTime);
         sendMessage(pingMessage);
     }
 
@@ -208,13 +236,95 @@ public class UltiPanelWebSocketClient extends WebSocketClient {
      * 启动心跳任务
      */
     private void startHeartbeat() {
-        // 按照文档建议，每60秒发送一次ping消息（而不是30秒）
-        heartbeatTask = heartbeatExecutor.scheduleWithFixedDelay(() -> {
-            if (isOpen()) {
-                sendPing();
-                UltiTools.getInstance().getLogger().log(Level.FINE, "发送心跳ping消息");
-            }
-        }, 60, 60, TimeUnit.SECONDS); // 修改为60秒间隔
+        heartbeatTask = heartbeatExecutor.scheduleWithFixedDelay(this::heartbeatTick,
+            HEARTBEAT_INTERVAL_SECONDS, HEARTBEAT_INTERVAL_SECONDS, TimeUnit.SECONDS);
+    }
+
+    /**
+     * 一次心跳：先判活，再发 ping。
+     * <p>
+     * 「先判活」是本方法存在的理由。在此之前，连接健康的唯一判据是 socket 有没有断
+     * —— 而一条 TCP 连接完全可以在不产生 {@code onClose} 的情况下静默失效（中间设备
+     * 超时、对端进程挂起、NAT 表项过期）。那种状态下 ping 发得出去、{@code onClose}
+     * 不触发、重连逻辑不启动，连接看着是好的，实际已经死了。
+     * <p>
+     * 判定为静默失效时**走 {@code close()} 而不是自己另起一套重连**：close 会触发
+     * {@code onClose}，复用既有的重连状态机（含 #181 加的全局预算）。另起一套就会变成
+     * 第二个「决定要不要重连」的地方，那正是 #181 的成因。
+     */
+    void heartbeatTick() {
+        if (!isOpen()) {
+            return;
+        }
+
+        if (!isAlive(PONG_TIMEOUT_MS)) {
+            long silentFor = clock.getAsLong() - lastPongTime;
+            UltiTools.getInstance().getLogger().log(Level.WARNING, String.format(
+                "WebSocket 已 %d 秒未收到 pong（阈值 %d 秒），判定为静默失效，主动重连",
+                silentFor / 1000, PONG_TIMEOUT_MS / 1000));
+            // 不设 intentionalDisconnect —— 这不是「有意断开」，重连必须继续
+            close(4000, "Heartbeat timeout: no pong received");
+            return;
+        }
+
+        sendPing();
+        UltiTools.getInstance().getLogger().log(Level.FINE, String.format(
+            "发送心跳ping消息%s", latencyMs >= 0 ? "（上次往返 " + latencyMs + "ms）" : ""));
+    }
+
+    /**
+     * 收到 pong 时调用：记录时间并算出往返延迟。
+     * <p>
+     * 由 {@link #onMessage(String)} 在分发给 messageHandler 之前调用 —— pong 是链路层面的
+     * 事实，不该依赖上层处理器是否接线。
+     */
+    private void recordPong() {
+        lastPongTime = clock.getAsLong();
+        if (lastPingTime > 0) {
+            latencyMs = lastPongTime - lastPingTime;
+        }
+    }
+
+    /**
+     * 根据 pong 应答判断连接是否还活着。
+     *
+     * <p><b>从未收到过 pong 时返回 true。</b> 这一条是刻意的：否则新建立的连接会在第一个
+     * 心跳周期就被判死。代价是这套机制发现不了「对端从来就不应答 pong」的情况 —— 但那是
+     * 安全的方向：面板若压根没实现 pong，我们不该把好连接反复踢掉。它能发现的是
+     * 「曾经在应答、后来不答了」，也就是静默失效。
+     *
+     * @param timeoutMs 判定阈值，毫秒
+     * @return 最近一次 pong 在阈值之内，或从未收到过 pong
+     */
+    public boolean isAlive(long timeoutMs) {
+        if (lastPongTime == 0) {
+            return true;
+        }
+        return (clock.getAsLong() - lastPongTime) < timeoutMs;
+    }
+
+    /**
+     * 最近一次测得的往返延迟，毫秒；尚未测到时为 -1。
+     *
+     * @return 延迟毫秒数，或 -1
+     */
+    public long getLatencyMs() {
+        return latencyMs;
+    }
+
+    /**
+     * 最近一次收到 pong 的时间戳；从未收到过时为 0。
+     *
+     * @return 时间戳，毫秒
+     */
+    public long getLastPongTime() {
+        return lastPongTime;
+    }
+
+    /** 仅供测试替换时钟。 */
+    @org.jetbrains.annotations.ApiStatus.Internal
+    void setClock(java.util.function.LongSupplier clock) {
+        this.clock = clock;
     }
 
     // WebSocketClient实现
@@ -250,6 +360,12 @@ public class UltiPanelWebSocketClient extends WebSocketClient {
                 ? jsonMessage.get("type").getAsString() : null;
             UltiTools.getInstance().getLogger().log(Level.FINE,
                 String.format("[WebSocket接收] 类型: %s", messageType != null ? messageType : "未知"));
+
+            // pong 在分发之前就记下来。它是链路层面的事实，不该取决于上层处理器
+            // 有没有接线——存活判定是本类自己的职责。
+            if ("pong".equals(messageType)) {
+                recordPong();
+            }
 
             if (messageHandler != null) {
                 messageHandler.accept(jsonMessage);

--- a/src/main/java/com/ultikits/ultitools/websocket/handlers/PongHandler.java
+++ b/src/main/java/com/ultikits/ultitools/websocket/handlers/PongHandler.java
@@ -10,6 +10,13 @@ import com.ultikits.ultitools.websocket.WebSocketMessageHandler;
  * <p>
  * 处理 pong/心跳响应消息的处理器。
  *
+ * <p><b>本类的能力已于 issue #235 全部搬进 {@code UltiPanelWebSocketClient} 的心跳路径</b>
+ * —— 延迟测量、最后一次 pong 时间、以及 {@code isAlive(long)} 存活判定都在那边了，并且
+ * 接上了「超过阈值未收到 pong 就主动重连」这条活路径（本类从来没有接线，见 #233）。
+ *
+ * <p>因此本类现在<b>可以被安全删除</b>，删除动作由 #233 执行。留着它只会造成
+ * 「registry 模式部分启用」的中间态。
+ *
  * @author wisdomme
  * @version 1.0.0
  * @since 6.2.0

--- a/src/test/java/com/ultikits/ultitools/websocket/HeartbeatLivenessTest.java
+++ b/src/test/java/com/ultikits/ultitools/websocket/HeartbeatLivenessTest.java
@@ -1,0 +1,182 @@
+package com.ultikits.ultitools.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.ultikits.ultitools.UltiTools;
+import com.ultikits.ultitools.utils.TestHelper;
+
+/**
+ * 心跳路径上的存活判定与延迟测量（issue #235）。
+ *
+ * <p>这三样能力原先只存在于 {@code websocket.handlers.PongHandler} —— 一个从未接线的死类
+ * （见 #233）。搬进客户端之前，连接健康的唯一判据是 socket 有没有断，而一条 TCP 连接完全
+ * 可以在不产生 {@code onClose} 的情况下静默失效。
+ *
+ * <p>全部用假时钟推进，不用 {@code Thread.sleep} —— 真等两个心跳周期是 120 秒。
+ */
+@DisplayName("心跳存活判定")
+class HeartbeatLivenessTest {
+
+    /** 假时钟，测试自己推进。 */
+    private final AtomicLong now = new AtomicLong(1_000_000L);
+
+    private UltiPanelWebSocketClient client;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Logger mockLogger = mock(Logger.class);
+        TestHelper.mockUltiToolsInstance(ultiTools ->
+                lenient().when(ultiTools.getLogger()).thenReturn(mockLogger));
+
+        client = new UltiPanelWebSocketClient("ws://localhost:1", "test-server", "test-token");
+        client.setClock(now::get);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (client != null) {
+            // 构造函数里起了 heartbeatExecutor，不关就是泄漏线程。见 #250。
+            client.disconnect();
+        }
+        Field instanceField = UltiTools.class.getDeclaredField("ultiTools");
+        instanceField.setAccessible(true);
+        instanceField.set(null, null);
+    }
+
+    /** 让假时钟前进若干秒。 */
+    private void advanceSeconds(long seconds) {
+        now.addAndGet(seconds * 1000);
+    }
+
+    /** 喂一条 pong 进真实的 onMessage 入口。 */
+    private void receivePong() {
+        client.onMessage("{\"type\":\"pong\",\"data\":{}}");
+    }
+
+    @Nested
+    @DisplayName("存活判定")
+    class Liveness {
+
+        @Test
+        @DisplayName("从未收到过 pong 时判为存活")
+        void neverReceivedPongIsConsideredAlive() {
+            // 刻意的语义：否则新连接会在第一个心跳周期就被判死。
+            // 代价是发现不了「对端从来不应答」，但那是安全的方向。
+            assertThat(client.getLastPongTime()).isZero();
+            assertThat(client.isAlive(120_000)).isTrue();
+
+            advanceSeconds(3600);
+            assertThat(client.isAlive(120_000))
+                    .as("即使过了一小时，只要一次 pong 都没收到过，也不该判死")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("阈值之内收到过 pong 判为存活")
+        void recentPongIsAlive() {
+            receivePong();
+            advanceSeconds(119);
+
+            assertThat(client.isAlive(120_000)).isTrue();
+        }
+
+        @Test
+        @DisplayName("超过阈值未收到 pong 判为静默失效")
+        void stalePongIsNotAlive() {
+            receivePong();
+            advanceSeconds(121);
+
+            assertThat(client.isAlive(120_000))
+                    .as("曾经在应答、后来不答了 —— 这正是静默失效")
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("新的 pong 会刷新判定")
+        void newPongRefreshesLiveness() {
+            receivePong();
+            advanceSeconds(119);
+            receivePong();
+            advanceSeconds(119);
+
+            assertThat(client.isAlive(120_000))
+                    .as("累计 238 秒，但最后一次 pong 在 119 秒前")
+                    .isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("延迟测量")
+    class Latency {
+
+        @Test
+        @DisplayName("尚未测到时为 -1")
+        void latencyIsUnsetInitially() {
+            assertThat(client.getLatencyMs()).isEqualTo(-1);
+        }
+
+        @Test
+        @DisplayName("ping 到 pong 的往返时间被记录下来")
+        void latencyIsMeasuredAcrossPingPong() {
+            client.sendPing();      // 未连接，消息发不出去，但发送时间已记录
+            advanceSeconds(3);
+            receivePong();
+
+            assertThat(client.getLatencyMs()).isEqualTo(3000);
+        }
+
+        @Test
+        @DisplayName("没发过 ping 就收到 pong 时，不产生虚假延迟")
+        void unsolicitedPongDoesNotProduceLatency() {
+            receivePong();
+
+            assertThat(client.getLatencyMs())
+                    .as("没有 ping 时间戳可比，延迟应当保持未测到状态")
+                    .isEqualTo(-1);
+        }
+    }
+
+    @Nested
+    @DisplayName("心跳 tick 的行为")
+    class HeartbeatTick {
+
+        @Test
+        @DisplayName("socket 未打开时 tick 什么都不做")
+        void tickIsNoOpWhenSocketClosed() {
+            // 本用例里 socket 从未连接，isOpen() 为假
+            assertThatCode(client::heartbeatTick).doesNotThrowAnyException();
+
+            assertThat(client.getLastPongTime())
+                    .as("不该产生任何副作用")
+                    .isZero();
+        }
+
+        @Test
+        @DisplayName("静默失效的判定不依赖 onClose 被触发")
+        void silentFailureIsDetectedWithoutOnClose() {
+            // 这是整条改动的要点：onClose 从未触发，socket 在系统看来还开着，
+            // 但对端已经不应答了。判定必须只依赖 pong 的时间戳。
+            receivePong();
+            assertThat(client.isAlive(120_000)).isTrue();
+
+            advanceSeconds(121);
+
+            assertThat(client.isAlive(120_000))
+                    .as("没有任何 onClose 发生，仅凭 pong 静默这一点就应当判死")
+                    .isFalse();
+        }
+    }
+}


### PR DESCRIPTION
PongHandler 是五个死 handler 里唯一含有活路径没有的逻辑的一个（src/main
引用数为 0，见 #233）。它有而活路径没有的三样：最后一次 pong 时间、
往返延迟、以及 isAlive(timeoutMs) 存活判定。删掉 #233 之前先把这部分
收割进来，否则一并丢掉。

搬进 UltiPanelWebSocketClient 的心跳路径，没有保留 PongHandler 类本身
——按 issue 的要求，留着它会造成「registry 模式部分启用」的中间态。
只在它的 javadoc 上留了一条指路标，说明能力已搬走、可安全删除，给做
#233 的人看。

三处接线：

一、sendPing() 记录发出时间戳。
二、onMessage() 在分发给 messageHandler **之前**捕获 pong。pong 是链路
    层面的事实，不该取决于上层处理器有没有接线——存活判定是客户端自己
    的职责。
三、心跳 tick 改成「先判活、再发 ping」。

第三条是这次改动的要点。在此之前，连接健康的唯一判据是 socket 有没有
断，而一条 TCP 连接完全可以在不产生 onClose 的情况下静默失效（中间设备
超时、对端进程挂起、NAT 表项过期）。那种状态下 ping 发得出去、onClose
不触发、重连逻辑不启动——连接看着是好的，实际已经死了。

判定为静默失效时走 close() 而不是自己另起一套重连。close 会触发
onClose，复用既有的重连状态机（含 #181 刚加的全局预算）。另起一套就会
变成第二个「决定要不要重连」的地方，而那正是 #181 的成因。也刻意没有设
intentionalDisconnect——这不是有意断开，重连必须继续。

阈值取两个心跳周期（120 秒）而不是一个：容忍单次丢包或一次调度抖动。
误判的代价是把一条好连接踢掉重连，漏判只是晚一个周期发现。

有一条语义要单独说明：**从未收到过 pong 时 isAlive 返回 true**。这是刻意
的，否则新建立的连接会在第一个心跳周期就被判死。代价是这套机制发现不了
「对端从来就不应答 pong」，但那是安全的方向——面板若压根没实现 pong，
不该把好连接反复踢掉。它能发现的是「曾经在应答、后来不答了」。

测试：新增 HeartbeatLivenessTest，9 个用例，全部用假时钟推进，没有
Thread.sleep（真等两个心跳周期是 120 秒，那种测试没人会留着）。为此加了
一个包级的 setClock，标了 @ApiStatus.Internal。

覆盖：从未收到 pong 判活、阈值内判活、超阈值判死、新 pong 刷新判定、
延迟初始为 -1、ping-pong 往返被测出、无 ping 时的 pong 不产生虚假延迟、
socket 未开时 tick 无副作用、以及静默失效的判定不依赖 onClose。

负向对照：拆掉 onMessage 里的 pong 捕获 → 3 条红；让 isAlive 恒返回
true → 2 条红。

mvn clean verify 4193 -> 4202。

Closes #235