### PR TITLE
fix: API 兼容门禁挪到 bean 构造之前（#184）

### DIFF
--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -130,7 +130,11 @@ public class PluginManager {
             );
             return false;
         }
-        boolean result = invokeRegisterSelf(plugin);
+        // null 表示兼容性门禁拒了它，拒绝理由已经打过日志，这里不要再包一层通用错误。
+        if (plugin == null) {
+            return false;
+        }
+        boolean result = attemptPluginRegistration(plugin);
         if (result) {
             registerBukkit(plugin, true);
         }
@@ -173,7 +177,11 @@ public class PluginManager {
             );
             return false;
         }
-        boolean result = invokeRegisterSelf(plugin);
+        // 同上：null 是门禁拒绝，不是初始化失败。
+        if (plugin == null) {
+            return false;
+        }
+        boolean result = attemptPluginRegistration(plugin);
         if (result) {
             registerBukkit(plugin, false);
         }
@@ -185,6 +193,11 @@ public class PluginManager {
      * @return Register result <br> 注册结果
      */
     public boolean register(UltiToolsPlugin plugin) {
+        // 门禁先跑：这条路径的实例是调用方给的，容器还没建，被拒时一个 bean 都不会被构造。
+        // 见 issue #184。
+        if (!passesCompatibilityGates(plugin)) {
+            return false;
+        }
         try {
             SimpleContainer pluginContext = new SimpleContainer();
             plugin.setContext(pluginContext);
@@ -216,7 +229,7 @@ public class PluginManager {
             );
             return false;
         }
-        boolean result = invokeRegisterSelf(plugin);
+        boolean result = attemptPluginRegistration(plugin);
         if (result) {
             registerBukkit(plugin, false);
         }
@@ -427,23 +440,33 @@ public class PluginManager {
 
 
     /**
-     * Invoke registerSelf method.
+     * Compatibility gates that must run before the module's bean graph is built.
      * <br>
-     * 调用registerSelf方法。
+     * 必须跑在模块 bean 图构建之前的兼容性门禁。
+     * <p>
+     * 这两道门禁原先跑在 {@code initializePlugin} 之后，也就是容器 {@code refresh()}、整张
+     * bean 图连同 {@code @PostConstruct} 都已经跑完之后。倒置的后果正好落在它们唯一有意义的
+     * 场景上：针对更新 API 编译的模块，恰恰是那种 bean 会引用不存在方法的模块，它会先死在
+     * {@code refresh()} 里，被通用 catch 报成一条普通的初始化失败，而「UltiTools 版本过旧」
+     * 那句友好提示永远说不出口。见 issue #184。
+     * <p>
+     * 门禁只读 {@code plugin.yml} 里来的元数据（{@code api-version} / {@code main} /
+     * {@code version}），这些在实例构造完就已经就位，不需要容器。
      *
-     * @param plugin UltiTools plugin instance <br> UltiTools模块实例
-     * @return Register result <br> 注册结果
+     * @param plugin freshly constructed plugin instance, context not yet attached <br> 刚构造出来、还没挂上容器的插件实例
+     * @return true if the module may proceed to context construction <br> 允许继续建容器则为 true
      */
-    private boolean invokeRegisterSelf(UltiToolsPlugin plugin) {
-        if (hasNewerVersionLoaded(plugin)) {
-            return false;
-        }
-        if (!isUltiToolsVersionCompatible(plugin)) {
-            return false;
-        }
-        return attemptPluginRegistration(plugin);
+    private boolean passesCompatibilityGates(UltiToolsPlugin plugin) {
+        return !hasNewerVersionLoaded(plugin) && isUltiToolsVersionCompatible(plugin);
     }
 
+    /**
+     * 判定是否已经加载了同一模块的更新版本。**只判定，不改动已加载的模块。**
+     * <p>
+     * 卸掉被本次加载取代的旧版本是另一件事，见 {@link #unregisterSupersededVersions}。
+     * 两者拆开是因为判定要提前到 bean 构造之前，而卸载不能——提前卸载会让「新版本初始化失败」
+     * 变成「服务器上两个版本都没有」。
+     */
     private boolean hasNewerVersionLoaded(UltiToolsPlugin plugin) {
         for (UltiToolsPlugin existing : pluginList) {
             if (!existing.getMainClass().equals(plugin.getMainClass())) {
@@ -452,26 +475,38 @@ public class PluginManager {
             if (existing.isNewerVersionThan(plugin)) {
                 Bukkit.getLogger().log(Level.WARNING,
                         String.format("[UltiTools-API] %s load failed！There is already a new version！", plugin.getPluginName()));
-                plugin.getContext().close();
                 return true;
-            } else if (plugin.isNewerVersionThan(existing)) {
-                existing.unregisterSelf();
             }
         }
         return false;
+    }
+
+    /**
+     * 卸掉被本次加载取代的旧版本。必须等新模块初始化成功之后才调用。
+     */
+    private void unregisterSupersededVersions(UltiToolsPlugin plugin) {
+        for (UltiToolsPlugin existing : pluginList) {
+            if (!existing.getMainClass().equals(plugin.getMainClass())) {
+                continue;
+            }
+            if (plugin.isNewerVersionThan(existing)) {
+                existing.unregisterSelf();
+            }
+        }
     }
 
     private boolean isUltiToolsVersionCompatible(UltiToolsPlugin plugin) {
         if (plugin.getMinUltiToolsVersion() > UltiTools.getPluginVersion()) {
             Bukkit.getLogger().log(Level.WARNING,
                     String.format("[UltiTools-API] %s load failed！UltiTools version is outdated！", plugin.getPluginName()));
-            plugin.getContext().close();
             return false;
         }
         return true;
     }
 
     private boolean attemptPluginRegistration(UltiToolsPlugin plugin) {
+        // 到这一步新模块已经初始化成功，可以安全地把它取代掉的旧版本卸下来了。
+        unregisterSupersededVersions(plugin);
         try {
             boolean registerSelf = plugin.registerSelf();
             if (registerSelf) {
@@ -543,21 +578,17 @@ public class PluginManager {
      * @param classLoader     Class loader <br> 类加载器
      * @param pluginClass     Plugin class <br> 插件类
      * @param constructorArgs Constructor arguments <br> 构造器参数
-     * @return UltiTools plugin instance <br> UltiTools模块实例
+     * @return the initialized module, or {@code null} if a compatibility gate rejected it
+     *         <br> 初始化好的模块；被兼容性门禁拒绝时返回 {@code null}
      */
     private UltiToolsPlugin initializePlugin(ClassLoader classLoader, Class<? extends UltiToolsPlugin> pluginClass, Object... constructorArgs) {
         // 验证构造器参数安全性
         if (!validateConstructorArgs(constructorArgs)) {
             throw new SecurityException("Invalid constructor arguments provided");
         }
-        
-        SimpleContainer pluginContext = new SimpleContainer();
-        pluginContext.setParent(UltiTools.getInstance().getDependenceManagers().getContext());
-        pluginContext.registerShutdownHook();
-        pluginContext.setClassLoader(classLoader);
+
+        UltiToolsPlugin plugin;
         try {
-            UltiToolsPlugin plugin;
-            
             if (constructorArgs.length == 0) {
                 // 使用默认构造器
                 Constructor<? extends UltiToolsPlugin> constructor = pluginClass.getDeclaredConstructor();
@@ -570,17 +601,31 @@ public class PluginManager {
                         throw new SecurityException("Null constructor argument not allowed at index: " + i);
                     }
                     paramTypes[i] = constructorArgs[i].getClass();
-                    
+
                     // 验证参数类型是否安全
                     if (!isSafeParameterType(paramTypes[i])) {
                         throw new SecurityException("Unsafe parameter type: " + paramTypes[i].getName());
                     }
                 }
-                
+
                 Constructor<? extends UltiToolsPlugin> constructor = pluginClass.getDeclaredConstructor(paramTypes);
                 plugin = constructor.newInstance(constructorArgs);
             }
-            
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to initialize plugin: " + pluginClass.getName(), e);
+        }
+
+        // 门禁跑在建容器之前。它读的元数据在实例构造完就已经就位，而 refresh() 之后才检查
+        // 等于先让不兼容的 bean 图跑一遍——那正是它会炸的地方。见 passesCompatibilityGates。
+        if (!passesCompatibilityGates(plugin)) {
+            return null;
+        }
+
+        SimpleContainer pluginContext = new SimpleContainer();
+        pluginContext.setParent(UltiTools.getInstance().getDependenceManagers().getContext());
+        pluginContext.registerShutdownHook();
+        pluginContext.setClassLoader(classLoader);
+        try {
             pluginContext.getBeanFactory().registerSingleton(pluginClass.getSimpleName(), plugin);
             // Register plugin as UltiToolsPlugin type so services can inject it via constructor
             pluginContext.registerType(UltiToolsPlugin.class, plugin);

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerTest.java
@@ -2,7 +2,13 @@ package com.ultikits.ultitools.manager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -11,6 +17,9 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 import org.junit.jupiter.api.AfterEach;
@@ -20,9 +29,14 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InOrder;
+import org.mockito.MockedStatic;
 
+import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
+import com.ultikits.ultitools.context.SimpleContainer;
 
+import org.bukkit.Bukkit;
 import org.mockbukkit.mockbukkit.MockBukkit;
 
 /**
@@ -730,6 +744,176 @@ class PluginManagerTest {
 
             // Assert
             assertThat(java.lang.reflect.Modifier.isPublic(method.getModifiers())).isTrue();
+        }
+    }
+
+    /**
+     * 兼容性门禁的时序测试。
+     * <p>
+     * 守的是 issue #184：门禁原先跑在容器 refresh() 之后，于是「UltiTools 版本过旧」那句提示
+     * 在它唯一有意义的场景里（模块的 bean 引用了不存在的方法）永远说不出口——模块先死在
+     * refresh 里，被通用 catch 报成普通初始化失败。
+     * <p>
+     * 这里用 {@code register(UltiToolsPlugin)} 这条路径：实例由调用方给，容器由 PluginManager
+     * 现建，所以「有没有发生 bean 构造」可以直接用 {@code setContext} 有没有被调过来观测。
+     */
+    @Nested
+    @DisplayName("兼容性门禁时序测试")
+    class CompatibilityGateOrderingTests {
+
+        private static final int CURRENT_API_VERSION = 625;
+
+        private MockedStatic<UltiTools> ultiToolsStatic;
+        private final List<LogRecord> bukkitLogs = new ArrayList<>();
+        private Handler captureHandler;
+
+        @BeforeEach
+        void setUpGate() {
+            UltiTools ultiTools = mock(UltiTools.class);
+            DependenceManagers dependenceManagers = mock(DependenceManagers.class);
+            lenient().when(dependenceManagers.getContext()).thenReturn(new SimpleContainer());
+            lenient().when(ultiTools.getDependenceManagers()).thenReturn(dependenceManagers);
+            lenient().when(ultiTools.getLogger()).thenReturn(mockLogger);
+
+            // getPluginVersion() 走 getEnv() → getInstance().getTextResource("env.yml")，
+            // 而那个方法在 JavaPlugin 里是 protected，测试包里打不了桩，所以直接桩静态方法。
+            ultiToolsStatic = mockStatic(UltiTools.class);
+            ultiToolsStatic.when(UltiTools::getInstance).thenReturn(ultiTools);
+            ultiToolsStatic.when(UltiTools::getPluginVersion).thenReturn(CURRENT_API_VERSION);
+
+            bukkitLogs.clear();
+            captureHandler = new Handler() {
+                @Override
+                public void publish(LogRecord record) {
+                    bukkitLogs.add(record);
+                }
+
+                @Override
+                public void flush() {
+                    // nothing buffered
+                }
+
+                @Override
+                public void close() {
+                    // nothing to release
+                }
+            };
+            Bukkit.getLogger().addHandler(captureHandler);
+        }
+
+        @AfterEach
+        void tearDownGate() {
+            Bukkit.getLogger().removeHandler(captureHandler);
+            if (ultiToolsStatic != null) {
+                ultiToolsStatic.close();
+            }
+        }
+
+        private UltiToolsPlugin modules(String name, String mainClass, String version, int minApiVersion) {
+            UltiToolsPlugin plugin = mock(UltiToolsPlugin.class);
+            lenient().when(plugin.getPluginName()).thenReturn(name);
+            lenient().when(plugin.getMainClass()).thenReturn(mainClass);
+            lenient().when(plugin.getVersion()).thenReturn(version);
+            lenient().when(plugin.getMinUltiToolsVersion()).thenReturn(minApiVersion);
+            return plugin;
+        }
+
+        private String warnings() {
+            StringBuilder joined = new StringBuilder();
+            for (LogRecord record : bukkitLogs) {
+                if (Level.WARNING.equals(record.getLevel())) {
+                    joined.append(record.getMessage()).append('\n');
+                }
+            }
+            return joined.toString();
+        }
+
+        @Test
+        @DisplayName("声明了更高 API 版本的模块应该在任何 bean 被构造之前就被拒绝")
+        void incompatibleModuleShouldBeRejectedBeforeAnyBeanIsBuilt() throws Exception {
+            // Arrange - 针对未来 API 编译的模块，正是那种 bean 会引用不存在方法的模块
+            UltiToolsPlugin plugin = modules("FutureModule", "com.example.FutureModule",
+                    "1.0.0", CURRENT_API_VERSION + 1);
+
+            // Act
+            boolean result = pluginManager.register(plugin);
+
+            // Assert
+            assertThat(result).isFalse();
+            assertThat(warnings()).contains("UltiTools version is outdated");
+            verify(plugin, never()).setContext(any());
+            verify(plugin, never()).registerSelf();
+        }
+
+        @Test
+        @DisplayName("版本兼容的模块应该被放行去建容器")
+        void compatibleModuleShouldProceedToContextConstruction() throws Exception {
+            // Arrange
+            UltiToolsPlugin plugin = modules("OkModule", "com.example.OkModule",
+                    "1.0.0", CURRENT_API_VERSION);
+            when(plugin.registerSelf()).thenReturn(true);
+
+            // Act
+            boolean result = pluginManager.register(plugin);
+
+            // Assert
+            assertThat(result).isTrue();
+            verify(plugin).setContext(any());
+        }
+
+        @Test
+        @DisplayName("已经加载了更新版本时也应该在建容器之前拒绝")
+        void supersededModuleShouldBeRejectedBeforeContextConstruction() {
+            // Arrange
+            UltiToolsPlugin loaded = modules("Dup", "com.example.Dup", "2.0.0", CURRENT_API_VERSION);
+            UltiToolsPlugin older = modules("Dup", "com.example.Dup", "1.0.0", CURRENT_API_VERSION);
+            when(loaded.isNewerVersionThan(older)).thenReturn(true);
+            pluginManager.getPluginList().add(loaded);
+
+            // Act
+            boolean result = pluginManager.register(older);
+
+            // Assert
+            assertThat(result).isFalse();
+            assertThat(warnings()).contains("There is already a new version");
+            verify(older, never()).setContext(any());
+        }
+
+        @Test
+        @DisplayName("被取代的旧版本要等新模块初始化成功之后才卸载")
+        void olderVersionShouldBeUnregisteredOnlyAfterInitialization() throws Exception {
+            // Arrange
+            UltiToolsPlugin older = modules("Dup", "com.example.Dup", "1.0.0", CURRENT_API_VERSION);
+            UltiToolsPlugin newer = modules("Dup", "com.example.Dup", "2.0.0", CURRENT_API_VERSION);
+            when(newer.isNewerVersionThan(older)).thenReturn(true);
+            when(newer.registerSelf()).thenReturn(true);
+            pluginManager.getPluginList().add(older);
+
+            // Act
+            boolean result = pluginManager.register(newer);
+
+            // Assert - 顺序要求：先把新的建起来，再卸旧的
+            assertThat(result).isTrue();
+            InOrder order = inOrder(newer, older);
+            order.verify(newer).setContext(any());
+            order.verify(older).unregisterSelf();
+        }
+
+        @Test
+        @DisplayName("新模块因版本不兼容被拒时不应该顺手卸掉已加载的旧版本")
+        void rejectedModuleShouldNotUnregisterTheLoadedOlderVersion() {
+            // Arrange - 新版本更高但要求的 API 太新：拒它，同时不能动线上正在跑的那个
+            UltiToolsPlugin older = modules("Dup", "com.example.Dup", "1.0.0", CURRENT_API_VERSION);
+            UltiToolsPlugin newer = modules("Dup", "com.example.Dup", "2.0.0", CURRENT_API_VERSION + 1);
+            lenient().when(newer.isNewerVersionThan(older)).thenReturn(true);
+            pluginManager.getPluginList().add(older);
+
+            // Act
+            boolean result = pluginManager.register(newer);
+
+            // Assert
+            assertThat(result).isFalse();
+            verify(older, never()).unregisterSelf();
         }
     }
 }


### PR DESCRIPTION
Closes #184

## 问题

`register()` 先调 `initializePlugin()`——它在内部把整张 bean 图建完、`@PostConstruct` 也跑完——之后才回到调用方检查模块声明的 API 版本。

倒置的后果恰好落在这道检查唯一有意义的场景上：**针对更新 API 编译的模块，正是那种 bean 会引用不存在方法的模块**。它先死在 `refresh()` 里，被通用 catch 报成一条普通的「Cannot initialize plugin」，而「UltiTools version is outdated」——唯一能告诉服主该干什么的那句话——永远说不出口。重复版本检测有同样的倒置。

## 改动

两道门禁都挪到刚构造出来的实例上跑，此时容器还不存在。它们只读 `plugin.yml` 来的元数据（`api-version` / `main` / `version`），而这些在构造器里就已经填好，所以提前不损失任何信息。

`initializePlugin` 相应重排：先实例化 → 过门禁 → 再建容器。被拒的模块现在**根本不会有容器被建出来**，也就不再有「建了又关」和一个白注册的 shutdown hook。

## 两件刻意没跟着挪的事

**① 卸载被取代的旧版本。** 原来的 `hasNewerVersionLoaded` 里混着一个 mutation：如果新版本更高，就 `existing.unregisterSelf()`。那是动作不是判定，跟着门禁提前会把「新模块初始化失败」变成「服务器上两个版本都没有」。现在拆成两个方法：判定留在门禁里，卸载放到 `attemptPluginRegistration` 开头——也就是新模块起来之后，跟改动前在序列里的位置一致。

**② 拒绝路径不再 `plugin.getContext().close()`。** 原先两道门禁各自调它，因为那时候容器已经建好了。现在门禁跑在建容器之前，没有容器可关。

顺带：`invokeRegisterSelf` 在门禁搬走之后只剩一句转发，删掉了，三个调用点直接调 `attemptPluginRegistration`。

## 测试

`PluginManagerTest` 新增 5 个（4265 → 4270），本地 `mvn clean verify` 通过。

走的是 `register(UltiToolsPlugin)` 这条路径：实例由调用方给、容器由 `PluginManager` 现建，所以**「有没有发生 bean 构造」可以直接用 `setContext` 有没有被调过来观测**，不需要去数容器内部状态。

`UltiTools.getPluginVersion()` 走 `getEnv()` → `getInstance().getTextResource("env.yml")`，而 `getTextResource` 在 `JavaPlugin` 里是 `protected`，测试包里打不了桩，所以直接 `mockStatic` 桩静态方法——跟 `MysqlDataStoreTest` 已有的做法一致。

**两次负向对照，各打掉一个维度：**

| 对照 | 改法 | 挂掉的用例 |
|---|---|---|
| A | 门禁挪回容器构造之后 | `incompatibleModuleShouldBeRejectedBeforeAnyBeanIsBuilt` · `supersededModuleShouldBeRejectedBeforeContextConstruction` |
| B | 卸载旧版本不延后，塞回门禁里 | `olderVersionShouldBeUnregisteredOnlyAfterInitialization` · `rejectedModuleShouldNotUnregisterTheLoadedOlderVersion` |

两组互不重叠，各自钉住一个性质：A 钉「拒绝发生在 bean 构造之前」，B 钉「卸载发生在初始化成功之后」。剩下的 `compatibleModuleShouldProceedToContextConstruction` 在两个对照里都通过——它是正向通路的守卫，不是时序断言，这里说明一下免得被当成对照证据。

行尾：`PluginManager.java` 是 CRLF，保住了（947/947）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzTkgBjRdaTcLrbvkoaFkp