### PR TITLE
fix(websocket): 玩家事件带上真实服务器身份，监听器注册改为幂等

### DIFF
--- a/src/main/java/com/ultikits/ultitools/manager/PlayerEventManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PlayerEventManager.java
@@ -25,7 +25,17 @@ import org.jetbrains.annotations.ApiStatus;
 @SuppressWarnings("deprecation")
 @ApiStatus.Internal
 public class PlayerEventManager implements Listener {
-    private UltiPanelWebSocketClient webSocketClient;
+    /**
+     * 必须 volatile。写在 WebSocket 的 onOpen 线程上（{@link #initialize}），读在 Bukkit 主线程上
+     * （三个事件处理器）。只给写方加 {@code synchronized} 不构成发布——读方从不获取同一把监视器，
+     * 两边之间没有 happens-before 边。
+     * <p>
+     * 这一点在加幂等守卫之前是<b>被意外掩盖</b>的：那时每次 {@code initialize} 都会调
+     * {@code registerEvents}，而 Bukkit 注册监听器会写 {@code HandlerList} 的 volatile 字段，
+     * 事件分发再读它，于是本字段的写被顺带发布了出去。守卫跳过注册之后这条捎带链就断了，
+     * 重连后处理器可能一直看着旧的、已断开的客户端，玩家事件被静默丢弃。见 PR #264 的评审。
+     */
+    private volatile UltiPanelWebSocketClient webSocketClient;
 
     /**
      * 是否已经把自己挂进 Bukkit 事件系统。

--- a/src/main/java/com/ultikits/ultitools/manager/PlayerEventManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PlayerEventManager.java
@@ -6,10 +6,12 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerChatEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.Plugin;
 
 import com.google.gson.JsonObject;
 import com.ultikits.ultitools.UltiTools;
@@ -24,18 +26,62 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.Internal
 public class PlayerEventManager implements Listener {
     private UltiPanelWebSocketClient webSocketClient;
-    
+
+    /**
+     * 是否已经把自己挂进 Bukkit 事件系统。
+     * <p>
+     * {@link #initialize(UltiPanelWebSocketClient)} 由 {@code initializeManagers()} 调用，而后者挂在
+     * WebSocket 的 {@code onConnectHandler} 上——<b>每次 onOpen 都会跑一遍</b>。没有这个守卫的话，
+     * 断线重连 N 次就会注册 N 份监听器，同一个玩家事件被发 N 遍。见 issue #180。
+     */
+    private volatile boolean listenerRegistered = false;
+
     /**
      * 初始化玩家事件管理器
      * @param client WebSocket客户端
      */
     public void initialize(UltiPanelWebSocketClient client) {
+        // 客户端每次重连都是新造的实例（见 PluginInitiationUtils.getPanelWebsocketClient），
+        // 所以引用要无条件更新；只有注册动作是幂等的。
         this.webSocketClient = client;
-        // 注册事件监听器
-        Bukkit.getPluginManager().registerEvents(this, 
-            Bukkit.getPluginManager().getPlugin("UltiTools"));
+        registerEvents();
     }
-    
+
+    /**
+     * 幂等地注册事件监听器：已注册过就直接返回。
+     */
+    private synchronized void registerEvents() {
+        if (listenerRegistered) {
+            return;
+        }
+        Plugin plugin = Bukkit.getPluginManager().getPlugin("UltiTools");
+        if (plugin == null) {
+            UltiTools.getInstance().getLogger().log(java.util.logging.Level.WARNING,
+                "[PlayerEventManager] 找不到 UltiTools 插件实例，玩家事件监听器未注册");
+            return;
+        }
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+        listenerRegistered = true;
+    }
+
+    /**
+     * 注销事件监听器并断开与客户端的关联。
+     * <p>
+     * 由 {@code PluginInitiationUtils.disableCloud()} 调用——即 {@code /ulticloud logout} 之后。
+     * 注意与「断线重连」区分：那种断开之后 {@code initialize} 还会被调回来，注销了反而要重注册；
+     * 这里处理的是「云功能被显式关掉」，监听器应当真的摘掉。
+     */
+    public synchronized void shutdown() {
+        HandlerList.unregisterAll(this);
+        listenerRegistered = false;
+        this.webSocketClient = null;
+    }
+
+    /** 供测试断言幂等守卫的状态。 */
+    boolean isListenerRegistered() {
+        return listenerRegistered;
+    }
+
     /**
      * 处理玩家加入事件
      */
@@ -131,10 +177,15 @@ public class PlayerEventManager implements Listener {
     
     /**
      * 获取服务器ID
+     * <p>
+     * 取建连时交给客户端的那份 UUID（即 {@code CommonUtils.getUltiToolsUUID()}，见
+     * {@code PluginInitiationUtils.getPanelWebsocketClient}），与所有兄弟 manager 一致。
+     * 在 #180 之前这里返回的是一个写死的占位字符串，意味着全球每台服务器发出的
+     * {@code player_event} 都自称同一身份，面板侧无法路由。
+     *
      * @return 服务器ID
      */
     private String getServerId() {
-        // 这里应该返回配置中的服务器ID或生成一个唯一ID
-        return "minecraft-server-1";
+        return webSocketClient == null ? "unknown" : webSocketClient.getServerId();
     }
 }

--- a/src/main/java/com/ultikits/ultitools/manager/PlayerEventManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PlayerEventManager.java
@@ -38,9 +38,15 @@ public class PlayerEventManager implements Listener {
 
     /**
      * 初始化玩家事件管理器
+     * <p>
+     * 整个方法与 {@link #shutdown()} 互斥。只让 {@code registerEvents} 单独同步是不够的：
+     * 「赋值客户端」与「注册监听器」之间会留下一个窗口，logout 恰好挤进去的话，
+     * {@code shutdown()} 摘掉的监听器会被紧随其后的 {@code registerEvents} 又装回去，
+     * 于是 {@code disableCloud()} 之后 {@code listenerRegistered} 仍为 true。见 PR #264 的评审。
+     *
      * @param client WebSocket客户端
      */
-    public void initialize(UltiPanelWebSocketClient client) {
+    public synchronized void initialize(UltiPanelWebSocketClient client) {
         // 客户端每次重连都是新造的实例（见 PluginInitiationUtils.getPanelWebsocketClient），
         // 所以引用要无条件更新；只有注册动作是幂等的。
         this.webSocketClient = client;
@@ -49,6 +55,8 @@ public class PlayerEventManager implements Listener {
 
     /**
      * 幂等地注册事件监听器：已注册过就直接返回。
+     * <p>
+     * 调用方必须已持有本对象的监视器锁（目前唯一调用方是 {@link #initialize}）。
      */
     private synchronized void registerEvents() {
         if (listenerRegistered) {

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
@@ -965,6 +965,17 @@ public class PluginInitiationUtils {
                 "Error shutting down log stream manager: " + e.getMessage());
         }
 
+        // 摘掉玩家事件监听器。云关掉之后再收玩家事件是纯浪费——事件处理器里那句
+        // isConnected() 判断只是让它不发消息，监听本身还在跑。见 issue #180。
+        try {
+            if (UltiTools.getInstance().getPlayerEventManager() != null) {
+                UltiTools.getInstance().getPlayerEventManager().shutdown();
+            }
+        } catch (Exception e) {
+            UltiTools.getInstance().getLogger().log(Level.FINE,
+                "Error shutting down player event manager: " + e.getMessage());
+        }
+
         stopWebsocket();
         panelWS = null;
 

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
@@ -45,6 +45,19 @@ public class PluginInitiationUtils {
     private static final java.util.concurrent.atomic.AtomicBoolean cloudEnabled =
             new java.util.concurrent.atomic.AtomicBoolean(false);
 
+    /**
+     * 云管理器「接线」与「拆线」的互斥锁。
+     * <p>
+     * {@link #cloudEnabled} 单独用是不够的：它只能表达状态，表达不了「检查与动作之间不许有人插队」。
+     * {@code initializeManagers()} 读到 true 之后、真正接线之前，{@code disableCloud()} 完全可以
+     * 插进来把开关置否并把监听器拆干净，随后前者继续往下又把它们装回去——logout 之后监听器
+     * 还在，甚至还能继续往面板发事件。见 PR #264 的两轮评审。
+     * <p>
+     * 两边都持这把锁之后，二者只能整体先后发生：要么先接线再拆掉（干净），要么先拆再接而接线
+     * 一侧在持锁复查时看到 false 直接返回（也干净）。
+     */
+    private static final Object cloudLifecycleLock = new Object();
+
     /** 外层 reinit 的全局上限。超过之后进入终态，需要 {@code /ulticloud login} 或重启才恢复。 */
     private static final int MAX_REINIT_ATTEMPTS = 10;
 
@@ -333,20 +346,32 @@ public class PluginInitiationUtils {
     /**
      * 把所有 WebSocket 管理器接到当前连接上。
      * <p>
-     * 顶上这道 {@link #cloudEnabled} 闸不是可有可无的：本方法挂在 {@code onConnectHandler} 上，
-     * 而 {@code /ulticloud logout} 之后仍可能有一次在途的握手落地。没有闸的话，
-     * {@code disableCloud()} 刚摘掉的监听器会被这次迟到的 onOpen 原样装回去——
-     * 这正是 #181/#223 里「谁都不是所有者」那个毛病换个地方重现。闸放在这里而不是各个
-     * manager 里，是因为生命周期的决定权本来就属于这一层。见 PR #264 的评审。
+     * 本方法挂在 {@code onConnectHandler} 上，而 {@code /ulticloud logout} 之后仍可能有一次
+     * 在途的握手落地。不设防的话，{@code disableCloud()} 刚摘掉的监听器会被这次迟到的 onOpen
+     * 原样装回去——这正是 #181/#223 里「谁都不是所有者」那个毛病换个地方重现。
+     * <p>
+     * <b>光检查 {@link #cloudEnabled} 是不够的。</b>那只是一次锁外的读：读到 true 之后、
+     * 真正接线之前，{@code disableCloud()} 完全可以插进来把开关置否并拆干净，然后本方法
+     * 继续往下把监听器又装回去。所以接线与拆线必须落在同一把 {@link #cloudLifecycleLock} 上，
+     * 并在<b>持锁期间</b>复查开关。见 PR #264 的两轮评审。
      * <p>
      * 包级可见而非 private —— 只为可测。
      */
     static void initializeManagers() {
-        if (!cloudEnabled.get()) {
-            UltiTools.getInstance().getLogger().log(Level.FINE,
-                "云连接已关闭，跳过管理器初始化（这是一次登出之后迟到的握手）");
-            return;
+        synchronized (cloudLifecycleLock) {
+            // 持锁复查：disableCloud() 拿的是同一把锁，所以到这里为止它要么还没开始、
+            // 要么已经整个跑完，不可能卡在中间。
+            if (!cloudEnabled.get()) {
+                UltiTools.getInstance().getLogger().log(Level.FINE,
+                    "云连接已关闭，跳过管理器初始化（这是一次登出之后迟到的握手）");
+                return;
+            }
+            wireManagers();
         }
+    }
+
+    /** {@link #initializeManagers()} 的实际接线动作。调用方必须持有 {@link #cloudLifecycleLock}。 */
+    private static void wireManagers() {
         try {
             // 初始化服务器监控管理器
             UltiTools.getInstance().getServerMonitorManager().setWebSocketClient(panelWS);
@@ -965,8 +990,19 @@ public class PluginInitiationUtils {
      * <p>
      * 顺带摘掉 root logger 上的日志 handler 与传输线程，并停掉 token 刷新调度——
      * 都是「云功能已关闭」这句话应当为真的组成部分。
+     * <p>
+     * 整个方法持有 {@link #cloudLifecycleLock}，与 {@code initializeManagers()} 互斥。
+     * 不然的话，一次在途的 onOpen 可以在「置否」与「拆线」之间挤进来，把刚要拆的东西
+     * 又装回去。见 PR #264 的两轮评审。
      */
     public static void disableCloud() {
+        synchronized (cloudLifecycleLock) {
+            doDisableCloud();
+        }
+    }
+
+    /** {@link #disableCloud()} 的实际拆线动作。调用方必须持有 {@link #cloudLifecycleLock}。 */
+    private static void doDisableCloud() {
         cloudEnabled.set(false);
         reinitBackoff.reset();
 

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
@@ -330,7 +330,23 @@ public class PluginInitiationUtils {
             String.format("[WebSocket消息处理] 类型: %s, 处理完成", type));
     }
 
-    private static void initializeManagers() {
+    /**
+     * 把所有 WebSocket 管理器接到当前连接上。
+     * <p>
+     * 顶上这道 {@link #cloudEnabled} 闸不是可有可无的：本方法挂在 {@code onConnectHandler} 上，
+     * 而 {@code /ulticloud logout} 之后仍可能有一次在途的握手落地。没有闸的话，
+     * {@code disableCloud()} 刚摘掉的监听器会被这次迟到的 onOpen 原样装回去——
+     * 这正是 #181/#223 里「谁都不是所有者」那个毛病换个地方重现。闸放在这里而不是各个
+     * manager 里，是因为生命周期的决定权本来就属于这一层。见 PR #264 的评审。
+     * <p>
+     * 包级可见而非 private —— 只为可测。
+     */
+    static void initializeManagers() {
+        if (!cloudEnabled.get()) {
+            UltiTools.getInstance().getLogger().log(Level.FINE,
+                "云连接已关闭，跳过管理器初始化（这是一次登出之后迟到的握手）");
+            return;
+        }
         try {
             // 初始化服务器监控管理器
             UltiTools.getInstance().getServerMonitorManager().setWebSocketClient(panelWS);

--- a/src/test/java/com/ultikits/ultitools/manager/PlayerEventManagerRegistrationTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PlayerEventManagerRegistrationTest.java
@@ -1,0 +1,215 @@
+package com.ultikits.ultitools.manager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.ArgumentCaptor;
+
+import com.google.gson.JsonObject;
+import com.ultikits.ultitools.UltiTools;
+import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+/**
+ * 玩家事件管理器的身份与注册幂等性（issue #180）。
+ *
+ * <p>两件事在这里被钉住：
+ * <ul>
+ *   <li>发出去的 {@code serverId} 是本服真实 UUID，不是常量 {@code "minecraft-server-1"} ——
+ *       在 #180 之前全球每台服务器都自称同一身份，面板侧无法路由；</li>
+ *   <li>{@code initialize()} 挂在 WebSocket 的 {@code onConnectHandler} 上，<b>每次重连都会被调</b>，
+ *       所以注册动作必须幂等，否则断线 N 次后每个玩家事件被发 N 份。</li>
+ * </ul>
+ *
+ * <p>与既有的 {@code PlayerEventManagerTest} 的区别：那边用反射直接塞 {@code webSocketClient} 字段、
+ * 手工调处理器方法，绕过了 Bukkit 的事件分发；重复注册这种缺陷只有<b>让事件真的走一遍 Bukkit
+ * 的 HandlerList</b> 才看得见，所以这里必须造一个名叫 {@code UltiTools} 的插件、走 {@code callEvent}。
+ */
+@DisplayName("玩家事件管理器：身份与注册幂等")
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+class PlayerEventManagerRegistrationTest {
+
+    private static final String SERVER_UUID = "8f14e45f-ceea-467a-9575-9d1e1c1c1c1c";
+
+    private ServerMock server;
+    private PlayerEventManager manager;
+    private UltiPanelWebSocketClient mockClient;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
+        server = MockBukkit.mock();
+        // 名字必须是 UltiTools —— registerEvents 拿的就是 getPlugin("UltiTools")
+        MockBukkit.createMockPlugin("UltiTools");
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
+
+        Logger mockLogger = mock(Logger.class);
+        when(UltiTools.getInstance().getLogger()).thenReturn(mockLogger);
+
+        LogStreamManager mockLogStreamManager = mock(LogStreamManager.class);
+        when(UltiTools.getInstance().getLogStreamManager()).thenReturn(mockLogStreamManager);
+
+        mockClient = mock(UltiPanelWebSocketClient.class);
+        when(mockClient.isConnected()).thenReturn(true);
+        when(mockClient.getServerId()).thenReturn(SERVER_UUID);
+
+        manager = new PlayerEventManager();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (manager != null) {
+            manager.shutdown();
+        }
+        com.ultikits.ultitools.utils.MockBukkitHelper.safeUnmock();
+    }
+
+    /**
+     * 让一个玩家加入事件真的走一遍 Bukkit 的事件分发。
+     * <p>
+     * {@code ServerMock.addPlayer()} 模拟的是完整的加入流程，<b>它自己就会派发 PlayerJoinEvent</b>，
+     * 所以不能再手工 {@code callEvent} 一次——那会变成两个事件，看上去和「监听器注册了两份」
+     * 一模一样，正是这个测试要区分的东西。
+     */
+    private void fireJoinEvent() {
+        server.addPlayer();
+    }
+
+    @Nested
+    @DisplayName("服务器身份")
+    class ServerIdentity {
+
+        @Test
+        @DisplayName("serverId 取自 WebSocket 客户端，不是硬编码常量")
+        void serverIdComesFromWebSocketClient() {
+            manager.initialize(mockClient);
+
+            fireJoinEvent();
+
+            ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
+            verify(mockClient).sendMessage(captor.capture());
+
+            JsonObject message = captor.getValue();
+            assertThat(message.get("serverId").getAsString())
+                    .as("面板靠这个字段路由；一个写死的常量会让所有服务器撞在一起")
+                    .isEqualTo(SERVER_UUID)
+                    .isNotEqualTo("minecraft-server-1");
+        }
+
+        @Test
+        @DisplayName("重连换了新客户端后，身份跟着新客户端走")
+        void serverIdFollowsTheLatestClient() {
+            // 每次重连 PluginInitiationUtils 都会造一个新的客户端实例，
+            // 幂等守卫只能挡住重复注册，不能顺带把引用也挡住不更新。
+            UltiPanelWebSocketClient secondClient = mock(UltiPanelWebSocketClient.class);
+            when(secondClient.isConnected()).thenReturn(true);
+            when(secondClient.getServerId()).thenReturn("second-client-uuid");
+
+            manager.initialize(mockClient);
+            manager.initialize(secondClient);
+
+            fireJoinEvent();
+
+            verify(mockClient, never()).sendMessage(any(JsonObject.class));
+            ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
+            verify(secondClient).sendMessage(captor.capture());
+            assertThat(captor.getValue().get("serverId").getAsString()).isEqualTo("second-client-uuid");
+        }
+    }
+
+    @Nested
+    @DisplayName("注册幂等性")
+    class RegistrationIdempotency {
+
+        @Test
+        @DisplayName("两次 onOpen 之后监听器只注册一次")
+        void twoInitializationsRegisterListenerOnce() {
+            manager.initialize(mockClient);
+            manager.initialize(mockClient);
+
+            fireJoinEvent();
+
+            verify(mockClient, times(1))
+                    .sendMessage(any(JsonObject.class));
+        }
+
+        @Test
+        @DisplayName("重连五次也只发一份")
+        void manyReconnectsStillSendOne() {
+            for (int i = 0; i < 5; i++) {
+                manager.initialize(mockClient);
+            }
+
+            fireJoinEvent();
+
+            verify(mockClient, times(1)).sendMessage(any(JsonObject.class));
+        }
+
+        @Test
+        @DisplayName("首次 initialize 之后守卫置位")
+        void guardIsSetAfterFirstInitialize() {
+            assertThat(manager.isListenerRegistered()).isFalse();
+
+            manager.initialize(mockClient);
+
+            assertThat(manager.isListenerRegistered()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("注销")
+    class Unregistration {
+
+        @Test
+        @DisplayName("shutdown 之后不再收到事件")
+        void shutdownStopsListening() {
+            manager.initialize(mockClient);
+            manager.shutdown();
+
+            fireJoinEvent();
+
+            verify(mockClient, never()).sendMessage(any(JsonObject.class));
+            assertThat(manager.isListenerRegistered()).isFalse();
+        }
+
+        @Test
+        @DisplayName("shutdown 之后可以重新 initialize，且仍然只注册一份")
+        void reinitializeAfterShutdownIsStillSingle() {
+            manager.initialize(mockClient);
+            manager.shutdown();
+            manager.initialize(mockClient);
+
+            fireJoinEvent();
+
+            verify(mockClient, times(1)).sendMessage(any(JsonObject.class));
+        }
+
+        @Test
+        @DisplayName("重复 shutdown 不抛异常")
+        void repeatedShutdownIsSafe() {
+            manager.initialize(mockClient);
+
+            assertThatCode(() -> {
+                manager.shutdown();
+                manager.shutdown();
+            }).doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/manager/PlayerEventManagerRegistrationTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PlayerEventManagerRegistrationTest.java
@@ -211,5 +211,23 @@ class PlayerEventManagerRegistrationTest {
                 manager.shutdown();
             }).doesNotThrowAnyException();
         }
+
+        @Test
+        @DisplayName("initialize 与 shutdown 互斥")
+        void initializeAndShutdownShareTheSameLock() throws Exception {
+            // 只让 registerEvents 单独同步是不够的：initialize 里「赋值客户端」与「注册监听器」
+            // 之间会留下一个窗口，logout 恰好挤进去的话，shutdown 摘掉的监听器会被紧随其后的
+            // registerEvents 又装回去。见 PR #264 的评审。
+            //
+            // 真实竞态无法确定性复现，这里退而钉住结构：两个方法必须落在同一把锁上。
+            assertThat(java.lang.reflect.Modifier.isSynchronized(
+                    PlayerEventManager.class.getDeclaredMethod("initialize", UltiPanelWebSocketClient.class)
+                            .getModifiers()))
+                    .as("initialize 必须整体同步，而不是只同步内部的 registerEvents")
+                    .isTrue();
+            assertThat(java.lang.reflect.Modifier.isSynchronized(
+                    PlayerEventManager.class.getDeclaredMethod("shutdown").getModifiers()))
+                    .isTrue();
+        }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
@@ -347,6 +347,54 @@ class CloudReconnectStateMachineTest {
 
             Mockito.verify(UltiTools.getInstance(), Mockito.atLeastOnce()).getServerMonitorManager();
         }
+
+        @Test
+        @DisplayName("接线与拆线落在同一把生命周期锁上")
+        void wiringAndTeardownShareTheSameLock() throws Exception {
+            // 光检查 cloudEnabled 是不够的：那只是一次锁外的读。读到 true 之后、真正接线之前，
+            // disableCloud() 完全可以插进来把开关置否并拆干净，随后接线一侧继续往下又装回去。
+            // 状态位表达不了「检查与动作之间不许有人插队」，只有锁能。见 PR #264 第二轮评审。
+            Field lockField = PluginInitiationUtils.class.getDeclaredField("cloudLifecycleLock");
+            lockField.setAccessible(true);
+            Object lock = lockField.get(null);
+
+            Runnable[] actions = {
+                PluginInitiationUtils::initializeManagers,
+                PluginInitiationUtils::disableCloud
+            };
+
+            for (Runnable action : actions) {
+                java.util.concurrent.CountDownLatch started = new java.util.concurrent.CountDownLatch(1);
+                java.util.concurrent.CountDownLatch finished = new java.util.concurrent.CountDownLatch(1);
+
+                Thread worker = new Thread(() -> {
+                    started.countDown();
+                    try {
+                        action.run();
+                    } catch (Exception ignored) {
+                        // 本用例只关心它能不能进得去，不关心它做了什么
+                    } finally {
+                        finished.countDown();
+                    }
+                }, "lifecycle-lock-probe");
+                worker.setDaemon(true);
+
+                synchronized (lock) {
+                    worker.start();
+                    assertThat(started.await(5, java.util.concurrent.TimeUnit.SECONDS))
+                            .as("探针线程本身要真的跑起来，否则下面那条断言是空转")
+                            .isTrue();
+                    assertThat(finished.await(300, java.util.concurrent.TimeUnit.MILLISECONDS))
+                            .as("持有生命周期锁期间，这个动作必须进不去")
+                            .isFalse();
+                }
+
+                assertThat(finished.await(5, java.util.concurrent.TimeUnit.SECONDS))
+                        .as("释放锁之后应当立刻放行")
+                        .isTrue();
+                worker.join(1000);
+            }
+        }
     }
 
     /** 数一数 JVM root logger 上挂了几个本框架的 handler。 */

--- a/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
@@ -319,6 +319,36 @@ class CloudReconnectStateMachineTest {
         }
     }
 
+    @Nested
+    @DisplayName("迟到的握手不得复活管理器（#264 评审）")
+    class LateHandshakeIsIgnored {
+
+        @Test
+        @DisplayName("云已关闭时 initializeManagers 直接返回")
+        void managersAreNotWiredWhenCloudDisabled() {
+            // logout 之后仍可能有一次在途的握手落地。没有这道闸的话，disableCloud() 刚摘掉的
+            // 监听器会被这次迟到的 onOpen 原样装回去——「谁都不是所有者」的毛病换个地方重现。
+            PluginInitiationUtils.disableCloud();
+
+            PluginInitiationUtils.initializeManagers();
+
+            Mockito.verify(UltiTools.getInstance(), Mockito.never()).getServerMonitorManager();
+            assertThat(loggedAt(Level.FINE))
+                    .anySatisfy(line -> assertThat(line).contains("跳过管理器初始化"));
+        }
+
+        @Test
+        @DisplayName("云开启时照常接线")
+        void managersAreWiredWhenCloudEnabled() {
+            // 负向对照：闸门只该拦住关闭态，正常路径必须原样通过。
+            PluginInitiationUtils.enableCloud();
+
+            PluginInitiationUtils.initializeManagers();
+
+            Mockito.verify(UltiTools.getInstance(), Mockito.atLeastOnce()).getServerMonitorManager();
+        }
+    }
+
     /** 数一数 JVM root logger 上挂了几个本框架的 handler。 */
     private static int countFrameworkHandlersOnRootLogger() {
         int count = 0;

--- a/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
@@ -31,6 +31,7 @@ import com.ultikits.ultitools.manager.LogStreamManager;
  * 于是 logout 之后插件仍在拿已作废的凭证持续敲面板。
  */
 @DisplayName("云连接重连状态机")
+@SuppressWarnings("PMD.AvoidAccessibilityAlteration") // 测试需要反射读写内部状态，与仓库其它测试类一致
 class CloudReconnectStateMachineTest {
 
     private Logger mockLogger;

--- a/src/test/java/com/ultikits/ultitools/utils/PluginInitiationUtilsWebSocketTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/PluginInitiationUtilsWebSocketTest.java
@@ -194,9 +194,13 @@ class PluginInitiationUtilsWebSocketTest {
         @DisplayName("initializeManagers 方法应该存在")
         void initializeManagersMethodShouldExist() throws NoSuchMethodException {
             Method method = PluginInitiationUtils.class.getDeclaredMethod("initializeManagers");
-            
+
             assertThat(Modifier.isStatic(method.getModifiers())).isTrue();
-            assertThat(Modifier.isPrivate(method.getModifiers())).isTrue();
+            // 包级可见（PR #264 起）：cloudEnabled 闸门需要被单元测试直接驱动。
+            // 仍然不是 public —— 它不是对外 API。
+            assertThat(Modifier.isPrivate(method.getModifiers())).isFalse();
+            assertThat(Modifier.isPublic(method.getModifiers())).isFalse();
+            assertThat(Modifier.isProtected(method.getModifiers())).isFalse();
         }
 
         @Test


### PR DESCRIPTION
Closes #180

## 两个缺陷

**身份写死。** `getServerId()` 返回的是一个写死的占位字符串，注释还留着「这里应该返回配置中的服务器ID」。结果是全球每台 UltiTools 服务器发出的 `player_event` 都自称同一身份，面板侧无法路由。

改成 `webSocketClient.getServerId()`。这不是随便挑的——`ServerMonitorManager`、`CommandExecutionManager`、`FileOperationManager`、`ServerPropertiesManager` 全都用它，`PlayerEventManager` 是唯一的例外。而这个值就是建连时传进去的 `CommonUtils.getUltiToolsUUID()`（见 `PluginInitiationUtils.getPanelWebsocketClient`），所以它天然不会和面板认证用的那份漂移。

**重复注册。** `initialize()` 由 `initializeManagers()` 调用，而后者挂在 `onConnectHandler` 上——**每次 onOpen 都会跑一遍**。`registerEvents` 没有任何守卫，于是断线重连 N 次之后，同一个玩家事件被发 N 份。

加 `listenerRegistered` 守卫。注意客户端引用仍然无条件更新：每次重连 `PluginInitiationUtils` 都会造一个**新的**客户端实例，守卫只该挡住重复注册，不该顺带把引用也冻住——这一点有单独的测试钉住。

另补 `shutdown()`，在 `disableCloud()`（即 `/ulticloud logout`）时把监听器真的摘掉。事件处理器里那句 `isConnected()` 判断只是让它不发消息，监听本身还在跑。

## 测试

新增 8 条。关键点是**走 Bukkit 真实的事件分发**，而不是像既有的 `PlayerEventManagerTest` 那样反射塞字段、手工调处理器方法——重复注册这种缺陷只有让事件真的过一遍 `HandlerList` 才看得见。

踩了一个坑值得记：`ServerMock.addPlayer()` 自己就会派发 `PlayerJoinEvent`，我一开始还手工 `callEvent` 了一次，两个事件看起来和「注册了两份监听器」一模一样。

**负向对照已做**：拆掉守卫 + 还原写死常量之后，8 条里 4 条失败（`ServerIdentity` 全挂，`RegistrationIdempotency` 挂 2 条）。恢复后 8/8 通过。

验收里那句 `grep -rn 'minecraft-server-1' src/main/java` 现在无命中——顺带把 javadoc 里的字面引用也改成了描述性措辞，免得 grep 假阳性。测试里保留了 `.isNotEqualTo(...)` 那句断言，它在 `src/test/java`，正是钉住回归的地方。

总测试数 4202 → 4210。`mvn clean verify` 通过。

## 顺带记一笔（不在本 PR 范围）

`initialize()` 是在 WebSocket 的 onOpen 线程上跑的，也就是说 `registerEvents` 是**非主线程**调用 Bukkit API。这与 #179 是同一类问题，留给那条一并处理，本 PR 不扩大范围。

另外 `LogStreamManager.getServerId()` 走的是 `CommonUtils.getUltiToolsUUID()` 而非客户端那份，两者今天等价，但它是唯一一个不跟兄弟们走同一条路的——不影响正确性，先不动。