### PR TITLE
fix: @Autowired(required) 从不被读取，本版先发 WARNING（#182）

### DIFF
--- a/src/main/java/com/ultikits/ultitools/context/AutowireFactory.java
+++ b/src/main/java/com/ultikits/ultitools/context/AutowireFactory.java
@@ -3,6 +3,8 @@ package com.ultikits.ultitools.context;
 import com.ultikits.ultitools.annotations.Autowired;
 
 import java.lang.reflect.Field;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
@@ -13,6 +15,8 @@ import org.jetbrains.annotations.ApiStatus;
 @SuppressWarnings("PMD.AvoidAccessibilityAlteration") // Autowiring requires reflection
 @ApiStatus.Internal
 public class AutowireFactory {
+    private static final Logger LOGGER = Logger.getLogger(AutowireFactory.class.getName());
+
     private final SimpleContainer container;
 
     public AutowireFactory(SimpleContainer container) {
@@ -34,20 +38,53 @@ public class AutowireFactory {
             Field[] fields = clazz.getDeclaredFields();
             
             for (Field field : fields) {
-                if (field.isAnnotationPresent(Autowired.class)) {
+                Autowired autowired = field.getAnnotation(Autowired.class);
+                if (autowired != null) {
                     try {
                         field.setAccessible(true);
                         Object dependency = container.getBean(field.getType());
                         if (dependency != null) {
                             field.set(bean, dependency);
+                        } else if (autowired.required()) {
+                            warnUnresolvedRequiredDependency(field);
                         }
                     } catch (IllegalAccessException e) {
                         throw new IllegalStateException("Failed to autowire field: " + field.getName(), e);
                     }
                 }
             }
-            
+
             clazz = clazz.getSuperclass();
         }
+    }
+
+    /**
+     * Warn that a {@code required = true} dependency could not be resolved.
+     * <br>
+     * 一个 {@code required = true} 的依赖没解析出来时发出警告。
+     * <p>
+     * 在此之前 {@code required()} 从来没被读过：解析不到就把字段留成 null，插件照常启动，
+     * NPE 在之后某处才炸，而模块作者分不清是「bean 没注册」「不在扫描范围」「宿主是 new 出来
+     * 的所以根本没走注入」还是「自己忘了写注解」——四种原因同一个症状。见 issue #182。
+     * <p>
+     * 本版只警告，不抛。可能已经有下游模块正带着 null 字段跑在生产上，需要一个版本的观察期；
+     * 改抛留给 6.3.0。构造器注入路径（{@code SimpleContainer#createBeanWithConstructorInjection}）
+     * 一直是直接抛的，两者的不一致也留到那时一起收。
+     *
+     * @param field the unresolved field <br> 没解析出来的字段
+     */
+    private void warnUnresolvedRequiredDependency(Field field) {
+        // 这个 Throwable 不是被抛出来的，它只负责把「哪条路径触发了这次注入」记进日志：
+        // 容器建 bean、命令注册、监听器注册、插件对象注入是四个不同的入口，
+        // 而模块作者拿到 NPE 的时候现场早就离开这里了。
+        Throwable site = new Throwable("@Autowired injection site (not a thrown exception; "
+                + "the stack below shows which code path triggered this injection)");
+        LOGGER.log(Level.WARNING, "[UltiTools-API] @Autowired could not resolve "
+                + field.getType().getName() + " for field " + field.getDeclaringClass().getName()
+                + "." + field.getName() + " - the field stays null, so the NullPointerException will "
+                + "surface somewhere else, not here. Check that the target class is annotated with "
+                + "@Service/@Component, that it is inside the module's scanBasePackages, and that the "
+                + "owning object was created by the container rather than with 'new'. "
+                + "Use @Autowired(required = false) if the dependency really is optional.", site);
     }
 }

--- a/src/test/java/com/ultikits/ultitools/context/AutowireFactoryTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/AutowireFactoryTest.java
@@ -1,9 +1,17 @@
 package com.ultikits.ultitools.context;
 
 import com.ultikits.ultitools.annotations.Autowired;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -18,10 +26,61 @@ class AutowireFactoryTest {
     private SimpleContainer container;
     private AutowireFactory autowireFactory;
 
+    private final List<LogRecord> captured = new ArrayList<>();
+    private Logger factoryLogger;
+    private Handler captureHandler;
+    private Level previousLevel;
+    private boolean previousUseParentHandlers;
+
     @BeforeEach
     void setUp() {
         container = new SimpleContainer();
         autowireFactory = new AutowireFactory(container);
+
+        captured.clear();
+        factoryLogger = Logger.getLogger(AutowireFactory.class.getName());
+        previousLevel = factoryLogger.getLevel();
+        previousUseParentHandlers = factoryLogger.getUseParentHandlers();
+        // 关掉向上冒泡，否则这些用例每跑一条就往测试输出里打一段堆栈
+        factoryLogger.setUseParentHandlers(false);
+        factoryLogger.setLevel(Level.ALL);
+        captureHandler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                captured.add(record);
+            }
+
+            @Override
+            public void flush() {
+                // nothing buffered
+            }
+
+            @Override
+            public void close() {
+                // nothing to release
+            }
+        };
+        factoryLogger.addHandler(captureHandler);
+    }
+
+    @AfterEach
+    void tearDown() {
+        factoryLogger.removeHandler(captureHandler);
+        factoryLogger.setLevel(previousLevel);
+        factoryLogger.setUseParentHandlers(previousUseParentHandlers);
+    }
+
+    /**
+     * WARNING 级别的记录。别的级别（比如 SimpleContainer 的 fine）不算。
+     */
+    private List<LogRecord> warnings() {
+        List<LogRecord> result = new ArrayList<>();
+        for (LogRecord record : captured) {
+            if (Level.WARNING.equals(record.getLevel())) {
+                result.add(record);
+            }
+        }
+        return result;
     }
 
     @Test
@@ -111,6 +170,85 @@ class AutowireFactoryTest {
         assertEquals(service, controller.getService());
     }
 
+    @Test
+    @DisplayName("Should warn when a required dependency cannot be resolved")
+    void testWarnOnMissingRequiredDependency() {
+        // Given - nothing registered, so TestRepository cannot be resolved
+        TestController controller = new TestController();
+
+        // When
+        autowireFactory.autowireBean(controller);
+
+        // Then
+        List<LogRecord> warnings = warnings();
+        assertEquals(1, warnings.size());
+        LogRecord record = warnings.get(0);
+        assertTrue(record.getMessage().contains(TestRepository.class.getName()),
+                "the warning must name the bean type that could not be resolved");
+        assertTrue(record.getMessage().contains(TestController.class.getName() + ".repository"),
+                "the warning must name the host field");
+        assertNotNull(record.getThrown(),
+                "the stack is the point: it tells the module author which code path triggered the injection");
+    }
+
+    @Test
+    @DisplayName("Should stay silent when required = false")
+    void testNoWarnWhenDependencyIsOptional() {
+        // Given
+        TestOptionalController controller = new TestOptionalController();
+
+        // When
+        autowireFactory.autowireBean(controller);
+
+        // Then - opting out is exactly what required = false means
+        assertNull(controller.getRepository());
+        assertTrue(warnings().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should stay silent when the dependency resolves")
+    void testNoWarnWhenDependencyResolves() {
+        // Given
+        container.registerType(TestRepository.class, new TestRepository());
+
+        // When
+        autowireFactory.autowireBean(new TestController());
+
+        // Then
+        assertTrue(warnings().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should name the declaring class for inherited fields")
+    void testWarnNamesDeclaringClassForInheritedField() {
+        // Given - the annotated field lives on the base class, not the one being autowired
+        TestExtendedController controller = new TestExtendedController();
+
+        // When
+        autowireFactory.autowireBean(controller);
+
+        // Then
+        assertEquals(1, warnings().size());
+        assertTrue(warnings().get(0).getMessage().contains(TestBaseController.class.getName() + ".service"),
+                "pointing at the subclass would send the author to a file that has no such field");
+    }
+
+    @Test
+    @DisplayName("Should not interrupt container refresh when a required dependency is missing")
+    void testRefreshIsNotInterrupted() {
+        // Given - a bean whose required dependency is not registered
+        container.registerBean(TestController.class);
+
+        // When - 本版只警告不抛，可能有下游模块正带着 null 字段跑在生产上
+        assertDoesNotThrow(() -> container.refresh());
+
+        // Then
+        TestController bean = container.getBean(TestController.class);
+        assertNotNull(bean);
+        assertNull(bean.getRepository());
+        assertFalse(warnings().isEmpty());
+    }
+
     // Test helper classes
     public static class TestRepository {
         public String getData() {
@@ -146,6 +284,15 @@ class AutowireFactoryTest {
 
         public TestService getService() {
             return service;
+        }
+    }
+
+    public static class TestOptionalController {
+        @Autowired(required = false)
+        private TestRepository repository;
+
+        public TestRepository getRepository() {
+            return repository;
         }
     }
 


### PR DESCRIPTION
Closes #182

## 问题

`@Autowired` 从引入起就声明了 `boolean required() default true`，但没有任何地方读它。`AutowireFactory` 解析不到 bean 就把字段留成 null 走人，插件照常启动，NPE 在之后某处才炸。

模块作者拿到那个 NPE 时，分不清是「bean 压根没注册」「不在 `scanBasePackages` 范围内」「宿主对象是 `new` 出来的所以根本没走注入」还是「自己忘了写注解」——**四种原因同一个症状**。而同一个容器类里的构造器注入路径（`SimpleContainer#createBeanWithConstructorInjection`）解析不到是**直接抛**的。

## 改动

`AutowireFactory` 读 `required()`，为 true 且解析为 null 时打一条 WARNING，写明缺的 bean 类型和宿主字段（都用全限定名，方便 grep），并附一个合成的 `Throwable` 带出堆栈。

堆栈不是装饰。`autowireBean` 有四个入口——容器建 bean、`CommandManager` 注册命令、`ListenerManager` 注册监听器、`PluginManager` 注入插件对象——**「宿主是怎么来的」正是四种原因里最难自查的一条**，堆栈直接把它答了。`Throwable` 的 message 里写明了它不是被抛出来的异常，免得读日志的人以为出了 exception。

`required = false` 时保持沉默——那正是这个标志的语义。

## 只警告，不抛

issue 正文要求本版只警告，我同意，理由在代码注释里也写了：**可能已经有下游模块正带着 null 字段跑在生产上**。改抛（以及跟构造器注入路径对齐）留给 6.3.0。

WARNING 级别还有一个附带好处：`SystemLogHandler` 只把 **SEVERE + 带 Throwable** 的记录送进 `ErrorReportCollector`，所以这条不会在观察期里把面板的错误上报刷爆；它仍然会作为普通日志（连堆栈）传给 UltiPanel。

## 影响面

框架自身**没有任何 `@Autowired` 字段**（`src/main/java` 里的命中全是注释、javadoc 和注解声明本身），所以核心启动不会自己刷屏。

`Modules/` 那边 **12 个模块共 80 个文件**用了 `@Autowired`，其中只有 3 处写了 `required = false`（`UltiSocial` 2 处、`UltiWorlds` 1 处）。这 3 处反而是个佐证：**已经有模块作者按「这个标志是生效的」在写代码了**，而框架一直把它们和必需依赖同等对待。剩下的全部依赖 `required = true` 默认值，所以观察期里真有解析不到的字段就会响——这正是想要的。

## 测试

`AutowireFactoryTest` 新增 5 个（4260 → 4265），本地 `mvn clean verify` 通过。

**两次负向对照**，分别打掉一个维度：

| 对照 | 改法 | 结果 |
|---|---|---|
| A | 完全不警告 | 挂 3 条（三条断言「警告发生了」的） |
| B | 无视 `required()`，一律警告 | 挂 1 条（`testNoWarnWhenDependencyIsOptional`） |

**A 单独跑是不够的**：只看 A 的话，一个「无条件警告」的实现能全绿通过——而那恰恰就是 issue 标题说的缺陷（`required()` 依然没被读）。只有 B 钉住了「真的读了这个标志」。对照 A 里那两条「应保持沉默」的用例是真空通过的。

## 一处风格取舍

日志文案用英文，跟 `SimpleContainer` 同包的既有日志（`Failed to create bean:`、`Bean 'x' was modified after early exposure.`）保持一致。容器内部的日志一直是英文，面向运维者的启动消息才走 i18n 中文；在一个子系统的输出里混两种语言比选任何一种都糟。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzTkgBjRdaTcLrbvkoaFkp