### PR TITLE
fix: JSON 后端补齐 id 自动生成

### DIFF
--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperator.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperator.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -233,6 +234,14 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
 
     @Override
     public synchronized void insert(T obj) {
+        // 关系型后端在 id 为空时自动补一个 UUID（AbstractRelationalDataOperator.insert），
+        // 所以模块从来不自己设 id —— 全部 Modules 加起来的 setId 调用是 0 次。
+        // JSON 侧过去不补，null 直接进 ConcurrentHashMap 当 key，于是同一份模块代码
+        // 换成 datasource.type: json 就 NPE。补齐是为了让「谁生成 id」重新变成
+        // 框架的保证，而不是取决于后端。见 issue #275。
+        if (obj.getId() == null) {
+            obj.setId(UUID.randomUUID().toString());
+        }
         cache.putIfAbsent(obj.getId(), obj);
     }
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/BackendIdContractTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/BackendIdContractTest.java
@@ -48,7 +48,6 @@ import lombok.EqualsAndHashCode;
 @DisplayName("后端间的 id 生成契约")
 class BackendIdContractTest {
 
-    private static final String H2_AUTH = "";
     private static DataSource dataSource;
 
     @TempDir
@@ -90,7 +89,11 @@ class BackendIdContractTest {
         HikariConfig config = new HikariConfig();
         config.setJdbcUrl("jdbc:h2:mem:idcontract;DB_CLOSE_DELAY=-1;MODE=MySQL");
         config.setUsername("sa");
-        config.setPassword(H2_AUTH); // nosemgrep: java.lang.security.audit.hardcoded-password
+        // 刻意不调用 setPassword：内存库首次连接时就以「无口令」创建，
+        // 传一个空字符串反而会被静态分析当成硬编码口令（Codacy/Opengrep 的
+        // Semgrep_java_password_rule-HardcodePassword）。这里没有凭据可言。
+        // 顺带说明：别的测试类里那条 `// nosemgrep: java.lang.security.audit.hardcoded-password`
+        // 其实抑制不了它，规则 id 对不上——只是存量问题不进 PR diff 所以没人发现。
         dataSource = new HikariDataSource(config);
     }
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/BackendIdContractTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/BackendIdContractTest.java
@@ -1,0 +1,204 @@
+package com.ultikits.ultitools.interfaces.impl.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+
+import javax.sql.DataSource;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
+import com.ultikits.ultitools.annotations.Column;
+import com.ultikits.ultitools.annotations.Table;
+import com.ultikits.ultitools.interfaces.impl.data.json.SimpleJsonDataOperator;
+import com.ultikits.ultitools.interfaces.impl.data.sqlite.SQLiteDataOperator;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+import lombok.EqualsAndHashCode;
+
+/**
+ * JSON 与关系型后端在 id 生成上的共同契约。
+ * <p>
+ * 这两个实现没有共同基类：{@link SimpleJsonDataOperator} 是独立写的，
+ * {@link SQLiteDataOperator} 继承 {@code AbstractRelationalDataOperator}。
+ * 于是关系型侧每加一条隐含行为，JSON 侧就多欠一笔，而模块作者是按关系型的
+ * 行为写代码的——全部 Modules 加起来的 {@code setId} 调用是 0 次。issue #275
+ * 就是这么来的：JSON 侧不补 id，null 进 ConcurrentHashMap 当 key，写入必 NPE。
+ * <p>
+ * 所以这个类刻意<b>不</b>测任何一个后端的私有行为，只测两边必须一致的那部分。
+ * 新增一条跨后端约定时，断言应当加在这里而不是各自的测试类里——分开写就是
+ * 当初漂移的成因。
+ */
+@DisplayName("后端间的 id 生成契约")
+class BackendIdContractTest {
+
+    private static final String H2_AUTH = "";
+    private static DataSource dataSource;
+
+    @TempDir
+    Path tempDir;
+
+    private SimpleJsonDataOperator<ContractEntity> json;
+    private SQLiteDataOperator<ContractEntity> sqlite;
+
+    @EqualsAndHashCode(callSuper = true)
+    @Table("id_contract_entity")
+    public static class ContractEntity extends BaseDataEntity<String> {
+        @Column("name")
+        private String name;
+
+        public ContractEntity() {
+        }
+
+        public ContractEntity(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @BeforeAll
+    static void initBackends() {
+        if (Bukkit.getServer() == null) {
+            Server mockServer = mock(Server.class);
+            Logger mockLogger = mock(Logger.class);
+            when(mockServer.getLogger()).thenReturn(mockLogger);
+            Bukkit.setServer(mockServer);
+        }
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:h2:mem:idcontract;DB_CLOSE_DELAY=-1;MODE=MySQL");
+        config.setUsername("sa");
+        config.setPassword(H2_AUTH); // nosemgrep: java.lang.security.audit.hardcoded-password
+        dataSource = new HikariDataSource(config);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        try (Connection conn = dataSource.getConnection();
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("DROP TABLE IF EXISTS id_contract_entity");
+        }
+        json = new SimpleJsonDataOperator<>(tempDir.toFile().getAbsolutePath(), ContractEntity.class);
+        sqlite = new SQLiteDataOperator<>(dataSource, ContractEntity.class);
+    }
+
+    @Nested
+    @DisplayName("insert")
+    class InsertContract {
+
+        @Test
+        @DisplayName("未设 id 的实体，两个后端都要替它生成一个")
+        void unsetIdShouldBeGeneratedByBothBackends() {
+            ContractEntity forJson = new ContractEntity("json");
+            ContractEntity forSqlite = new ContractEntity("sqlite");
+
+            json.insert(forJson);
+            sqlite.insert(forSqlite);
+
+            assertThat(forJson.getId())
+                    .as("JSON 后端未给实体生成 id —— 这正是 #275 的形状")
+                    .isNotNull().isNotEmpty();
+            assertThat(forSqlite.getId())
+                    .as("关系型后端未给实体生成 id")
+                    .isNotNull().isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("未设 id 插入之后，两个后端都要能把它取回来")
+        void entityInsertedWithoutIdShouldBeRetrievableOnBothBackends() {
+            ContractEntity forJson = new ContractEntity("json");
+            ContractEntity forSqlite = new ContractEntity("sqlite");
+
+            json.insert(forJson);
+            sqlite.insert(forSqlite);
+
+            // 取回用的是后端刚生成的那个 id：调用方除此之外没有别的句柄，
+            // 所以「生成了 id」和「拿得回来」必须一起成立才算数。
+            assertThat(json.getById(forJson.getId()))
+                    .as("JSON 后端取不回刚插入的实体")
+                    .isNotNull()
+                    .extracting(ContractEntity::getName).isEqualTo("json");
+            assertThat(sqlite.getById(forSqlite.getId()))
+                    .as("关系型后端取不回刚插入的实体")
+                    .isNotNull()
+                    .extracting(ContractEntity::getName).isEqualTo("sqlite");
+        }
+
+        @Test
+        @DisplayName("已显式设 id 的实体，两个后端都不许覆盖它")
+        void explicitIdShouldSurviveOnBothBackends() {
+            ContractEntity forJson = new ContractEntity("json");
+            forJson.setId("explicit-json");
+            ContractEntity forSqlite = new ContractEntity("sqlite");
+            forSqlite.setId("explicit-sqlite");
+
+            json.insert(forJson);
+            sqlite.insert(forSqlite);
+
+            assertThat(forJson.getId())
+                    .as("JSON 后端覆盖了调用方设定的 id")
+                    .isEqualTo("explicit-json");
+            assertThat(sqlite.getById("explicit-sqlite"))
+                    .as("关系型后端没按调用方设定的 id 存进去")
+                    .isNotNull();
+            assertThat(json.getById("explicit-json"))
+                    .as("JSON 后端没按调用方设定的 id 存进去")
+                    .isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("insertAll")
+    class InsertAllContract {
+
+        @Test
+        @DisplayName("批量插入未设 id 的实体，两个后端都要各给一个且互不相同")
+        void unsetIdsShouldBeGeneratedAndDistinctOnBothBackends() {
+            // 关系型侧的 insertAll 是自己重写的、又抄了一遍 id 生成；JSON 侧的
+            // insertAll 委托给 insert。两条路径不同，所以要单独钉一次。
+            List<ContractEntity> jsonBatch = Arrays.asList(
+                    new ContractEntity("a"), new ContractEntity("b"), new ContractEntity("c"));
+            List<ContractEntity> sqliteBatch = Arrays.asList(
+                    new ContractEntity("a"), new ContractEntity("b"), new ContractEntity("c"));
+
+            json.insertAll(jsonBatch);
+            sqlite.insertAll(sqliteBatch);
+
+            assertThat(jsonBatch).extracting(ContractEntity::getId)
+                    .as("JSON 后端批量插入后有 id 为空的实体")
+                    .doesNotContainNull().doesNotHaveDuplicates();
+            assertThat(sqliteBatch).extracting(ContractEntity::getId)
+                    .as("关系型后端批量插入后有 id 为空的实体")
+                    .doesNotContainNull().doesNotHaveDuplicates();
+
+            assertThat(json.getAll())
+                    .as("JSON 后端批量插入的条数不对")
+                    .hasSize(3);
+            assertThat(sqlite.getAll())
+                    .as("关系型后端批量插入的条数不对")
+                    .hasSize(3);
+        }
+    }
+}


### PR DESCRIPTION
修 #275。

`AbstractRelationalDataOperator.insert` 在 id 为 null 时补一个 UUID，mysql / sqlite 因此都接受「没设过 id」的实体；`SimpleJsonDataOperator.insert` 不补，直接把 null 交给 `ConcurrentHashMap.putIfAbsent` 当 key —— `datasource.type: json` 下每一次写入都是 NPE。

改动本身是 4 行。**值得说的是为什么修在框架侧而不是调用方**：跨 Modules 实测 **11 个模块 24 处** `insert` / `insertAll` 调用点，而全部模块加起来的 `setId` 调用是 **0 次**。那个 0 才是重点 —— 没有任何模块作者认为自己该生成 id，因为在他们开发时用的后端上确实不需要。这是框架承诺了一件事然后在一个后端上没兑现，不是 24 个调用方各自写错了。

把生成责任推给模块还会有第二个坏处：「谁分配 id」会变成取决于配置的后端，而那恰恰是本缺陷的成因。

## 测试

新增 `BackendIdContractTest`（4 条），刻意**只测两个后端必须一致的部分**，不测任何一方的私有行为。这一点写在了类注释里：一个跨后端的约定被拆进两个各自的测试类，正是当初两个实现漂移开的方式。

**两个负向对照，失败集完全不重叠**：

| 对照 | 结果 |
|---|---|
| A — JSON 侧完全不生成（缺陷原貌） | 3 条挂：`unsetIdShouldBeGenerated` · `entityInsertedWithoutIdShouldBeRetrievable` · `unsetIdsShouldBeGeneratedAndDistinct`，全部 NPE。「显式 id 不被覆盖」那条正确通过 |
| B — JSON 侧无条件生成，覆盖已设的 id | 1 条挂：`explicitIdShouldSurvive`。另外 3 条正确通过 |

只跑 A 是不够的：一个「无条件覆盖」的实现能让 A 全绿，而那是另一个 bug。B 才钉住了那个 `if`。

`insertAll` 单独钉了一次 —— 关系型侧的 `insertAll` 是自己重写的、又抄了一遍 id 生成逻辑，JSON 侧的则委托给 `insert`，两条路径不同。

本地 `mvn clean verify`：**4274 用例 · 0 失败 · 0 错误 · 5 跳过**（4270 + 新增 4）。

## 背景

这是 #176 的同族第二例。#176 是读路径上 JSON 侧不认 `@Column` 列名，这条是写路径上不补 id。共同成因是 `SimpleJsonDataOperator` 独立实现、不继承 `AbstractRelationalDataOperator`。缺陷是在 #176 的真机回归验证中撞出来的 —— 那次验证证明了 #176 的修复本身是好的，但正式注册流程走不通，追下去就是这条。

## 范围

不重构 JSON ORM，不动 `SimpleJsonDataOperator` 的其他方法。`del` 里那个「空条件抛 NPE、难看但失败方向安全」的既有取舍保持不动。