### PR TITLE
test: 把能提到 mock 发布之前的桩都提上去（#256）

### DIFF
--- a/src/test/java/com/ultikits/ultitools/abstracts/AbstractCommandExecutorTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/AbstractCommandExecutorTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import java.util.concurrent.TimeUnit;
 
-import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.annotations.command.CmdCD;
 import com.ultikits.ultitools.annotations.command.CmdExecutor;
 import com.ultikits.ultitools.annotations.command.CmdMapping;
@@ -47,7 +46,6 @@ class AbstractCommandExecutorTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         server = MockBukkit.mock();
         MockBukkit.createMockPlugin(); // Create a dummy plugin for permissions
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
         player = server.addPlayer("testplayer");
         player.setOp(false);
         mockCommand = mock(Command.class);
@@ -56,7 +54,9 @@ class AbstractCommandExecutorTest {
         // Mock CommandManager for suggestion tests
         CommandManager mockCommandManager = mock(CommandManager.class);
         UltiToolsPlugin mockPlugin = mock(UltiToolsPlugin.class);
-        when(UltiTools.getInstance().getCommandManager()).thenReturn(mockCommandManager);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getCommandManager()).thenReturn(mockCommandManager);
+        });
         when(mockCommandManager.getPluginByCommand(any())).thenReturn(mockPlugin);
         
         executor = new ComplexCommandExecutor();

--- a/src/test/java/com/ultikits/ultitools/abstracts/guis/OkCancelPageTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/guis/OkCancelPageTest.java
@@ -65,11 +65,12 @@ class OkCancelPageTest {
     void setUp() {
         MockBukkitHelper.ensureCleanState();
         server = MockBukkit.mock();
-        TestHelper.mockUltiToolsInstance();
 
         // Mock VersionWrapper
         VersionWrapper versionWrapper = mock(VersionWrapper.class);
-        lenient().when(UltiTools.getInstance().getVersionWrapper()).thenReturn(versionWrapper);
+        TestHelper.mockUltiToolsInstance(ultiTools -> {
+            lenient().when(ultiTools.getVersionWrapper()).thenReturn(versionWrapper);
+        });
         lenient().when(versionWrapper.getColoredPlaneGlass(any())).thenReturn(new ItemStack(Material.STONE));
 
         // Initialize InventoryAPI

--- a/src/test/java/com/ultikits/ultitools/abstracts/guis/PagingPageTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/guis/PagingPageTest.java
@@ -50,11 +50,12 @@ class PagingPageTest {
     void setUp() {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         server = MockBukkit.mock();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
         
         // Mock VersionWrapper
         com.ultikits.ultitools.interfaces.VersionWrapper versionWrapper = org.mockito.Mockito.mock(com.ultikits.ultitools.interfaces.VersionWrapper.class);
-        org.mockito.Mockito.lenient().when(com.ultikits.ultitools.UltiTools.getInstance().getVersionWrapper()).thenReturn(versionWrapper);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            org.mockito.Mockito.lenient().when(ultiTools.getVersionWrapper()).thenReturn(versionWrapper);
+        });
         org.mockito.Mockito.lenient().when(versionWrapper.getColoredPlaneGlass(org.mockito.ArgumentMatchers.any())).thenReturn(new org.bukkit.inventory.ItemStack(org.bukkit.Material.STONE));
         
         // Initialize InventoryAPI

--- a/src/test/java/com/ultikits/ultitools/commands/UltiToolsCommandsTest.java
+++ b/src/test/java/com/ultikits/ultitools/commands/UltiToolsCommandsTest.java
@@ -39,7 +39,6 @@ class UltiToolsCommandsTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         server = MockBukkit.mock();
         MockBukkit.createMockPlugin();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
         
         player = server.addPlayer("testplayer");
         player.setOp(true);
@@ -48,7 +47,9 @@ class UltiToolsCommandsTest {
         when(mockCommand.getName()).thenReturn("ul");
         
         mockPluginManager = mock(PluginManager.class);
-        when(UltiTools.getInstance().getPluginManager()).thenReturn(mockPluginManager);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getPluginManager()).thenReturn(mockPluginManager);
+        });
         
         executor = new UltiToolsCommands();
     }

--- a/src/test/java/com/ultikits/ultitools/listeners/EnhancedPlayerEventListenerTest.java
+++ b/src/test/java/com/ultikits/ultitools/listeners/EnhancedPlayerEventListenerTest.java
@@ -50,11 +50,12 @@ class EnhancedPlayerEventListenerTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         server = MockBukkit.mock();
         MockBukkit.createMockPlugin();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
 
         // Mock ServerMonitorManager
         mockMonitorManager = mock(ServerMonitorManager.class);
-        when(UltiTools.getInstance().getServerMonitorManager()).thenReturn(mockMonitorManager);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getServerMonitorManager()).thenReturn(mockMonitorManager);
+        });
 
         listener = new EnhancedPlayerEventListener();
     }

--- a/src/test/java/com/ultikits/ultitools/manager/CommandExecutionManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/CommandExecutionManagerTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import com.google.gson.JsonObject;
-import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
 
 import org.mockbukkit.mockbukkit.MockBukkit;
@@ -42,11 +41,12 @@ class CommandExecutionManagerTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         server = MockBukkit.mock();
         MockBukkit.createMockPlugin();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
 
         // Mock logger
         mockLogger = mock(Logger.class);
-        when(UltiTools.getInstance().getLogger()).thenReturn(mockLogger);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getLogger()).thenReturn(mockLogger);
+        });
 
         // Mock WebSocket client
         mockWebSocketClient = mock(UltiPanelWebSocketClient.class);

--- a/src/test/java/com/ultikits/ultitools/manager/CommandManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/CommandManagerTest.java
@@ -62,11 +62,12 @@ class CommandManagerTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         server = MockBukkit.mock();
         MockBukkit.createMockPlugin();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
 
         // Mock logger
         mockLogger = mock(Logger.class);
-        when(UltiTools.getInstance().getLogger()).thenReturn(mockLogger);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getLogger()).thenReturn(mockLogger);
+        });
 
         // Mock plugin
         mockPlugin = mock(UltiToolsPlugin.class);

--- a/src/test/java/com/ultikits/ultitools/manager/ConfigManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ConfigManagerTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
-import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.AbstractConfigEntity;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.annotations.ConfigEntity;
@@ -53,11 +52,12 @@ class ConfigManagerTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         MockBukkit.mock(); // Server mock not stored as field - only used for initialization
         MockBukkit.createMockPlugin();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
 
         // Mock logger
         mockLogger = mock(Logger.class);
-        when(UltiTools.getInstance().getLogger()).thenReturn(mockLogger);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getLogger()).thenReturn(mockLogger);
+        });
 
         // Mock plugin
         mockPlugin = mock(UltiToolsPlugin.class);

--- a/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.interfaces.DataStore;
 import com.ultikits.ultitools.interfaces.impl.data.json.JsonStore;
 
@@ -38,12 +37,13 @@ class DataStoreManagerTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         server = MockBukkit.mock();
         MockBukkit.createMockPlugin();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
         
         // Mock getDataFolder
         File mockDataFolder = new File(System.getProperty("java.io.tmpdir"), "ultitools-test");
         mockDataFolder.mkdirs();
-        when(UltiTools.getInstance().getDataFolder()).thenReturn(mockDataFolder);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getDataFolder()).thenReturn(mockDataFolder);
+        });
 
         // 清理静态 map
         clearDataMap();

--- a/src/test/java/com/ultikits/ultitools/manager/ErrorReportCollectorTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ErrorReportCollectorTest.java
@@ -39,12 +39,13 @@ class ErrorReportCollectorTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         server = MockBukkit.mock();
         MockBukkit.createMockPlugin();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
 
         // Mock serverMonitorManager
         ServerMonitorManager mockSmm = mock(ServerMonitorManager.class);
         when(mockSmm.getCurrentTPS()).thenReturn(20.0);
-        when(UltiTools.getInstance().getServerMonitorManager()).thenReturn(mockSmm);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getServerMonitorManager()).thenReturn(mockSmm);
+        });
 
         collector = new ErrorReportCollector();
         // Don't call init() — avoid scheduler thread in tests. Set enabled directly.

--- a/src/test/java/com/ultikits/ultitools/manager/FileOperationManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/FileOperationManagerTest.java
@@ -46,11 +46,12 @@ class FileOperationManagerTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         MockBukkit.mock();
         MockBukkit.createMockPlugin();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
 
         // Mock logger
         mockLogger = mock(Logger.class);
-        when(UltiTools.getInstance().getLogger()).thenReturn(mockLogger);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getLogger()).thenReturn(mockLogger);
+        });
 
         // Mock WebSocket client
         mockWebSocketClient = mock(UltiPanelWebSocketClient.class);

--- a/src/test/java/com/ultikits/ultitools/manager/ListenerManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ListenerManagerTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.annotations.EventListener;
 import com.ultikits.ultitools.context.AutowireFactory;
@@ -46,11 +45,12 @@ class ListenerManagerTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         MockBukkit.mock();
         MockBukkit.createMockPlugin();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
 
         // Mock logger
         Logger mockLogger = mock(Logger.class);
-        when(UltiTools.getInstance().getLogger()).thenReturn(mockLogger);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getLogger()).thenReturn(mockLogger);
+        });
 
         // Mock plugin
         mockPlugin = mock(UltiToolsPlugin.class);

--- a/src/test/java/com/ultikits/ultitools/manager/PlayerEventManagerRegistrationTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PlayerEventManagerRegistrationTest.java
@@ -58,13 +58,14 @@ class PlayerEventManagerRegistrationTest {
         server = MockBukkit.mock();
         // 名字必须是 UltiTools —— registerEvents 拿的就是 getPlugin("UltiTools")
         MockBukkit.createMockPlugin("UltiTools");
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
 
         Logger mockLogger = mock(Logger.class);
-        when(UltiTools.getInstance().getLogger()).thenReturn(mockLogger);
 
         LogStreamManager mockLogStreamManager = mock(LogStreamManager.class);
-        when(UltiTools.getInstance().getLogStreamManager()).thenReturn(mockLogStreamManager);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getLogger()).thenReturn(mockLogger);
+            when(ultiTools.getLogStreamManager()).thenReturn(mockLogStreamManager);
+        });
 
         mockClient = mock(UltiPanelWebSocketClient.class);
         when(mockClient.isConnected()).thenReturn(true);

--- a/src/test/java/com/ultikits/ultitools/manager/PlayerEventManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PlayerEventManagerTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import com.google.gson.JsonObject;
-import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
 
 import org.mockbukkit.mockbukkit.MockBukkit;
@@ -50,11 +49,9 @@ class PlayerEventManagerTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         server = MockBukkit.mock();
         MockBukkit.createMockPlugin();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
 
         // Mock logger
         mockLogger = mock(Logger.class);
-        when(UltiTools.getInstance().getLogger()).thenReturn(mockLogger);
 
         // Mock WebSocket client
         mockWebSocketClient = mock(UltiPanelWebSocketClient.class);
@@ -65,7 +62,10 @@ class PlayerEventManagerTest {
         mockLogStreamManager = mock(LogStreamManager.class);
         UltiPanelLogTransmitter mockTransmitter = mock(UltiPanelLogTransmitter.class);
         when(mockLogStreamManager.getLogTransmitter()).thenReturn(mockTransmitter);
-        when(UltiTools.getInstance().getLogStreamManager()).thenReturn(mockLogStreamManager);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getLogger()).thenReturn(mockLogger);
+            when(ultiTools.getLogStreamManager()).thenReturn(mockLogStreamManager);
+        });
 
         playerEventManager = new PlayerEventManager();
         

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
-import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 
 import org.mockbukkit.mockbukkit.MockBukkit;
@@ -45,11 +44,12 @@ class PluginManagerTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         MockBukkit.mock(); // Server mock not stored as field - only used for initialization
         MockBukkit.createMockPlugin();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
 
         // Mock logger
         mockLogger = mock(Logger.class);
-        when(UltiTools.getInstance().getLogger()).thenReturn(mockLogger);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getLogger()).thenReturn(mockLogger);
+        });
 
         pluginManager = new PluginManager();
     }

--- a/src/test/java/com/ultikits/ultitools/manager/ServerMonitorManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ServerMonitorManagerTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Timeout;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
 
 import org.mockbukkit.mockbukkit.MockBukkit;
@@ -47,11 +46,12 @@ class ServerMonitorManagerTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         server = MockBukkit.mock();
         MockBukkit.createMockPlugin();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
 
         // Mock logger
         mockLogger = mock(Logger.class);
-        when(UltiTools.getInstance().getLogger()).thenReturn(mockLogger);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getLogger()).thenReturn(mockLogger);
+        });
 
         // Mock WebSocket client
         mockWebSocketClient = mock(UltiPanelWebSocketClient.class);

--- a/src/test/java/com/ultikits/ultitools/manager/ServerMonitorSnapshotTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ServerMonitorSnapshotTest.java
@@ -25,7 +25,6 @@ import org.mockito.ArgumentCaptor;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
 
 import org.mockbukkit.mockbukkit.MockBukkit;
@@ -58,14 +57,15 @@ class ServerMonitorSnapshotTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         server = MockBukkit.mock();
         MockBukkit.createMockPlugin();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
 
         // MockBukkit 默认一个世界都没有，而 worlds 数组正是本次改动搬家的重点之一，
         // 没有世界的话形状断言会变成空转。
         server.addSimpleWorld("world");
 
         mockLogger = mock(Logger.class);
-        when(UltiTools.getInstance().getLogger()).thenReturn(mockLogger);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getLogger()).thenReturn(mockLogger);
+        });
 
         mockClient = mock(UltiPanelWebSocketClient.class);
         when(mockClient.isConnected()).thenReturn(true);

--- a/src/test/java/com/ultikits/ultitools/services/impl/InMemeryTeleportServiceTest.java
+++ b/src/test/java/com/ultikits/ultitools/services/impl/InMemeryTeleportServiceTest.java
@@ -2,6 +2,7 @@ package com.ultikits.ultitools.services.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -22,7 +23,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.interfaces.VersionWrapper;
 
 import org.mockbukkit.mockbukkit.MockBukkit;
@@ -44,15 +44,19 @@ class InMemeryTeleportServiceTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         server = MockBukkit.mock();
         MockBukkit.createMockPlugin();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
 
         // Mock logger
         Logger mockLogger = mock(Logger.class);
-        when(UltiTools.getInstance().getLogger()).thenReturn(mockLogger);
 
         // Mock VersionWrapper
         VersionWrapper mockVersionWrapper = mock(VersionWrapper.class);
-        when(UltiTools.getInstance().getVersionWrapper()).thenReturn(mockVersionWrapper);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getLogger()).thenReturn(mockLogger);
+            when(ultiTools.getVersionWrapper()).thenReturn(mockVersionWrapper);
+            // i18n 原先在 6 个用例里各打一遍、内容完全相同。提到发布之前既消掉重复，
+            // 也让这 6 处不再在「mock 已全进程可见」的窗口里打桩。见 issue #256。
+            lenient().when(ultiTools.i18n(any(String.class))).thenAnswer(inv -> inv.getArgument(0));
+        });
         when(mockVersionWrapper.getSound(any())).thenReturn(Sound.ENTITY_ENDERMAN_TELEPORT);
 
         teleportService = new InMemeryTeleportService();
@@ -305,8 +309,6 @@ class InMemeryTeleportServiceTest {
             World world = player.getWorld();
             Location targetLocation = new Location(world, 100, 64, 100);
             
-            // Mock i18n
-            when(UltiTools.getInstance().i18n(any(String.class))).thenAnswer(inv -> inv.getArgument(0));
 
             // Act
             teleportService.delayTeleport(player, targetLocation, 3);
@@ -326,8 +328,6 @@ class InMemeryTeleportServiceTest {
             PlayerMock player = server.addPlayer();
             World world = player.getWorld();
             Location targetLocation = new Location(world, 100, 64, 100);
-            
-            when(UltiTools.getInstance().i18n(any(String.class))).thenAnswer(inv -> inv.getArgument(0));
 
             // Act
             teleportService.delayTeleport(player, targetLocation, 0);
@@ -588,8 +588,6 @@ class InMemeryTeleportServiceTest {
             Location targetLocation = new Location(world, 100, 64, 100);
             InMemeryTeleportService.setTeleportingStatus(player.getUniqueId(), false);
 
-            // Mock i18n
-            when(UltiTools.getInstance().i18n(any(String.class))).thenAnswer(inv -> inv.getArgument(0));
 
             // Act
             InMemeryTeleportService.DelayTeleportResult result = 
@@ -608,8 +606,6 @@ class InMemeryTeleportServiceTest {
             Location targetLocation = new Location(world, 100, 64, 100);
             InMemeryTeleportService.setTeleportingStatus(player.getUniqueId(), true);
 
-            // Mock i18n
-            when(UltiTools.getInstance().i18n(any(String.class))).thenAnswer(inv -> inv.getArgument(0));
 
             // Act
             InMemeryTeleportService.DelayTeleportResult result = 
@@ -629,8 +625,6 @@ class InMemeryTeleportServiceTest {
             Location targetLocation = new Location(world, 100, 64, 100);
             InMemeryTeleportService.setTeleportingStatus(player.getUniqueId(), true);
 
-            // Mock i18n
-            when(UltiTools.getInstance().i18n(any(String.class))).thenAnswer(inv -> inv.getArgument(0));
 
             // Act
             InMemeryTeleportService.DelayTeleportResult result = 
@@ -650,8 +644,6 @@ class InMemeryTeleportServiceTest {
             Location targetLocation = new Location(world, 100, 64, 100);
             InMemeryTeleportService.setTeleportingStatus(player.getUniqueId(), true);
 
-            // Mock i18n
-            when(UltiTools.getInstance().i18n(any(String.class))).thenAnswer(inv -> inv.getArgument(0));
 
             // Act - time = 4.0 应该显示标题 (4.0 / 0.5 = 8, 8 % 2 = 0)
             InMemeryTeleportService.DelayTeleportResult result = 

--- a/src/test/java/com/ultikits/ultitools/services/impl/InMemoryNotificationServiceTest.java
+++ b/src/test/java/com/ultikits/ultitools/services/impl/InMemoryNotificationServiceTest.java
@@ -47,15 +47,16 @@ class InMemoryNotificationServiceTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
         server = MockBukkit.mock();
         MockBukkit.createMockPlugin();
-        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
 
         // Mock logger
         mockLogger = mock(Logger.class);
-        when(UltiTools.getInstance().getLogger()).thenReturn(mockLogger);
 
         // Mock VersionWrapper - local variable as only used for stubbing
         VersionWrapper mockVersionWrapper = mock(VersionWrapper.class);
-        when(UltiTools.getInstance().getVersionWrapper()).thenReturn(mockVersionWrapper);
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getLogger()).thenReturn(mockLogger);
+            when(ultiTools.getVersionWrapper()).thenReturn(mockVersionWrapper);
+        });
 
         notificationService = new InMemoryNotificationService();
 


### PR DESCRIPTION
Closes #256

## 做了什么

19 个测试类、**29 处**桩从「发布后打桩」改成「打桩后发布」，用的是 PR #253 已经备好的 `TestHelper.mockUltiToolsInstance(Consumer<UltiTools>)` 重载：

```java
// 之前：发布与打桩之间存在窗口
TestHelper.mockUltiToolsInstance();
mockLogger = mock(Logger.class);
when(UltiTools.getInstance().getLogger()).thenReturn(mockLogger);

// 现在：打完桩才发布
mockLogger = mock(Logger.class);
TestHelper.mockUltiToolsInstance(ultiTools -> {
    when(ultiTools.getLogger()).thenReturn(mockLogger);
});
```

其中 `InMemeryTeleportServiceTest` 的 `i18n` 桩原先在 6 个用例里各写一遍、内容完全相同，一并提到 `setUp` 回调里，顺带消掉重复。

顺带清掉 10 个因此失效的 `UltiTools` import——留着就是 PMD 的 `UnusedImports`。

改动是机械的，但**转换方式值得说一句**：脚本把 `mockUltiToolsInstance(...)` 挪到「**最后一处桩所在的位置**」，而不是去分析每个桩依赖哪些 mock。挪到最后一处桩的位置，就保证了它们依赖的 mock 创建语句必然都在上面执行过——不需要依赖分析也不会漏。脚本带一道安全闸：原调用点与最后一处桩之间若存在桩以外的 `UltiTools.getInstance()` 引用就跳过该文件（那种引用会因为实例尚未发布而变成 NPE），被拦下的两个文件单独看过。

## ⚠️ issue 的验收标准需要调整

issue 写的是「`grep` 归零」。**这一条我做不到，而且不该做到。**

剩余 10 处全在 `@Test` 方法内，打桩用的是每个用例自己造的、行为各不相同的 mock。`PluginInstallCommandsTest` 的 6 处 `getUpdateManager` 是典型：

```java
UpdateManager mockUpdateManager = mock(UpdateManager.class);
when(mockUpdateManager.getModuleUpdates()).thenReturn(updates);   // 每个用例不一样
when(UltiTools.getInstance().getUpdateManager()).thenReturn(mockUpdateManager);
```

这类桩天然发生在发布之后，提不到 `setUp`。而把接收者从 `UltiTools.getInstance()` 换成一个存好的字段，**在 Mockito 看来是完全一样的两句代码**——`invocationForStubbing` 是 per-mock 的，跟你通过哪个引用拿到这个 mock 毫无关系。窗口一模一样，只是 grep 变绿了。那是刷指标不是修问题。

所以真实的分界线不是「写法」而是「**桩能不能提到发布之前**」：能提的，窗口真的消失了；提不上去的，唯一防线就是 issue 最后那条验收——**别泄漏后台线程**。那条比 grep 重要得多，建议把它扶正为主要验收项。

具体清单：`PluginInstallCommandsTest` ×7（1 处在 `setUp` 但被 `mockStatic(UltiTools.class)` 结构挡着）、`PluginInstallCommandsEnhancedTest` ×1、`CommandManagerTest` ×1、`EnhancedPlayerEventListenerTest` ×1。

## 另外，这个数字比 issue 写的大

issue 统计的是 19 个类 36 处，实际是 **21 个类 39 处**——多出来的两个类 `PlayerEventManagerRegistrationTest` 和 `ServerMonitorSnapshotTest` 是我自己在 #264 / #265 里新加的，当时照着周围的写法就跟着写错了。已一并改掉。这说明光修存量不够，写法本身会自我复制。

## 验收

- [x] 连续 **10 次** `mvn -B clean test` 全绿，4231 一次不少
- [x] 没有用 `@Disabled`、放宽断言或重试插件
- [x] 新改的测试类 `tearDown` 已确认（本 PR 没有新增起线程的测试）
- [ ] ~~grep 归零~~ → 见上，标准需要调整