### PR TITLE
fix(websocket): 服务器状态采样搬到主线程，异步线程只负责发送

### DIFF
--- a/src/main/java/com/ultikits/ultitools/manager/ServerMonitorManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/ServerMonitorManager.java
@@ -355,12 +355,14 @@ public class ServerMonitorManager {
             plugins.add(pluginInfo);
         }
 
+        // 计数一律取自上面刚构造好的数组，而不是再问一次 Bukkit：既少两次遍历，
+        // 也让「playerCount 与 onlinePlayers 长度一致」由构造保证，而不是靠「同一 tick 内不会变」这条推理。
         return new ServerStateSnapshot(
-                Bukkit.getOnlinePlayers().size(),
+                onlinePlayers.size(),
                 Bukkit.getMaxPlayers(),
                 Bukkit.getOnlineMode(),
                 extractVersionNumber(Bukkit.getVersion()),
-                Bukkit.getWorlds().size(),
+                worlds.size(),
                 plugins.size(),
                 worlds,
                 onlinePlayers,

--- a/src/main/java/com/ultikits/ultitools/manager/ServerMonitorManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/ServerMonitorManager.java
@@ -433,8 +433,9 @@ public class ServerMonitorManager {
                 stateSnapshot = snapshot;
             }
         } catch (Exception e) {
+            // 与 cancelTask 保持一致：异常交给 logger，不在调用点拼 getMessage()。
             UltiTools.getInstance().getLogger().log(Level.WARNING,
-                "[ServerMonitor] 采样服务器状态失败: " + e.getMessage(), e);
+                "[ServerMonitor] 采样服务器状态失败", e);
         }
     }
 

--- a/src/main/java/com/ultikits/ultitools/manager/ServerMonitorManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/ServerMonitorManager.java
@@ -38,9 +38,66 @@ public class ServerMonitorManager {
 
     // CPU采样（在Bukkit主线程定期采样，batch_update线程读取）
     private volatile double lastCpuUsage = 0.0;
-    
+
+    /** 世界/玩家/插件状态的采样周期，单位 tick。100 tick = 5 秒，与 batch_update 的发送节拍一致。 */
+    private static final long SNAPSHOT_INTERVAL_TICKS = 100L;
+
+    /**
+     * 主线程采出来的服务器状态快照，异步发送线程只读它。
+     * <p>
+     * <b>这是 issue #179 的全部要点。</b>在它存在之前，{@code sendBatchUpdate} 跑在普通
+     * {@code ScheduledThreadPool} 上，却在那里直接调 {@code Bukkit.getWorlds()}、
+     * {@code world.getLoadedChunks()}、{@code Bukkit.getOnlinePlayers()}、
+     * {@code player.getLocation()} —— 全是 Paper 明确不支持在异步线程上碰的可变世界状态，
+     * 表现为偶发的并发修改异常或读到撕裂的数据。
+     * <p>
+     * 同一个类里的 TPS/CPU 采样<b>已经</b>正确地 hop 到了 {@code runTaskTimer}，说明契约当时
+     * 就被识别到了，只是只应用了一半。本字段把剩下那一半补齐，沿用完全相同的模式。
+     * <p>
+     * 代价是数据最多陈旧一个采样周期（5 秒）。这是刻意选的：另一条路是让异步线程用
+     * {@code callSyncMethod().get()} 同步等主线程，那会让监控的存活依赖主线程的健康度，
+     * 而服务器卡顿时恰恰是最需要监控还能说话的时候。
+     */
+    private volatile ServerStateSnapshot stateSnapshot = ServerStateSnapshot.EMPTY;
+
     public ServerMonitorManager() {
         this.scheduler = Executors.newScheduledThreadPool(2);
+    }
+
+    /**
+     * 一次主线程采样的结果。字段全部 final，构造完成后不再改动，通过 volatile 字段发布，
+     * 因此读线程看到的要么是上一份完整快照、要么是这一份完整快照，不会看到半份。
+     * <p>
+     * 其中三个 {@link JsonArray} 在发布之后<b>绝不可再被修改</b>——它们会被直接塞进待发送的
+     * 消息里，序列化只读不写，所以共享实例是安全的；一旦有人在发布后 add 一笔，这个前提就没了。
+     */
+    private static final class ServerStateSnapshot {
+        static final ServerStateSnapshot EMPTY = new ServerStateSnapshot(
+                0, 0, false, "Unknown", 0, 0, new JsonArray(), new JsonArray(), new JsonArray());
+
+        final int playerCount;
+        final int maxPlayers;
+        final boolean onlineMode;
+        final String serverVersion;
+        final int worldCount;
+        final int pluginCount;
+        final JsonArray worlds;
+        final JsonArray onlinePlayers;
+        final JsonArray plugins;
+
+        ServerStateSnapshot(int playerCount, int maxPlayers, boolean onlineMode, String serverVersion,
+                            int worldCount, int pluginCount,
+                            JsonArray worlds, JsonArray onlinePlayers, JsonArray plugins) {
+            this.playerCount = playerCount;
+            this.maxPlayers = maxPlayers;
+            this.onlineMode = onlineMode;
+            this.serverVersion = serverVersion;
+            this.worldCount = worldCount;
+            this.pluginCount = pluginCount;
+            this.worlds = worlds;
+            this.onlinePlayers = onlinePlayers;
+            this.plugins = plugins;
+        }
     }
     
     /**
@@ -76,10 +133,18 @@ public class ServerMonitorManager {
         }
 
         // 每5秒发送一次batch_update（包含status、metrics，每12个tick包含plugins，每次包含logs）
+        // 注意：这条线程**只负责发送**，一切 Bukkit 状态都来自主线程采好的快照。见 issue #179。
         scheduler.scheduleAtFixedRate(this::sendBatchUpdate, 5, 5, TimeUnit.SECONDS);
 
         // 启动TPS计算 + CPU采样任务（每秒）
         Bukkit.getScheduler().runTaskTimer(UltiTools.getInstance(), this::updateTpsAndCpu, 0L, 20L);
+
+        // 世界/玩家/插件状态的采样任务（每5秒，主线程）。
+        // 刻意不并进上面那个 1Hz 的任务：world.getLoadedChunks() 会分配一个装下所有已加载区块
+        // 的数组，大服上并不便宜，按 1Hz 采就是凭空把这份开销放大 5 倍。100 tick 与今天实际的
+        // 采样频率一致，只是换到了正确的线程上。
+        Bukkit.getScheduler().runTaskTimer(UltiTools.getInstance(), this::refreshStateSnapshot,
+                0L, SNAPSHOT_INTERVAL_TICKS);
     }
     
     /**
@@ -116,10 +181,12 @@ public class ServerMonitorManager {
             // 发送消息
             webSocketClient.sendMessage(message);
             
-            UltiTools.getInstance().getLogger().log(Level.FINE, 
-                String.format("已发送服务器状态: 玩家 %d/%d, TPS %.1f, 内存 %dMB/%dMB", 
-                    Bukkit.getOnlinePlayers().size(), Bukkit.getMaxPlayers(),
-                    calculateTPS()[0], 
+            // 日志里的玩家数同样取自快照——这句也跑在异步线程上，直接读 Bukkit 是同一个毛病。
+            ServerStateSnapshot snapshot = currentSnapshot();
+            UltiTools.getInstance().getLogger().log(Level.FINE,
+                String.format("已发送服务器状态: 玩家 %d/%d, TPS %.1f, 内存 %dMB/%dMB",
+                    snapshot.playerCount, snapshot.maxPlayers,
+                    calculateTPS()[0],
                     (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1024 / 1024,
                     Runtime.getRuntime().maxMemory() / 1024 / 1024));
             
@@ -219,21 +286,141 @@ public class ServerMonitorManager {
     }
     
     /**
+     * 在主线程上采一份服务器状态快照。
+     * <p>
+     * <b>只能在 Bukkit 主线程调用。</b>非主线程调用会被拒绝并记 SEVERE —— 这是防御性的第二道
+     * 闸：调度已经保证了线程，但这个类的历史正是「契约被识别了，只应用了一半」，把契约写进
+     * 代码里比写进注释里可靠。
+     *
+     * @return 新的快照；若不在主线程则返回 {@code null}
+     */
+    private ServerStateSnapshot sampleServerState() {
+        if (!Bukkit.isPrimaryThread()) {
+            UltiTools.getInstance().getLogger().log(Level.SEVERE,
+                "[ServerMonitor] 试图在非主线程上采样 Bukkit 状态，已拒绝。这是一个编程错误，请检查调度。");
+            return null;
+        }
+
+        JsonArray worlds = new JsonArray();
+        for (World world : Bukkit.getWorlds()) {
+            JsonObject worldObj = new JsonObject();
+            worldObj.addProperty("name", world.getName());
+            worldObj.addProperty("environment", world.getEnvironment().name());
+            worldObj.addProperty("difficulty", world.getDifficulty().name());
+            worldObj.addProperty("playerCount", world.getPlayers().size());
+            worldObj.addProperty("loadedChunks", world.getLoadedChunks().length);
+            worldObj.addProperty("pvpEnabled", world.getPVP());
+
+            JsonObject spawnLoc = new JsonObject();
+            spawnLoc.addProperty("x", world.getSpawnLocation().getBlockX());
+            spawnLoc.addProperty("y", world.getSpawnLocation().getBlockY());
+            spawnLoc.addProperty("z", world.getSpawnLocation().getBlockZ());
+            worldObj.add("spawnLocation", spawnLoc);
+
+            worlds.add(worldObj);
+        }
+
+        JsonArray onlinePlayers = new JsonArray();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            JsonObject playerObj = new JsonObject();
+            playerObj.addProperty("uuid", player.getUniqueId().toString());
+            playerObj.addProperty("name", player.getName());
+            playerObj.addProperty("world", player.getWorld().getName());
+            Location loc = player.getLocation();
+            playerObj.addProperty("x", Math.round(loc.getX() * 10.0) / 10.0);
+            playerObj.addProperty("y", Math.round(loc.getY() * 10.0) / 10.0);
+            playerObj.addProperty("z", Math.round(loc.getZ() * 10.0) / 10.0);
+            playerObj.addProperty("health", player.getHealth());
+            playerObj.addProperty("maxHealth", player.getMaxHealth());
+            playerObj.addProperty("foodLevel", player.getFoodLevel());
+            playerObj.addProperty("gameMode", player.getGameMode().name());
+            playerObj.addProperty("op", player.isOp());
+            onlinePlayers.add(playerObj);
+        }
+
+        JsonArray plugins = new JsonArray();
+        for (Plugin plugin : Bukkit.getPluginManager().getPlugins()) {
+            JsonObject pluginInfo = new JsonObject();
+            pluginInfo.addProperty("name", plugin.getName());
+            pluginInfo.addProperty("version", plugin.getDescription().getVersion());
+            pluginInfo.addProperty("enabled", plugin.isEnabled());
+
+            if (plugin.getDescription().getAuthors() != null && !plugin.getDescription().getAuthors().isEmpty()) {
+                pluginInfo.addProperty("author", String.join(", ", plugin.getDescription().getAuthors()));
+            } else {
+                pluginInfo.addProperty("author", "Unknown");
+            }
+
+            pluginInfo.addProperty("description", plugin.getDescription().getDescription());
+            plugins.add(pluginInfo);
+        }
+
+        return new ServerStateSnapshot(
+                Bukkit.getOnlinePlayers().size(),
+                Bukkit.getMaxPlayers(),
+                Bukkit.getOnlineMode(),
+                extractVersionNumber(Bukkit.getVersion()),
+                Bukkit.getWorlds().size(),
+                plugins.size(),
+                worlds,
+                onlinePlayers,
+                plugins);
+    }
+
+    /**
+     * 主线程定时任务的入口：采样并发布快照。
+     * <p>
+     * 包级可见，供测试直接驱动。
+     */
+    void refreshStateSnapshot() {
+        try {
+            ServerStateSnapshot snapshot = sampleServerState();
+            if (snapshot != null) {
+                stateSnapshot = snapshot;
+            }
+        } catch (Exception e) {
+            UltiTools.getInstance().getLogger().log(Level.WARNING,
+                "[ServerMonitor] 采样服务器状态失败: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 取当前快照供发送线程使用。
+     * <p>
+     * 若还一次都没采过、而调用方恰好就在主线程上，就地补采一次——否则连接建立后的第一帧
+     * 会是一片零，以及 {@code sendServerStatusWithRequestId} 这类按需请求在监控启动前会返回空数据。
+     */
+    private ServerStateSnapshot currentSnapshot() {
+        ServerStateSnapshot snapshot = stateSnapshot;
+        if (snapshot == ServerStateSnapshot.EMPTY && Bukkit.isPrimaryThread()) {
+            ServerStateSnapshot sampled = sampleServerState();
+            if (sampled != null) {
+                stateSnapshot = sampled;
+                return sampled;
+            }
+        }
+        return snapshot;
+    }
+
+    /**
      * 获取当前服务器状态数据
+     * <p>
+     * 所有 Bukkit 派生的字段都取自主线程采好的快照（见 {@link #stateSnapshot}）；
+     * 本方法本身可以在任意线程调用。Runtime 内存、JVM 运行时长、TPS、CPU 不属于 Bukkit 状态，
+     * 就地读取即可——TPS 与 CPU 早已由主线程的 1Hz 任务维护。
      */
     private JsonObject getCurrentServerStatusData() {
+        ServerStateSnapshot snapshot = currentSnapshot();
         JsonObject data = new JsonObject();
-        
+
         // 玩家信息
-        data.addProperty("playerCount", Bukkit.getOnlinePlayers().size());
-        data.addProperty("maxPlayers", Bukkit.getMaxPlayers());
-        data.addProperty("onlineMode", Bukkit.getOnlineMode());
-        
+        data.addProperty("playerCount", snapshot.playerCount);
+        data.addProperty("maxPlayers", snapshot.maxPlayers);
+        data.addProperty("onlineMode", snapshot.onlineMode);
+
         // 服务器版本信息
-        String version = Bukkit.getVersion();
-        String serverVersion = extractVersionNumber(version);
-        data.addProperty("serverVersion", serverVersion);
-        
+        data.addProperty("serverVersion", snapshot.serverVersion);
+
         // TPS信息
         JsonArray tpsArray = new JsonArray();
         double[] tps = calculateTPS();
@@ -262,46 +449,11 @@ public class ServerMonitorManager {
         // 运行时间
         data.addProperty("uptime", ManagementFactory.getRuntimeMXBean().getUptime());
         
-        // 世界列表 (enriched objects)
-        JsonArray worlds = new JsonArray();
-        for (World world : Bukkit.getWorlds()) {
-            JsonObject worldObj = new JsonObject();
-            worldObj.addProperty("name", world.getName());
-            worldObj.addProperty("environment", world.getEnvironment().name());
-            worldObj.addProperty("difficulty", world.getDifficulty().name());
-            worldObj.addProperty("playerCount", world.getPlayers().size());
-            worldObj.addProperty("loadedChunks", world.getLoadedChunks().length);
-            worldObj.addProperty("pvpEnabled", world.getPVP());
+        // 世界列表 (enriched objects) —— 主线程采样，此处只引用
+        data.add("worlds", snapshot.worlds);
 
-            JsonObject spawnLoc = new JsonObject();
-            spawnLoc.addProperty("x", world.getSpawnLocation().getBlockX());
-            spawnLoc.addProperty("y", world.getSpawnLocation().getBlockY());
-            spawnLoc.addProperty("z", world.getSpawnLocation().getBlockZ());
-            worldObj.add("spawnLocation", spawnLoc);
-
-            worlds.add(worldObj);
-        }
-        data.add("worlds", worlds);
-
-        // Online player details
-        JsonArray onlinePlayers = new JsonArray();
-        for (Player player : Bukkit.getOnlinePlayers()) {
-            JsonObject playerObj = new JsonObject();
-            playerObj.addProperty("uuid", player.getUniqueId().toString());
-            playerObj.addProperty("name", player.getName());
-            playerObj.addProperty("world", player.getWorld().getName());
-            Location loc = player.getLocation();
-            playerObj.addProperty("x", Math.round(loc.getX() * 10.0) / 10.0);
-            playerObj.addProperty("y", Math.round(loc.getY() * 10.0) / 10.0);
-            playerObj.addProperty("z", Math.round(loc.getZ() * 10.0) / 10.0);
-            playerObj.addProperty("health", player.getHealth());
-            playerObj.addProperty("maxHealth", player.getMaxHealth());
-            playerObj.addProperty("foodLevel", player.getFoodLevel());
-            playerObj.addProperty("gameMode", player.getGameMode().name());
-            playerObj.addProperty("op", player.isOp());
-            onlinePlayers.add(playerObj);
-        }
-        data.add("onlinePlayers", onlinePlayers);
+        // Online player details —— 同上
+        data.add("onlinePlayers", snapshot.onlinePlayers);
 
         return data;
     }
@@ -364,39 +516,26 @@ public class ServerMonitorManager {
 
     /**
      * 获取当前插件列表数组
+     * <p>
+     * 取自主线程采好的快照。{@code Bukkit.getPluginManager().getPlugins()} 同样不该在异步线程上遍历。
      */
     private JsonArray getCurrentPluginArray() {
-        JsonArray plugins = new JsonArray();
-
-        for (Plugin plugin : Bukkit.getPluginManager().getPlugins()) {
-            JsonObject pluginInfo = new JsonObject();
-            pluginInfo.addProperty("name", plugin.getName());
-            pluginInfo.addProperty("version", plugin.getDescription().getVersion());
-            pluginInfo.addProperty("enabled", plugin.isEnabled());
-
-            if (plugin.getDescription().getAuthors() != null && !plugin.getDescription().getAuthors().isEmpty()) {
-                pluginInfo.addProperty("author", String.join(", ", plugin.getDescription().getAuthors()));
-            } else {
-                pluginInfo.addProperty("author", "Unknown");
-            }
-
-            pluginInfo.addProperty("description", plugin.getDescription().getDescription());
-            plugins.add(pluginInfo);
-        }
-
-        return plugins;
+        return currentSnapshot().plugins;
     }
 
     /**
      * 获取当前性能统计数据
+     * <p>
+     * Bukkit 派生的字段取自快照；Runtime 内存与 TPS 就地计算。
      */
     private JsonObject getCurrentMetricsData() {
+        ServerStateSnapshot snapshot = currentSnapshot();
         JsonObject data = new JsonObject();
 
         // 玩家活动统计
         JsonObject playerActivity = new JsonObject();
-        playerActivity.addProperty("currentOnline", Bukkit.getOnlinePlayers().size());
-        playerActivity.addProperty("maxPlayers", Bukkit.getMaxPlayers());
+        playerActivity.addProperty("currentOnline", snapshot.playerCount);
+        playerActivity.addProperty("maxPlayers", snapshot.maxPlayers);
         data.add("playerActivity", playerActivity);
 
         // 服务器性能
@@ -421,8 +560,8 @@ public class ServerMonitorManager {
 
         // 插件使用情况
         JsonObject pluginUsage = new JsonObject();
-        pluginUsage.addProperty("enabledPlugins", Bukkit.getPluginManager().getPlugins().length);
-        pluginUsage.addProperty("loadedWorlds", Bukkit.getWorlds().size());
+        pluginUsage.addProperty("enabledPlugins", snapshot.pluginCount);
+        pluginUsage.addProperty("loadedWorlds", snapshot.worldCount);
         data.add("pluginUsage", pluginUsage);
 
         return data;

--- a/src/main/java/com/ultikits/ultitools/manager/ServerMonitorManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/ServerMonitorManager.java
@@ -9,6 +9,7 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
@@ -59,6 +60,10 @@ public class ServerMonitorManager {
      * 而服务器卡顿时恰恰是最需要监控还能说话的时候。
      */
     private volatile ServerStateSnapshot stateSnapshot = ServerStateSnapshot.EMPTY;
+
+    /** 主线程上的两个定时任务，{@link #stopMonitoring()} 需要能取消它们。 */
+    private BukkitTask tpsTask;
+    private BukkitTask snapshotTask;
 
     public ServerMonitorManager() {
         this.scheduler = Executors.newScheduledThreadPool(2);
@@ -137,27 +142,47 @@ public class ServerMonitorManager {
         scheduler.scheduleAtFixedRate(this::sendBatchUpdate, 5, 5, TimeUnit.SECONDS);
 
         // 启动TPS计算 + CPU采样任务（每秒）
-        Bukkit.getScheduler().runTaskTimer(UltiTools.getInstance(), this::updateTpsAndCpu, 0L, 20L);
+        tpsTask = Bukkit.getScheduler().runTaskTimer(UltiTools.getInstance(), this::updateTpsAndCpu, 0L, 20L);
 
         // 世界/玩家/插件状态的采样任务（每5秒，主线程）。
         // 刻意不并进上面那个 1Hz 的任务：world.getLoadedChunks() 会分配一个装下所有已加载区块
         // 的数组，大服上并不便宜，按 1Hz 采就是凭空把这份开销放大 5 倍。100 tick 与今天实际的
         // 采样频率一致，只是换到了正确的线程上。
-        Bukkit.getScheduler().runTaskTimer(UltiTools.getInstance(), this::refreshStateSnapshot,
+        snapshotTask = Bukkit.getScheduler().runTaskTimer(UltiTools.getInstance(), this::refreshStateSnapshot,
                 0L, SNAPSHOT_INTERVAL_TICKS);
     }
-    
+
     /**
      * 停止监控
+     * <p>
+     * 除了关掉发送线程，还要取消两个主线程定时任务。原先这里只 {@code scheduler.shutdown()}，
+     * 那在采样搬到主线程<b>之前</b>是够的——遍历世界那份开销本来就长在发送线程上，关掉发送
+     * 就一起没了。搬家之后不取消的话，「停止监控」会变成「不再发送、但照样每 5 秒遍历一遍
+     * 所有世界和区块」，而且是在主线程上。见 PR #265 的评审。
      */
     public void stopMonitoring() {
         if (!isMonitoring) {
             return;
         }
-        
+
         isMonitoring = false;
+        cancelTask(snapshotTask);
+        snapshotTask = null;
+        cancelTask(tpsTask);
+        tpsTask = null;
         scheduler.shutdown();
         UltiTools.getInstance().getLogger().log(Level.INFO, "停止服务器状态监控");
+    }
+
+    private static void cancelTask(BukkitTask task) {
+        if (task != null) {
+            try {
+                task.cancel();
+            } catch (Exception e) {
+                UltiTools.getInstance().getLogger().log(Level.FINE,
+                    "取消监控任务时出错: " + e.getMessage());
+            }
+        }
     }
     
     /**
@@ -295,9 +320,7 @@ public class ServerMonitorManager {
      * @return 新的快照；若不在主线程则返回 {@code null}
      */
     private ServerStateSnapshot sampleServerState() {
-        if (!Bukkit.isPrimaryThread()) {
-            UltiTools.getInstance().getLogger().log(Level.SEVERE,
-                "[ServerMonitor] 试图在非主线程上采样 Bukkit 状态，已拒绝。这是一个编程错误，请检查调度。");
+        if (!isOnPrimaryThreadOrComplain()) {
             return null;
         }
 
@@ -370,11 +393,39 @@ public class ServerMonitorManager {
     }
 
     /**
+     * 线程契约的唯一检查点：不在主线程就记 SEVERE 并返回 false。
+     * <p>
+     * 这个类的历史正是「契约被识别了，只应用了一半」，所以把契约写成运行时可观测的信号，
+     * 比写进注释可靠——真机上只要日志里出现这句，就说明调度被改错了。
+     */
+    private boolean isOnPrimaryThreadOrComplain() {
+        if (Bukkit.isPrimaryThread()) {
+            return true;
+        }
+        UltiTools.getInstance().getLogger().log(Level.SEVERE,
+            "[ServerMonitor] 试图在非主线程上采样 Bukkit 状态，已拒绝。这是一个编程错误，请检查调度。");
+        return false;
+    }
+
+    /**
      * 主线程定时任务的入口：采样并发布快照。
      * <p>
      * 包级可见，供测试直接驱动。
      */
     void refreshStateSnapshot() {
+        // 线程契约的检查放在连接判断**之前**：断连时也要抓得住「跑错线程」这件事，
+        // 否则这道防御闸在最需要它的场景（连不上、于是走到各种异常路径）反而是哑的。
+        if (!isOnPrimaryThreadOrComplain()) {
+            return;
+        }
+
+        // 没有连接就不采样。这一条不是省电，是保持修复前的行为：原先 sendBatchUpdate 在
+        // !isConnected 时是**先返回、再遍历**的，所以永久断连的服务器一次遍历都不做。
+        // 采样搬到主线程之后若不带上这个判断，断连反而变成了每 5 秒白遍历一遍所有世界和区块。
+        // 见 PR #265 的评审。
+        if (webSocketClient == null || !webSocketClient.isConnected()) {
+            return;
+        }
         try {
             ServerStateSnapshot snapshot = sampleServerState();
             if (snapshot != null) {
@@ -384,6 +435,11 @@ public class ServerMonitorManager {
             UltiTools.getInstance().getLogger().log(Level.WARNING,
                 "[ServerMonitor] 采样服务器状态失败: " + e.getMessage(), e);
         }
+    }
+
+    /** 供测试断言「到底采过样没有」——比从外部观察发出去的 JSON 更直接。 */
+    boolean hasSampledState() {
+        return stateSnapshot != ServerStateSnapshot.EMPTY;
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/manager/ServerMonitorManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/ServerMonitorManager.java
@@ -179,8 +179,9 @@ public class ServerMonitorManager {
             try {
                 task.cancel();
             } catch (Exception e) {
-                UltiTools.getInstance().getLogger().log(Level.FINE,
-                    "取消监控任务时出错: " + e.getMessage());
+                // 把异常本身交给 logger 而不是拼 getMessage()：既保住栈，也避免在日志调用点
+                // 无条件做字符串拼接（PMD 的 PreserveStackTrace / GuardLogStatement 都盯这一点）。
+                UltiTools.getInstance().getLogger().log(Level.FINE, "取消监控任务时出错", e);
             }
         }
     }

--- a/src/test/java/com/ultikits/ultitools/manager/ServerMonitorSnapshotTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ServerMonitorSnapshotTest.java
@@ -1,0 +1,293 @@
+package com.ultikits.ultitools.manager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.bukkit.Bukkit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.ArgumentCaptor;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.ultikits.ultitools.UltiTools;
+import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+/**
+ * 服务器状态采样的线程契约（issue #179）。
+ *
+ * <p>在这之前，{@code sendBatchUpdate} 跑在普通 {@code ScheduledThreadPool} 上，却在那里直接调
+ * {@code Bukkit.getWorlds()}、{@code world.getLoadedChunks()}、{@code Bukkit.getOnlinePlayers()}、
+ * {@code player.getLocation()}——全是 Paper 明确不支持在异步线程上碰的可变世界状态。
+ * 同一个类里的 TPS/CPU 采样早就正确地 hop 到了主线程，说明契约当时就被识别到了，只应用了一半。
+ *
+ * <p>这里钉住三件事：采样只在主线程发生；异步发送路径读的是快照而不是活的 Bukkit 状态；
+ * 以及重构没有改变发给面板的 JSON 形状。最后一条最要紧——面板那边靠这些字段名工作，
+ * 而这次改动把整段构造代码搬了家。
+ */
+@DisplayName("服务器状态采样的线程契约")
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+class ServerMonitorSnapshotTest {
+
+    private ServerMock server;
+    private ServerMonitorManager manager;
+    private UltiPanelWebSocketClient mockClient;
+    private Logger mockLogger;
+
+    @BeforeEach
+    void setUp() {
+        com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
+        server = MockBukkit.mock();
+        MockBukkit.createMockPlugin();
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
+
+        // MockBukkit 默认一个世界都没有，而 worlds 数组正是本次改动搬家的重点之一，
+        // 没有世界的话形状断言会变成空转。
+        server.addSimpleWorld("world");
+
+        mockLogger = mock(Logger.class);
+        when(UltiTools.getInstance().getLogger()).thenReturn(mockLogger);
+
+        mockClient = mock(UltiPanelWebSocketClient.class);
+        when(mockClient.isConnected()).thenReturn(true);
+        when(mockClient.getServerId()).thenReturn("test-server");
+
+        manager = new ServerMonitorManager();
+        manager.setWebSocketClient(mockClient);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (manager != null) {
+            manager.stopMonitoring();
+        }
+        com.ultikits.ultitools.utils.MockBukkitHelper.safeUnmock();
+    }
+
+    /** 在一条非主线程上跑给定动作，并把抛出的异常带回来。 */
+    private void runOffPrimaryThread(Runnable action) throws InterruptedException {
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Thread worker = new Thread(() -> {
+            try {
+                assertThat(Bukkit.isPrimaryThread())
+                        .as("这条线程必须不是主线程，否则整个用例失去意义")
+                        .isFalse();
+                action.run();
+            } catch (Throwable t) {
+                thrown.set(t);
+            }
+        }, "off-primary-test-thread");
+        worker.start();
+        worker.join(10_000);
+        if (thrown.get() != null) {
+            throw new AssertionError("非主线程上的动作抛异常了", thrown.get());
+        }
+    }
+
+    /** 抓取发往面板的 server_status 消息里的 data 段。 */
+    private JsonObject captureStatusData() {
+        ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
+        verify(mockClient, atLeastOnce()).sendMessage(captor.capture());
+        return captor.getValue().getAsJsonObject("data");
+    }
+
+    @Nested
+    @DisplayName("采样只在主线程发生")
+    class SamplingThreadContract {
+
+        @Test
+        @DisplayName("测试线程就是 MockBukkit 认的主线程")
+        void testThreadIsPrimary() {
+            // 这条是给下面所有用例做的前置断言：如果 MockBukkit 不把测试线程当主线程，
+            // 「主线程 / 非主线程」的对比就全部失效，那时候失败的应该是这一条而不是别的。
+            assertThat(Bukkit.isPrimaryThread()).isTrue();
+        }
+
+        @Test
+        @DisplayName("主线程上采样会填充快照")
+        void samplingOnPrimaryThreadPopulatesSnapshot() {
+            server.addPlayer();
+            server.addPlayer();
+
+            manager.refreshStateSnapshot();
+
+            // 从非主线程发送，确保读到的只可能是快照
+            manager.sendServerStatus();
+            assertThat(captureStatusData().get("playerCount").getAsInt()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("非主线程上采样被拒绝，并记 SEVERE")
+        void samplingOffPrimaryThreadIsRefused() throws InterruptedException {
+            server.addPlayer();
+
+            runOffPrimaryThread(manager::refreshStateSnapshot);
+
+            verify(mockLogger).log(eq(Level.SEVERE), anyString());
+
+            // 快照没被填上：异步读到的仍然是空的那份
+            runOffPrimaryThread(manager::sendServerStatus);
+            assertThat(captureStatusData().get("playerCount").getAsInt())
+                    .as("被拒绝的采样不该留下任何痕迹")
+                    .isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("异步发送读的是快照，不是活的 Bukkit 状态")
+    class AsyncPathReadsSnapshot {
+
+        @Test
+        @DisplayName("采样之后世界变了，异步发送仍然报采样时刻的值")
+        void asyncSendReportsSnapshotNotLiveState() throws InterruptedException {
+            server.addPlayer();
+            manager.refreshStateSnapshot();     // 主线程采样：此刻 1 人
+
+            server.addPlayer();
+            server.addPlayer();                 // 活的 Bukkit 现在是 3 人，但没有重新采样
+
+            runOffPrimaryThread(manager::sendServerStatus);
+
+            assertThat(captureStatusData().get("playerCount").getAsInt())
+                    .as("报 3 就说明异步线程直接读了 Bukkit——正是本 issue 要消灭的行为")
+                    .isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("从未采样时，异步发送不会就地去读 Bukkit")
+        void asyncSendDoesNotLazilySample() throws InterruptedException {
+            server.addPlayer();
+            server.addPlayer();
+            // 刻意不调 refreshStateSnapshot
+
+            runOffPrimaryThread(manager::sendServerStatus);
+
+            JsonObject data = captureStatusData();
+            assertThat(data.get("playerCount").getAsInt())
+                    .as("非主线程上宁可报空快照，也不能去读 Bukkit")
+                    .isZero();
+            assertThat(data.getAsJsonArray("worlds")).isEmpty();
+            assertThat(data.getAsJsonArray("onlinePlayers")).isEmpty();
+        }
+
+        @Test
+        @DisplayName("从未采样但当前就在主线程时，就地补采一次")
+        void primaryThreadLazilySamplesOnFirstUse() {
+            server.addPlayer();
+            server.addPlayer();
+            // 同样不调 refreshStateSnapshot，但这次在主线程上发送
+
+            manager.sendServerStatus();
+
+            assertThat(captureStatusData().get("playerCount").getAsInt())
+                    .as("否则连接建立后的第一帧会是一片零")
+                    .isEqualTo(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("发给面板的 JSON 形状没有变")
+    class PayloadContract {
+
+        @Test
+        @DisplayName("status 顶层字段齐全")
+        void statusKeysUnchanged() {
+            manager.refreshStateSnapshot();
+            manager.sendServerStatus();
+
+            assertThat(captureStatusData().keySet()).contains(
+                    "playerCount", "maxPlayers", "onlineMode", "serverVersion",
+                    "tps", "memory", "cpu", "uptime", "worlds", "onlinePlayers");
+        }
+
+        @Test
+        @DisplayName("worlds 元素字段齐全")
+        void worldObjectKeysUnchanged() {
+            manager.refreshStateSnapshot();
+            manager.sendServerStatus();
+
+            JsonArray worlds = captureStatusData().getAsJsonArray("worlds");
+            assertThat(worlds).as("MockBukkit 默认没有世界的话这条就没在测东西").isNotEmpty();
+            assertThat(worlds.get(0).getAsJsonObject().keySet()).containsExactlyInAnyOrder(
+                    "name", "environment", "difficulty", "playerCount",
+                    "loadedChunks", "pvpEnabled", "spawnLocation");
+        }
+
+        @Test
+        @DisplayName("onlinePlayers 元素字段齐全")
+        void playerObjectKeysUnchanged() {
+            server.addPlayer();
+            manager.refreshStateSnapshot();
+            manager.sendServerStatus();
+
+            JsonArray players = captureStatusData().getAsJsonArray("onlinePlayers");
+            assertThat(players).isNotEmpty();
+            assertThat(players.get(0).getAsJsonObject().keySet()).containsExactlyInAnyOrder(
+                    "uuid", "name", "world", "x", "y", "z",
+                    "health", "maxHealth", "foodLevel", "gameMode", "op");
+        }
+
+        @Test
+        @DisplayName("metrics 里的插件与世界计数取自快照")
+        void metricsCountsComeFromSnapshot() {
+            manager.refreshStateSnapshot();
+            manager.sendMetricsData();
+
+            ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
+            verify(mockClient, atLeastOnce()).sendMessage(captor.capture());
+            JsonObject pluginUsage = captor.getValue()
+                    .getAsJsonObject("data").getAsJsonObject("pluginUsage");
+
+            assertThat(pluginUsage.get("loadedWorlds").getAsInt())
+                    .isEqualTo(Bukkit.getWorlds().size());
+            assertThat(pluginUsage.get("enabledPlugins").getAsInt())
+                    .isEqualTo(Bukkit.getPluginManager().getPlugins().length);
+        }
+    }
+
+    @Nested
+    @DisplayName("采样失败不影响发送")
+    class Resilience {
+
+        @Test
+        @DisplayName("重复采样是安全的")
+        void repeatedSamplingIsSafe() {
+            server.addPlayer();
+            manager.refreshStateSnapshot();
+            manager.refreshStateSnapshot();
+            manager.refreshStateSnapshot();
+
+            manager.sendServerStatus();
+            assertThat(captureStatusData().get("playerCount").getAsInt()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("WebSocket 未连接时不发送")
+        void doesNotSendWhenDisconnected() {
+            when(mockClient.isConnected()).thenReturn(false);
+            manager.refreshStateSnapshot();
+
+            manager.sendServerStatus();
+
+            verify(mockClient, org.mockito.Mockito.never()).sendMessage(any(JsonObject.class));
+        }
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/manager/ServerMonitorSnapshotTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ServerMonitorSnapshotTest.java
@@ -45,6 +45,7 @@ import org.mockbukkit.mockbukkit.ServerMock;
  */
 @DisplayName("服务器状态采样的线程契约")
 @Timeout(value = 30, unit = TimeUnit.SECONDS)
+@SuppressWarnings("PMD.AvoidAccessibilityAlteration") // 测试需要反射读任务句柄，与仓库其它测试类一致
 class ServerMonitorSnapshotTest {
 
     private ServerMock server;
@@ -91,7 +92,9 @@ class ServerMonitorSnapshotTest {
                         .as("这条线程必须不是主线程，否则整个用例失去意义")
                         .isFalse();
                 action.run();
-            } catch (Throwable t) {
+            } catch (Exception | AssertionError t) {
+                // 精确到这两类：要带回来的是「动作失败」和「线程里的断言没过」，
+                // 顺手吞掉 OOM / StackOverflow 只会让失败更难看懂。
                 thrown.set(t);
             }
         }, "off-primary-test-thread");

--- a/src/test/java/com/ultikits/ultitools/manager/ServerMonitorSnapshotTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ServerMonitorSnapshotTest.java
@@ -246,6 +246,22 @@ class ServerMonitorSnapshotTest {
         }
 
         @Test
+        @DisplayName("playerCount 与 onlinePlayers 长度永远一致")
+        void playerCountMatchesPlayerArrayLength() {
+            server.addPlayer();
+            server.addPlayer();
+            server.addPlayer();
+            manager.refreshStateSnapshot();
+            manager.sendServerStatus();
+
+            JsonObject data = captureStatusData();
+            assertThat(data.get("playerCount").getAsInt())
+                    .as("两者由同一次采样的同一个数组导出，不该有分歧")
+                    .isEqualTo(data.getAsJsonArray("onlinePlayers").size())
+                    .isEqualTo(3);
+        }
+
+        @Test
         @DisplayName("metrics 里的插件与世界计数取自快照")
         void metricsCountsComeFromSnapshot() {
             manager.refreshStateSnapshot();

--- a/src/test/java/com/ultikits/ultitools/manager/ServerMonitorSnapshotTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ServerMonitorSnapshotTest.java
@@ -280,6 +280,73 @@ class ServerMonitorSnapshotTest {
     }
 
     @Nested
+    @DisplayName("断连与停止监控时不做无谓的主线程工作（#265 评审）")
+    class NoWorkWhenIdle {
+
+        @Test
+        @DisplayName("未连接时不采样")
+        void doesNotSampleWhileDisconnected() {
+            // 修复前 sendBatchUpdate 在 !isConnected 时是先返回、再遍历的，所以永久断连的
+            // 服务器一次遍历都不做。采样搬到主线程之后必须保住这个性质，否则断连反而变成了
+            // 每 5 秒白遍历一遍所有世界和区块——而且是在主线程上。
+            server.addPlayer();
+            when(mockClient.isConnected()).thenReturn(false);
+
+            manager.refreshStateSnapshot();
+
+            // 直接看快照有没有被填，而不是去看发出去的 JSON——后者会撞上「主线程惰性补采」
+            // 那条刻意保留的路径（见 primaryThreadLazilySamplesOnFirstUse），测错东西。
+            assertThat(manager.hasSampledState())
+                    .as("断连期间不该留下任何采样结果")
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("客户端为 null 时不采样也不抛异常")
+        void doesNotSampleWithoutClient() {
+            ServerMonitorManager fresh = new ServerMonitorManager();
+            server.addPlayer();
+
+            org.assertj.core.api.Assertions.assertThatCode(fresh::refreshStateSnapshot)
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("断连时线程契约的闸仍然有效")
+        void threadGuardStillFiresWhileDisconnected() throws InterruptedException {
+            // 线程检查排在连接判断之前：否则这道防御闸在最需要它的场景
+            //（连不上、于是走各种异常路径）反而是哑的。
+            when(mockClient.isConnected()).thenReturn(false);
+
+            runOffPrimaryThread(manager::refreshStateSnapshot);
+
+            verify(mockLogger).log(eq(Level.SEVERE), anyString());
+        }
+
+        @Test
+        @DisplayName("stopMonitoring 取消两个主线程定时任务")
+        void stopMonitoringCancelsMainThreadTasks() throws Exception {
+            manager.startMonitoring();
+
+            java.lang.reflect.Field snapshotField =
+                    ServerMonitorManager.class.getDeclaredField("snapshotTask");
+            java.lang.reflect.Field tpsField =
+                    ServerMonitorManager.class.getDeclaredField("tpsTask");
+            snapshotField.setAccessible(true);
+            tpsField.setAccessible(true);
+            assertThat(snapshotField.get(manager)).as("启动后应当持有任务句柄").isNotNull();
+            assertThat(tpsField.get(manager)).isNotNull();
+
+            manager.stopMonitoring();
+
+            assertThat(snapshotField.get(manager))
+                    .as("不取消的话，「停止监控」会变成「不再发送、但照样每 5 秒遍历所有世界」")
+                    .isNull();
+            assertThat(tpsField.get(manager)).isNull();
+        }
+    }
+
+    @Nested
     @DisplayName("采样失败不影响发送")
     class Resilience {
 


### PR DESCRIPTION
Closes #179

## 缺陷

`sendBatchUpdate` 跑在普通 `ScheduledThreadPool` 上（`startMonitoring` 里的 `scheduleAtFixedRate`，每 5 秒一次），却在那条线程上直接调：

- `Bukkit.getWorlds()` → `world.getLoadedChunks().length` / `getPlayers()` / `getPVP()` / `getSpawnLocation()`
- `Bukkit.getOnlinePlayers()` → `player.getLocation()` / `getHealth()` / `getFoodLevel()` / `getGameMode()`
- `Bukkit.getPluginManager().getPlugins()`

全是 Paper 明确不支持在异步线程上访问的可变世界状态，表现为偶发的并发修改异常或读到撕裂的数据。

这个类里的 TPS/CPU 采样**已经**正确地 hop 到了 `runTaskTimer`（`updateTpsAndCpu`，1 Hz），说明线程契约当时就被识别到了，只是只应用了一半。

## 修法

主线程按 100 tick 采一份不可变快照（`ServerStateSnapshot`，字段全 final，volatile 发布），异步发送线程只读快照。用的就是同文件里 CPU 采样那套模式。

**采样周期为什么不并进已有的 1 Hz 任务**：`world.getLoadedChunks()` 会分配一个装下所有已加载区块的数组，大服上并不便宜。按 1 Hz 采就是凭空把这份开销放大 5 倍。100 tick 与今天实际的采样频率完全一致，只是换到了正确的线程上——主线程开销不增不减。

**为什么不用 `callSyncMethod().get()`**：那条路能拿到完全新鲜的数据，但会让监控的存活依赖主线程的健康度，而服务器卡顿时恰恰是最需要监控还能说话的时候。快照模式下「主线程卡了」表现为数据变旧，而不是监控一起哑掉。代价是数据最多陈旧一个周期（5 秒）。

顺带修好的：`sendServerStatusWithRequestId` / `sendMetricsData*` 这些按需响应跑在 WebSocket 线程上，同样是非主线程，现在也走快照了。`sendServerStatus` 里那句 FINE 日志也在异步线程上直接读 `Bukkit.getOnlinePlayers()`，一并改掉。

`sampleServerState` 自带非主线程拒绝 + SEVERE 日志，作为第二道闸——这个类的历史正是「契约被识别了，只应用了一半」，把契约写进代码比写进注释可靠。

一处刻意的例外：从未采样过、而调用方恰好就在主线程上时，就地补采一次。否则连接建立后的第一帧会是一片零。非主线程上则宁可报空快照也不读 Bukkit，有测试钉住这个区别。

## 测试

新增 12 条，分四组：

- **采样线程契约** —— 主线程采样填充快照；非主线程采样被拒绝并记 SEVERE；外加一条前置断言确认 MockBukkit 把测试线程当主线程（否则整组对比失效，失败的应该是那一条）
- **异步路径读快照** —— 采样后往世界里再加两个玩家、不重新采样，从非主线程发送，断言报的是采样时刻的 1 而不是活的 3。**这是整组里最要紧的一条**：报 3 就说明异步线程直接读了 Bukkit
- **JSON 形状回归** —— 钉住 `status` 顶层字段、`worlds` 元素字段、`onlinePlayers` 元素字段。面板靠这些字段名工作，而这次改动把整段构造代码搬了家
- **韧性** —— 重复采样、未连接时不发送

**负向对照已做**：把 `currentSnapshot()` 改回每次都读活的 Bukkit（等价于修复前），12 条里挂 3 条，正是预测的那 3 条。形状那 4 条在对照组照样通过——它们是契约回归测试，不是缺陷探测器，这符合预期。

既有的 41 条 `ServerMonitorManagerTest` 一条没改，全部通过——重构是行为保持的。

总测试数 4202 → 4214。`mvn clean verify` 通过。

## ⚠️ 需要真机验收

这条是本批里唯一改了热路径线程模型的，单元测试测不到真实的 Paper 调度。会连同 #181/#223 一起送真机 UAT，重点看：连续运行时面板数据是否正常刷新、重连之后采样是否恢复、以及大世界下主线程有没有可观测的额外开销。