### PR TITLE
docs: 说明运行时依赖来源，区分本仓库可修与不可修的 Dependabot 告警 (#262)

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -224,6 +224,25 @@ flatten-maven-plugin 处理后不含依赖声明，因此把 UltiTools-API 放�
 | `plugin.yml` 的 `api-version` | `1.19`（Bukkit API 层级，与上面两项无关） |
 | 模块 `plugin.yml` 的 `api-version` | `620`（UltiTools API 层级，与 Bukkit 的同名字段无关） |
 
+### 运行时依赖来自哪里
+
+框架 JAR 里只打包三个库：obliviate-invs（GUI）、XSeries（跨版本）、UniversalScheduler（调度）。
+其余依赖一个都不在 JAR 里，而是走下面两条路之一：
+
+| 投送方式 | 版本由谁决定 | 例子 |
+|---|---|---|
+| `plugin.yml` 的 `libraries:` 块，Paper 按坐标下载 | **本仓库** | Gson、MySQL Connector/J、HikariCP、Java-WebSocket、CGLIB |
+| Paper 服务端自身携带 | **服主所装的 Paper 版本** | log4j、Paper 内部实现 `libraries:` 用的 Maven resolver 及其依赖 |
+
+这条分界决定了第三方安全告警该由谁修。命中第一类的，在本仓库钉版本是有效的修复；
+命中第二类的，唯一的修法是**升级 Paper** —— 在 `pom.xml` 里怎么写都不会改变服务器上
+实际加载的那个 jar，只会制造「已经修了」的错觉。
+
+注意 Maven 的 `provided` 作用域**不是**这条分界：上表两类依赖在 `pom.xml` 里都声明为
+`provided`。判断依据是「有没有出现在 `libraries:` 块里」，不是作用域。
+
+建议服主跟进 Paper 的构建更新，安全构建尤其如此。
+
 ## 反馈
 
 对本策略有异议，或你的模块受到上述移除影响，


### PR DESCRIPTION
Closes #262

## 复核结论

复核了四条 open 告警的来源链（issue 正文列了三条，实际 open 的是四条）。**判据不是 Maven 作用域，而是「有没有出现在 `plugin.yml` 的 `libraries:` 块里」** —— 四条在 `pom.xml` 里全部解析为 `provided`，其中一条照样能被本仓库修掉。

`mvn dependency:tree -Dverbose=true` 的实际输出：

```
com.ultikits:UltiTools-API:jar:6.2.5-SNAPSHOT
+- io.papermc.paper:paper-api:jar:1.21.11-R0.1-SNAPSHOT:provided
|  +- org.apache.logging.log4j:log4j-api:jar:2.24.1:provided
|  \- org.apache.maven:maven-resolver-provider:jar:3.9.6:provided
|     +- org.apache.maven:maven-model-builder:jar:3.9.6:provided
|     |  \- org.apache.maven:maven-artifact:jar:3.9.6:provided
|     |     \- org.apache.commons:commons-lang3:jar:3.12.0:provided
|     \- org.codehaus.plexus:plexus-utils:jar:3.5.1:provided
+- com.mysql:mysql-connector-j:jar:8.3.0:provided
|  \- (com.google.protobuf:protobuf-java:jar:3.25.1:provided - omitted for conflict with 3.25.5)
\- com.google.protobuf:protobuf-java:jar:3.25.5:provided
```

逐条核到三个独立证据：解析作用域、shaded JAR 里的 class entry 数、`plugin.yml` 的 `libraries:` 块。

| 告警 | 库 | 来源链 | shaded JAR | 在 `libraries:` | 本仓库能否影响运行时 | 处置 |
|---|---|---|---|---|---|---|
| #9 medium | `log4j-api:2.24.1` | `paper-api` 直接子节点 | 0 entry | 否 | **不能** | dismiss `not_used` |
| #8 high | `plexus-utils:3.5.1` | `maven-resolver-provider` ← `paper-api` | 0 entry | 否 | **不能** | dismiss `not_used` |
| #6 medium | `commons-lang3:3.12.0` | `maven-artifact` ← `maven-model-builder` ← `maven-resolver-provider` ← `paper-api` | 0 entry | 否 | **不能** | dismiss `not_used` |
| #5 high | `protobuf-java` | `mysql-connector-j` 传递，已被直接声明的 3.25.5 压过 | 0 entry | **是** | **能** | 不动，见下 |

补充证据：`mvn dependency:list -DincludeScope=runtime` 只列出 10 个 artifact，全是 obliviate-invs / XSeries / UniversalScheduler，四条告警的库一个都不在；源码里对 `org.apache.logging.log4j`、`org.codehaus.plexus`、`org.apache.commons.lang3` 零 `import`。

### 为什么 `provided` 不是判据

`protobuf-java` 同样是 `provided`、同样 0 个 class entry 进 JAR，但它**写在 `plugin.yml` 的 `libraries:` 块里** —— Paper 的 library loader 会照着坐标在运行时解析下载，所以 #220 在那里钉 3.25.5 是真实有效的修复。前三条不在 `libraries:` 里，它们在服务器上的那份副本属于 Paper 自己（log4j 是 Paper 的日志实现，另两个是 Paper 用来实现 `libraries:` 下载机制的 Maven resolver 的依赖），版本完全由服主所装的 Paper 构建决定。

因此在 `pom.xml` 里加 `<dependencyManagement>` 钉版本对前三条**没有任何运行时效果**，只会让告警变绿并制造「已经修了」的错觉。按 issue 的要求没有这么做。

### #5 protobuf-java 为什么还开着

它不属于本 issue，也不需要 dismiss。修复（`plugin.yml` 钉 3.25.5）已经在 `alpha` 上，但 Dependabot 扫的是默认分支 `main`，`main` 的 `libraries:` 块里还没有这条：

```
$ git show origin/main:src/main/resources/plugin.yml | grep -E 'protobuf|mysql'
  - com.mysql:mysql-connector-j:8.3.0

$ git show origin/alpha:src/main/resources/plugin.yml | grep protobuf
  - com.google.protobuf:protobuf-java:3.25.5
```

`alpha` 合入 `main` 后会自行关闭。**刻意保持 open**，dismiss 它反而会掩盖一条真实修复。

## 本 PR 的改动

三条 dismiss 是在 GitHub 上直接操作的（`not_used`，各带一条写明来源链的理由），不产生代码改动。本 PR 只落验收标准的最后一项：把上面这条判据写进 `COMPATIBILITY.md` 的「支持范围」一节，免得下次看到同类告警再推一遍，也给服主一个明确说法 —— 命中 Paper 那一类的，唯一修法是升级 Paper。

## 验收对照

- [x] 三条的来源链各自复核过，结论写进 PR 描述（三个独立证据，非照抄正文；并纠正了「`provided` 即不可修」这个判据）
- [x] 每条 dismiss 并带理由（#9 #8 #6，`not_used`）
- [x] 未通过在 `pom.xml` 里加对运行时无效的 pin 来消除告警
- [x] 在 `COMPATIBILITY.md` 里给出了运行时依赖来源与升级 Paper 的建议
