### PR TITLE
fix(data): JSON 后端认 @Column 列名，多条件 AND 改成真正的交集 (#176, #192)

### DIFF
--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/AbstractRelationalDataOperator.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/AbstractRelationalDataOperator.java
@@ -8,6 +8,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.logging.Logger;
@@ -105,7 +106,9 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
         for (Field f : ReflectionUtil.getFields(type)) {
             if (f.isAnnotationPresent(Column.class)) {
                 Column col = f.getAnnotation(Column.class);
-                String sqlName = col.value().toLowerCase();
+                // Locale.ROOT：土耳其语/阿塞拜疆语 locale 下 'I' 会折成无点的 'ı'，
+                // 建映射与查映射只要有一边跟着系统 locale 走，列名就对不上。
+                String sqlName = col.value().toLowerCase(Locale.ROOT);
                 columnToFieldName.put(sqlName, f.getName());
                 if (f.getType() == boolean.class || f.getType() == Boolean.class) {
                     booleanColumns.put(sqlName, true);
@@ -120,7 +123,7 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
             while (rs.next()) {
                 Map<String, Object> map = new LinkedHashMap<>();
                 for (int i = 1; i <= cols; i++) {
-                    String colName = meta.getColumnLabel(i).toLowerCase();
+                    String colName = meta.getColumnLabel(i).toLowerCase(Locale.ROOT);
                     Object value = rs.getObject(i);
                     // SQLite stores BOOLEAN as INTEGER (0/1); convert for Gson compatibility
                     if (value instanceof Number && booleanColumns.containsKey(colName)) {

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperator.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperator.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -92,7 +93,9 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
         Map<String, String> mapping = new LinkedHashMap<>();
         for (Field field : ReflectionUtil.getFields(type)) {
             if (field.isAnnotationPresent(Column.class)) {
-                mapping.put(field.getAnnotation(Column.class).value().toLowerCase(), field.getName());
+                // 必须用 Locale.ROOT：默认 locale 是土耳其语/阿塞拜疆语时，'I' 会折成无点的 'ı'，
+                // 建表侧与查询侧只要有一边跟着系统 locale 走，列名就对不上了。
+                mapping.put(field.getAnnotation(Column.class).value().toLowerCase(Locale.ROOT), field.getName());
             }
         }
         return Collections.unmodifiableMap(mapping);
@@ -112,7 +115,7 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
         if (column == null) {
             return null;
         }
-        String fieldName = columnToFieldName.get(column.toLowerCase());
+        String fieldName = columnToFieldName.get(column.toLowerCase(Locale.ROOT));
         return fieldName != null ? fieldName : column;
     }
 

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperator.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperator.java
@@ -5,13 +5,16 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.Serializable;
 import java.io.Writer;
+import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -26,12 +29,14 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
+import com.ultikits.ultitools.annotations.Column;
 import com.ultikits.ultitools.entities.WhereCondition;
 import com.ultikits.ultitools.interfaces.Cached;
 import com.ultikits.ultitools.interfaces.DataOperator;
 import com.ultikits.ultitools.utils.BeanCopyUtil;
 import com.ultikits.ultitools.utils.FileUtils;
 import com.ultikits.ultitools.utils.JsonPathUtil;
+import com.ultikits.ultitools.utils.ReflectionUtil;
 
 /**
  * Simple Json data operator.
@@ -48,10 +53,20 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
     private final String storeLocation;
     private final Class<T> type;
     private final Map<Object, T> cache = new ConcurrentHashMap<>();
+    /**
+     * SQL 列名（小写）→ Java 字段名。
+     * <p>
+     * 调用方一律用 {@code @Column} 里的 SQL 列名做查询（跨 17 个 Modules 共 52 处），
+     * 而 Gson 序列化出的 map 键是 Java 字段名，两者在 snake_case / camelCase 上对不上，
+     * 查询会静默零命中。这份映射把前者翻译成后者，做法与
+     * {@code AbstractRelationalDataOperator#getListHandler()} 的读路径一致。见 issue #176。
+     */
+    private final Map<String, String> columnToFieldName;
 
     public SimpleJsonDataOperator(String storeLocation, Class<T> type) {
         this.storeLocation = storeLocation;
         this.type = type;
+        this.columnToFieldName = buildColumnToFieldName(type);
         File file = new File(storeLocation);
         File[] files = file.listFiles();
         if (files != null) {
@@ -64,6 +79,41 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
                 }
             });
         }
+    }
+
+    /**
+     * 从实体类上的 {@code @Column} 标注建立「SQL 列名 → Java 字段名」映射。
+     * 沿继承链收集，因此 {@code BaseDataEntity} 继承来的 {@code @Column("id")} 也在内。
+     *
+     * @param type 实体类型
+     * @return 不可变映射，键为小写化的 SQL 列名
+     */
+    private static Map<String, String> buildColumnToFieldName(Class<?> type) {
+        Map<String, String> mapping = new LinkedHashMap<>();
+        for (Field field : ReflectionUtil.getFields(type)) {
+            if (field.isAnnotationPresent(Column.class)) {
+                mapping.put(field.getAnnotation(Column.class).value().toLowerCase(), field.getName());
+            }
+        }
+        return Collections.unmodifiableMap(mapping);
+    }
+
+    /**
+     * 把调用方给的列名解析成 Gson 序列化后 map 里的键。
+     * <p>
+     * 命中 {@code @Column} 就换成对应的 Java 字段名；否则原样返回 —— 这样一来，
+     * 直接写 Java 字段名的旧调用、以及 {@link JsonPathUtil} 的点分隔嵌套路径（如
+     * {@code "a.b.c"}）都不受影响。
+     *
+     * @param column 调用方给的列名，可能是 SQL 列名、Java 字段名或嵌套路径
+     * @return 可直接交给 {@link JsonPathUtil} 的键或路径
+     */
+    private String resolveColumn(String column) {
+        if (column == null) {
+            return null;
+        }
+        String fieldName = columnToFieldName.get(column.toLowerCase());
+        return fieldName != null ? fieldName : column;
     }
 
     @Override
@@ -88,19 +138,29 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
 
     @Override
     public List<T> getAll(WhereCondition... whereConditions) {
+        // 空条件表示「不施加过滤」，先摘出去，免得它出现在第二个位置时中途返回全量。
+        List<WhereCondition> effective = new ArrayList<>();
+        for (WhereCondition condition : whereConditions) {
+            if (!condition.isEmpty()) {
+                effective.add(condition);
+            }
+        }
+        if (effective.isEmpty()) {
+            // 传了条件但全为空（含 getAll() 走的那条单空条件）返回全量；
+            // 一条都没传时保持历史行为返回空集 —— page() 与 exist() 都依赖它。
+            return whereConditions.length > 0 ? new ArrayList<>(cache.values()) : new ArrayList<>();
+        }
         List<T> results = new ArrayList<>();
         Type mapType = new TypeToken<Map<String, Object>>(){}.getType();
-        for (WhereCondition condition : whereConditions) {
-            if (condition.isEmpty()) {
-                return new ArrayList<>(cache.values());
-            }
+        boolean firstCondition = true;
+        for (WhereCondition condition : effective) {
             if (!Serializable.class.isAssignableFrom(condition.getValue().getClass())) {
                 throw new RuntimeException("Query value is not serializable");
             }
             List<T> collection = new ArrayList<>();
             for (T each : cache.values()) {
                 Map<String, Object> map = GSON.fromJson(GSON.toJson(each), mapType);
-                Object byPath = JsonPathUtil.getByPath(map, condition.getColumn());
+                Object byPath = JsonPathUtil.getByPath(map, resolveColumn(condition.getColumn()));
                 if (byPath == null) {
                     continue;
                 }
@@ -108,8 +168,12 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
                 String value = GSON.toJson(condition.getValue());
                 if (conditionCal(data, value, condition)) collection.add(each);
             }
-            if (results.size() == 0) {
+            // 多条件是 AND：首个条件建立初始集合，其后一律求交，空集保持空集。
+            // 原先写的是「results 为空就 addAll」，于是首个条件零命中时会整体采信第二个
+            // 条件的命中集，AND 退化成 OR。见 issue #192。
+            if (firstCondition) {
                 results.addAll(collection);
+                firstCondition = false;
             } else {
                 results.removeIf(a -> !collection.contains(a));
             }
@@ -123,7 +187,7 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
         Type mapType = new TypeToken<Map<String, Object>>(){}.getType();
         for (T each : cache.values()) {
             Map<String, Object> map = GSON.fromJson(GSON.toJson(each), mapType);
-            String byPath = JsonPathUtil.getStr(map, column);
+            String byPath = JsonPathUtil.getStr(map, resolveColumn(column));
             if (byPath == null) {
                 continue;
             }
@@ -171,8 +235,11 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
 
     @Override
     public synchronized void del(WhereCondition... whereConditions) {
+        // 这里刻意不照搬 getAll 对空条件的处理：在查询侧「空条件 = 不过滤 = 返回全量」是合理的，
+        // 搬到删除侧就成了「删光全表」。空条件目前会在下面取 getValue() 时抛 NPE，难看但失败方向安全。
         Collection<Map.Entry<Object, T>> results = new ArrayList<>();
         Type mapType = new TypeToken<Map<String, Object>>(){}.getType();
+        boolean firstCondition = true;
         for (WhereCondition condition : whereConditions) {
             if (!Serializable.class.isAssignableFrom(condition.getValue().getClass())) {
                 throw new RuntimeException("Query value is not serializable");
@@ -181,7 +248,7 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
             Set<Map.Entry<Object, T>> values = cache.entrySet();
             for (Map.Entry<Object, T> next : values) {
                 Map<String, Object> map = GSON.fromJson(GSON.toJson(next.getValue()), mapType);
-                Object byPath = JsonPathUtil.getByPath(map, condition.getColumn());
+                Object byPath = JsonPathUtil.getByPath(map, resolveColumn(condition.getColumn()));
                 if (byPath == null) {
                     continue;
                 }
@@ -189,8 +256,11 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
                 String value = GSON.toJson(condition.getValue());
                 if (conditionCal(data, value, condition)) collection.add(next);
             }
-            if (results.size() == 0) {
+            // 与 getAll 同一处缺陷的复制品，同样改成真正的交集。在删除路径上，
+            // 原先的写法会在首个条件零命中时删掉第二个条件的全部命中行。见 issue #192。
+            if (firstCondition) {
                 results.addAll(collection);
+                firstCondition = false;
             } else {
                 results.removeIf(a -> !collection.contains(a));
             }
@@ -213,7 +283,8 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
         T obj = cache.get(id);
         Type mapType = new TypeToken<Map<String, Object>>(){}.getType();
         Map<String, Object> map = GSON.fromJson(GSON.toJson(obj), mapType);
-        JsonPathUtil.putByPath(map, column, value);
+        // 不解析列名的话，putByPath 会写进一个 Gson 反序列化时直接丢弃的新键 —— 静默丢写。
+        JsonPathUtil.putByPath(map, resolveColumn(column), value);
         T newObj = GSON.fromJson(GSON.toJson(map), type);
         cache.put(id, newObj);
     }

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonQuerySemanticsTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonQuerySemanticsTest.java
@@ -51,8 +51,6 @@ import lombok.EqualsAndHashCode;
 @DisplayName("JSON 后端查询语义（#176 列名匹配 / #192 AND 交集）")
 class JsonQuerySemanticsTest {
 
-    private static final String H2_AUTH = "";
-
     @TempDir
     Path tempDir;
 
@@ -121,7 +119,9 @@ class JsonQuerySemanticsTest {
         HikariConfig config = new HikariConfig();
         config.setJdbcUrl("jdbc:h2:mem:jsonquerysemantics;DB_CLOSE_DELAY=-1;MODE=MySQL");
         config.setUsername("sa");
-        config.setPassword(H2_AUTH); // nosemgrep: java.lang.security.audit.hardcoded-password
+        // 刻意不调用 setPassword：内存库首次连接时就以「无口令」创建，
+        // 传一个空字符串反而会被静态分析当成硬编码口令（Codacy/Opengrep 的
+        // Semgrep_java_password_rule-HardcodePassword）。这里没有凭据可言。
         dataSource = new HikariDataSource(config);
     }
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonQuerySemanticsTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonQuerySemanticsTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.Statement;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -352,6 +353,67 @@ class JsonQuerySemanticsTest {
             assertThat(idsOf(json.getAll(eq("player_name", "Bob"), WhereCondition.empty())))
                     .as("空条件排在后面时，原先会中途 return 全量，把真条件整个吃掉")
                     .containsExactly("2");
+        }
+    }
+
+    // ==================== 列名折叠不依赖系统 locale ====================
+
+    /**
+     * 土耳其语与阿塞拜疆语的大写 {@code 'I'} 小写化成无点的 {@code 'ı'}，
+     * 因此裸的 {@code toLowerCase()} 会让列名折叠随服务器 locale 漂移。
+     * {@code PLAYER_UUID} 在 {@code tr} 下折成 {@code player_uuıd}，与建映射时
+     * 用的 {@code player_uuid} 对不上，大小写不敏感解析就此失效。
+     * <p>
+     * 两个后端都必须钉 {@link Locale#ROOT}：只钉一边会在土耳其 locale 下重新
+     * 制造出本 PR 要消灭的那种后端分歧。
+     */
+    @Nested
+    @DisplayName("列名折叠不依赖系统 locale")
+    class LocaleIndependence {
+
+        private static final String TURKISH = "tr";
+
+        @Test
+        @DisplayName("JSON 后端：土耳其 locale 下大写列名仍能解析")
+        void jsonResolvesUpperCaseColumnUnderTurkishLocale() {
+            Locale original = Locale.getDefault();
+            try {
+                Locale.setDefault(Locale.forLanguageTag(TURKISH));
+                // 映射在构造期建立，因此必须在切换 locale 之后才 new
+                SimpleJsonDataOperator<PlayerRecord> operator =
+                        new SimpleJsonDataOperator<>(tempDir.toFile().getAbsolutePath(), PlayerRecord.class);
+                operator.insert(new PlayerRecord("1", "uuid-aaa", "Alice", 3));
+
+                assertThat(operator.getAll(eq("PLAYER_UUID", "uuid-aaa")))
+                        .as("PLAYER_UUID 在 tr 下折成 player_uuıd，裸 toLowerCase() 会查不到")
+                        .hasSize(1);
+            } finally {
+                Locale.setDefault(original);
+            }
+        }
+
+        @Test
+        @DisplayName("关系型后端：土耳其 locale 下读回的字段不为空")
+        void relationalMapsColumnsUnderTurkishLocale() throws Exception {
+            Locale original = Locale.getDefault();
+            try (Connection conn = dataSource.getConnection();
+                 Statement stmt = conn.createStatement()) {
+                stmt.execute("DROP TABLE IF EXISTS player_record");
+            }
+            try {
+                Locale.setDefault(Locale.forLanguageTag(TURKISH));
+                SQLiteDataOperator<PlayerRecord> operator =
+                        new SQLiteDataOperator<>(dataSource, PlayerRecord.class);
+                operator.insert(new PlayerRecord("1", "uuid-aaa", "Alice", 3));
+
+                PlayerRecord loaded = operator.getById("1");
+                assertThat(loaded).isNotNull();
+                assertThat(loaded.getPlayerUuid())
+                        .as("读路径把 JDBC 列标签折成字段名，裸 toLowerCase() 会让整列静默变 null")
+                        .isEqualTo("uuid-aaa");
+            } finally {
+                Locale.setDefault(original);
+            }
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonQuerySemanticsTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonQuerySemanticsTest.java
@@ -1,0 +1,357 @@
+package com.ultikits.ultitools.interfaces.impl.data.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import javax.sql.DataSource;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
+import com.ultikits.ultitools.annotations.Column;
+import com.ultikits.ultitools.annotations.Table;
+import com.ultikits.ultitools.entities.WhereCondition;
+import com.ultikits.ultitools.interfaces.DataOperator.LikeType;
+import com.ultikits.ultitools.interfaces.impl.data.sqlite.SQLiteDataOperator;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+import lombok.EqualsAndHashCode;
+
+/**
+ * JSON 后端的查询语义测试。
+ * <p>
+ * 覆盖两条互相咬合的缺陷：
+ * <ul>
+ *   <li>issue #176 —— JSON 侧按 Java 字段名匹配，而所有调用方给的是 {@code @Column} 里的
+ *       SQL 列名，查询恒零命中；</li>
+ *   <li>issue #192 —— 多条件 AND 在首个条件零命中时退化成「采信后一个条件」，
+ *       在 {@code del} 上是一条数据丢失路径。</li>
+ * </ul>
+ * 两者必须同时修：只修 #176 会把 #192 从「被零命中遮蔽」变成可触发。
+ *
+ * @author UltiKits Test Suite
+ * @since 6.2.5
+ */
+@DisplayName("JSON 后端查询语义（#176 列名匹配 / #192 AND 交集）")
+class JsonQuerySemanticsTest {
+
+    private static final String H2_AUTH = "";
+
+    @TempDir
+    Path tempDir;
+
+    private static DataSource dataSource;
+    private SimpleJsonDataOperator<PlayerRecord> json;
+
+    /**
+     * 与 UltiLogin 的真实形状一致：SQL 列名是 snake_case，Java 字段名是 camelCase。
+     * 这个差异正是 #176 的触发条件——列名与字段名相同的实体测不出该缺陷。
+     */
+    @EqualsAndHashCode(callSuper = true)
+    @Table("player_record")
+    public static class PlayerRecord extends BaseDataEntity<String> {
+        @Column("player_uuid")
+        private String playerUuid;
+
+        @Column("player_name")
+        private String playerName;
+
+        @Column(value = "login_count", type = "INT")
+        private int loginCount;
+
+        public PlayerRecord() {
+        }
+
+        public PlayerRecord(String id, String playerUuid, String playerName, int loginCount) {
+            this.setId(id);
+            this.playerUuid = playerUuid;
+            this.playerName = playerName;
+            this.loginCount = loginCount;
+        }
+
+        public String getPlayerUuid() {
+            return playerUuid;
+        }
+
+        public void setPlayerUuid(String playerUuid) {
+            this.playerUuid = playerUuid;
+        }
+
+        public String getPlayerName() {
+            return playerName;
+        }
+
+        public void setPlayerName(String playerName) {
+            this.playerName = playerName;
+        }
+
+        public int getLoginCount() {
+            return loginCount;
+        }
+
+        public void setLoginCount(int loginCount) {
+            this.loginCount = loginCount;
+        }
+    }
+
+    @BeforeAll
+    static void setUpClass() {
+        if (Bukkit.getServer() == null) {
+            Server mockServer = mock(Server.class);
+            Logger mockLogger = mock(Logger.class);
+            when(mockServer.getLogger()).thenReturn(mockLogger);
+            Bukkit.setServer(mockServer);
+        }
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:h2:mem:jsonquerysemantics;DB_CLOSE_DELAY=-1;MODE=MySQL");
+        config.setUsername("sa");
+        config.setPassword(H2_AUTH); // nosemgrep: java.lang.security.audit.hardcoded-password
+        dataSource = new HikariDataSource(config);
+    }
+
+    @BeforeEach
+    void setUp() {
+        json = new SimpleJsonDataOperator<>(tempDir.toFile().getAbsolutePath(), PlayerRecord.class);
+    }
+
+    private static WhereCondition eq(String column, Object value) {
+        return WhereCondition.builder().column(column).value(value).build();
+    }
+
+    private static List<String> idsOf(List<PlayerRecord> records) {
+        return records.stream().map(PlayerRecord::getId).sorted().collect(Collectors.toList());
+    }
+
+    // ==================== #176 列名解析 ====================
+
+    @Nested
+    @DisplayName("#176 列名解析")
+    class ColumnNameResolution {
+
+        @BeforeEach
+        void seed() {
+            json.insert(new PlayerRecord("1", "uuid-aaa", "Alice", 3));
+            json.insert(new PlayerRecord("2", "uuid-bbb", "Bob", 7));
+        }
+
+        @Test
+        @DisplayName("按 @Column 的 SQL 列名查询应命中（修复前恒为空）")
+        void shouldMatchBySqlColumnName() {
+            List<PlayerRecord> found = json.getAll(eq("player_uuid", "uuid-aaa"));
+
+            assertThat(found)
+                    .as("调用方给的是 @Column(\"player_uuid\")，JSON 侧必须把它翻译成字段 playerUuid")
+                    .hasSize(1);
+            assertThat(found.get(0).getPlayerName()).isEqualTo("Alice");
+        }
+
+        @Test
+        @DisplayName("按 Java 字段名查询仍应命中（向后兼容，未知列名原样透传）")
+        void shouldStillMatchByJavaFieldName() {
+            assertThat(json.getAll(eq("playerUuid", "uuid-bbb")))
+                    .as("旧调用直接写字段名，不能因为引入映射而失效")
+                    .hasSize(1);
+        }
+
+        @Test
+        @DisplayName("列名大小写不敏感，与关系型后端一致")
+        void shouldResolveColumnCaseInsensitively() {
+            assertThat(json.getAll(eq("PLAYER_UUID", "uuid-aaa"))).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("完全未知的列名返回空集而不是抛异常")
+        void shouldReturnEmptyForUnknownColumn() {
+            assertThat(json.getAll(eq("no_such_column", "whatever"))).isEmpty();
+        }
+
+        @Test
+        @DisplayName("getLike 也应认 SQL 列名")
+        void getLikeShouldResolveColumnName() {
+            assertThat(json.getLike("player_name", "Ali", LikeType.START))
+                    .as("getLike 与 getAll 走同一套列名域，不能只修一半")
+                    .hasSize(1);
+        }
+
+        @Test
+        @DisplayName("update(列名, 值, id) 应真正写入而不是静默丢弃")
+        void updateByColumnShouldActuallyWrite() {
+            json.update("player_name", "Alice2", "1");
+
+            assertThat(json.getById("1").getPlayerName())
+                    .as("列名不解析时 putByPath 会写进一个 Gson 反序列化时丢弃的新键，表现为静默丢写")
+                    .isEqualTo("Alice2");
+        }
+    }
+
+    // ==================== #176 跨后端一致性 ====================
+
+    @Nested
+    @DisplayName("#176 json 与 sqlite 两个后端结果集一致")
+    class CrossBackendParity {
+
+        private SQLiteDataOperator<PlayerRecord> sqlite;
+
+        @BeforeEach
+        void setUpBackends() throws Exception {
+            try (Connection conn = dataSource.getConnection();
+                 Statement stmt = conn.createStatement()) {
+                stmt.execute("DROP TABLE IF EXISTS player_record");
+            }
+            sqlite = new SQLiteDataOperator<>(dataSource, PlayerRecord.class);
+
+            for (PlayerRecord record : new PlayerRecord[]{
+                    new PlayerRecord("1", "uuid-aaa", "Alice", 3),
+                    new PlayerRecord("2", "uuid-bbb", "Bob", 7),
+                    new PlayerRecord("3", "uuid-ccc", "Alice", 7)}) {
+                json.insert(record);
+                sqlite.insert(record);
+            }
+        }
+
+        @Test
+        @DisplayName("单条件 where(@Column 名) 两个后端返回同一结果集")
+        void singleConditionShouldAgree() {
+            WhereCondition condition = eq("player_name", "Alice");
+
+            assertThat(idsOf(json.getAll(condition)))
+                    .as("同一个 @Column 列名，两个后端必须给出同一批行")
+                    .isEqualTo(idsOf(sqlite.getAll(condition)))
+                    .containsExactly("1", "3");
+        }
+
+        @Test
+        @DisplayName("多条件 AND 两个后端返回同一结果集")
+        void multiConditionShouldAgree() {
+            WhereCondition[] conditions = {eq("player_name", "Alice"), eq("login_count", 7)};
+
+            assertThat(idsOf(json.getAll(conditions)))
+                    .isEqualTo(idsOf(sqlite.getAll(conditions)))
+                    .containsExactly("3");
+        }
+
+        @Test
+        @DisplayName("首个条件零命中时两个后端都返回空集")
+        void firstConditionMissShouldAgree() {
+            WhereCondition[] conditions = {eq("player_uuid", "uuid-none"), eq("login_count", 7)};
+
+            assertThat(idsOf(json.getAll(conditions)))
+                    .as("SQL 的 AND 在这里给空集，JSON 侧不能给出第二个条件的命中集")
+                    .isEqualTo(idsOf(sqlite.getAll(conditions)))
+                    .isEmpty();
+        }
+    }
+
+    // ==================== #192 AND 交集 ====================
+
+    @Nested
+    @DisplayName("#192 多条件 AND 是交集")
+    class AndIntersection {
+
+        @BeforeEach
+        void seed() {
+            json.insert(new PlayerRecord("1", "uuid-aaa", "Alice", 7));
+            json.insert(new PlayerRecord("2", "uuid-bbb", "Bob", 7));
+            json.insert(new PlayerRecord("3", "uuid-ccc", "Carol", 9));
+        }
+
+        @Test
+        @DisplayName("首个条件零命中 → getAll 返回空集")
+        void firstConditionEmptyYieldsEmptyResult() {
+            List<PlayerRecord> found = json.getAll(
+                    eq("player_uuid", "uuid-does-not-exist"),
+                    eq("login_count", 7));
+
+            assertThat(found)
+                    .as("修复前 results 为空会导致第二个条件的命中集被整体采纳，AND 退化成 OR")
+                    .isEmpty();
+        }
+
+        @Test
+        @DisplayName("首个条件零命中 → del 一行都不删")
+        void firstConditionEmptyDeletesNothing() {
+            json.del(
+                    eq("player_uuid", "uuid-does-not-exist"),
+                    eq("login_count", 7));
+
+            assertThat(json.getAll())
+                    .as("这是本 issue 的真实危害：修复前会删掉第二个条件命中的全部行")
+                    .hasSize(3);
+        }
+
+        @Test
+        @DisplayName("中间条件零命中 → 同样得到空集")
+        void middleConditionEmptyYieldsEmptyResult() {
+            assertThat(json.getAll(
+                    eq("login_count", 7),
+                    eq("player_name", "NoSuchPlayer"),
+                    eq("player_uuid", "uuid-aaa")))
+                    .isEmpty();
+        }
+
+        @Test
+        @DisplayName("正常交集语义不受影响")
+        void normalIntersectionStillWorks() {
+            assertThat(idsOf(json.getAll(eq("login_count", 7), eq("player_name", "Bob"))))
+                    .containsExactly("2");
+        }
+
+        @Test
+        @DisplayName("del 的正常交集语义不受影响")
+        void normalDeleteIntersectionStillWorks() {
+            json.del(eq("login_count", 7), eq("player_name", "Bob"));
+
+            assertThat(idsOf(json.getAll())).containsExactly("1", "3");
+        }
+    }
+
+    // ==================== 空条件语义 ====================
+
+    @Nested
+    @DisplayName("空条件语义")
+    class EmptyConditionSemantics {
+
+        @BeforeEach
+        void seed() {
+            json.insert(new PlayerRecord("1", "uuid-aaa", "Alice", 3));
+            json.insert(new PlayerRecord("2", "uuid-bbb", "Bob", 7));
+        }
+
+        @Test
+        @DisplayName("getAll() 与 getAll(empty) 返回全量")
+        void emptyConditionReturnsEverything() {
+            assertThat(json.getAll()).hasSize(2);
+            assertThat(json.getAll(WhereCondition.empty())).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("零个条件返回空集（page/exist 依赖此历史行为）")
+        void zeroConditionsReturnEmpty() {
+            assertThat(json.getAll(new WhereCondition[0])).isEmpty();
+        }
+
+        @Test
+        @DisplayName("空条件与实条件混用时，空条件不施加约束")
+        void emptyConditionDoesNotOverrideRealOne() {
+            assertThat(idsOf(json.getAll(eq("player_name", "Bob"), WhereCondition.empty())))
+                    .as("空条件排在后面时，原先会中途 return 全量，把真条件整个吃掉")
+                    .containsExactly("2");
+        }
+    }
+}


### PR DESCRIPTION
Closes #176
Closes #192

## 为什么合成一个 PR

两条 issue 互相点名：`#176` 写「必须与 `#192` 同版本发布」，`#192` 写「目前被 `#176` 挡住」。分开合会让 `alpha` 出现一个「列名对了但交集错了」的窗口 —— 那正是 `#192` 描述的数据丢失路径**可触发**的状态。这与 `#181`+`#223` 必须同 PR 是同一种结构。

下面负向对照 A/B 的差异就是这件事的实证：同样三条用例，在「两条都没修」时**假通过**，在「只修 `#176`」时失败。

## 根因复核

### `#176` 列名域错配

`SimpleJsonDataOperator` 的 `GSON` 没有任何命名策略（全仓库零 `FieldNamingPolicy`、零 `@SerializedName`），所以 `GSON.toJson(entity)` 出来的 map 键是 **Java 字段名**：

```java
Map<String, Object> map = GSON.fromJson(GSON.toJson(each), mapType);
Object byPath = JsonPathUtil.getByPath(map, condition.getColumn());  // ← 给的是 SQL 列名
```

而所有调用方给的是 `@Column` 里的 **SQL 列名**（`QueryImpl.and(column).eq(value)` 原样透传）。`player_uuid` 在键为 `playerUuid` 的 map 里查不到 → `byPath == null` → `continue` → 恒零命中。

关系型侧早就处理了这件事，`AbstractRelationalDataOperator#getListHandler()` 里有现成先例：

```java
String fieldName = columnToFieldName.getOrDefault(colName, colName);
```

本 PR 就是把同一份映射搬到 JSON 侧，键、大小写策略、fallback 语义都与它对齐。

### `#192` AND 退化成 OR

`getAll` 与 `del` 里逐字重复的同一段：

```java
if (results.size() == 0) {
    results.addAll(collection);      // ← 首个条件零命中时，这里会整体采纳第二个条件的命中集
} else {
    results.removeIf(a -> !collection.contains(a));
}
```

判据用的是「累积结果是否为空」，而不是「这是不是第一个条件」。首个条件零命中 → `results` 为空 → 第二个条件走 `addAll` 分支 → AND 变成「采信后一个条件」。在 `del` 上就是删掉后一条件的全部命中行。

## 改动

`SimpleJsonDataOperator`（+81/−10，单文件）：

1. 构造期从 `@Column` 建一份不可变的 `columnToFieldName`（小写列名 → 字段名），沿继承链收集，因此 `BaseDataEntity` 继承来的 `@Column("id")` 也在内。
2. 新增 `resolveColumn(String)`：命中 `@Column` 就换成字段名，**否则原样返回**。这个 fallback 让直接写 Java 字段名的旧调用、以及 `JsonPathUtil` 的点分隔嵌套路径（`"a.b.c"`）都不受影响。
3. 把 `if (results.size() == 0)` 换成 `firstCondition` 标志位，`getAll` 与 `del` 两处同步。

### 超出 issue 正文的两处，请重点看

**① 列名解析同时应用到 `getLike` 与 `update(String column, …)`。** 两条 issue 只谈了 `where`，但这两个方法收的也是列名、走的也是 `JsonPathUtil`，缺陷完全相同。`update` 那处更糟 —— `putByPath` 会写进一个 Gson 反序列化时直接丢弃的新键，表现为**静默丢写**。只修 `where` 会留下同一个 bug 的两个副本。

**② `getAll` 的空条件处理从循环里提了出来。** 原先 `if (condition.isEmpty()) return 全量;` 写在循环体内，意味着 `getAll(实条件, 空条件)` 会中途返回全表、把真条件整个吃掉。新写法先滤掉空条件再判断。**历史行为逐条保留**：`getAll()` / `getAll(empty)` 仍返回全量，**零个条件仍返回空集**（`page()` 与 `exist()` 依赖它，现有测试 `testPageWithNoConditions` 也钉着它）。

### 刻意没做的一处

`del` **没有**跟着加空条件处理。查询侧「空条件 = 不过滤 = 返回全量」是合理的，同样的语义搬到删除侧就是「删光全表」。现在 `del(WhereCondition.empty())` 会在取 `getValue()` 时 NPE —— 难看，但失败方向是安全的，把它「修」成对称反而制造一条真正的删库路径。已在代码里留注释说明。这是一处独立的既有缺陷，不在本 PR 范围内。

## 负向对照

新测试全部验证过不是空测试。两次对照分别只回退一侧：

| 对照 | 状态 | 结果 |
|---|---|---|
| **A** | 两条都回退到修复前 | 17 条里 **9 条失败** |
| **B** | 只回退 `#192` 的交集逻辑，保留 `#176` | 17 条里 **4 条失败**，且恰好是 4 条 `#192` 专属用例 |
| 完整修复 | — | 17 条全过 |

**A 与 B 的差异是本 PR 最重要的一条证据**：`firstConditionEmptyYieldsEmptyResult`、`firstConditionEmptyDeletesNothing`、`middleConditionEmptyYieldsEmptyResult` 这三条在 A（全不修）里**通过**，在 B（只修 `#176`）里**失败**。因为全不修时所有查询都零命中，交集缺陷根本没有触发机会 —— 这就是 `#192` 所说的「被 `#176` 挡住」，也是两条必须同发的直接证明。

## 测试

新增 `JsonQuerySemanticsTest`，17 条分四组：

- **ColumnNameResolution**（6）—— SQL 列名命中、Java 字段名向后兼容、大小写不敏感、未知列名返回空集、`getLike`、`update` 真正写入
- **CrossBackendParity**（3）—— `#176` 验收要求的那条：同一个 `where(<@Column 名>)` 在 `SimpleJsonDataOperator` 与 `SQLiteDataOperator`（H2/MySQL 模式）上返回同一结果集，覆盖单条件、多条件、首条件零命中
- **AndIntersection**（5）—— `#192` 验收要求的那条：首条件零命中时 `getAll` 空集、`del` 零删除；另加中间条件零命中与两条正常交集回归
- **EmptyConditionSemantics**（3）—— 钉住上面提到的空条件行为，含「零个条件返回空集」这条历史行为

测试实体 `PlayerRecord` 刻意做成 `@Column("player_uuid") private String playerUuid` —— 与 issue 里 `LoginService` 的真实形状一致。**列名与字段名相同的实体测不出这个缺陷**，现有 `SimpleJsonDataOperatorTest` 的 `TestData` 正是如此（无 `@Column`），所以 93 条既有用例一条都没报警。

既有 JSON/SQLite 测试 93 条全部保持通过。

## 影响面

仓内 `@Column` 只有 `AbstractDataEntity` 的 `id`（列名与字段名相同）和 `AuditableDataEntity` 的四个 snake→camel 审计字段，**不存在「列名恰好等于另一个字段名」的碰撞**。那四个审计字段在 JSON 后端此前同样查不到，一并修好。

## 验收对照

`#176`
- [x] JSON 侧读 `@Column` 认 SQL 列名，用 column→field 映射，做法与关系型读路径一致
- [x] 新增 `where(<@Column 名>)` 在 json 与 sqlite 两个后端返回同一结果集的测试
- [ ] 「在 `datasource.type: json` 下跑通 UltiLogin 的注册与登录流程」—— 跨仓真机验收，本仓库内以跨后端一致性测试覆盖同一断言；需要真机确认的话可以另行安排

`#192`
- [x] 改为真正的交集语义，首个条件建立初始集合，其后一律求交，空集保持空集
- [x] `del` 路径同步修正
- [x] 测试：两个条件、第一个零命中、第二个命中若干，断言 `getAll` 返回空、`del` 删除零行
