### PR TITLE
chore: 带 cast 的 registerAll 重载标记为 6.3.0 移除

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -85,6 +85,7 @@ flatten-maven-plugin 处理后不含依赖声明，因此把 UltiTools-API 放�
 | `abstracts.AbstractCommandExecutor` | 6.2.1 | `abstracts.command.BaseCommandExecutor` | **15 个文件 / 6 个仓库** |
 | `abstracts.AbstractCommendExecutor`（拼写错误的空 shim） | 6.2.5 | 同上 | 0 |
 | `manager.CommandManager.register(CommandExecutor, …)` 的两个重载 | 6.2.5 | `register(UltiToolsPlugin, Class, String, String, String…)` | 0 |
+| `manager.CommandManager.registerAll(UltiToolsPlugin, String)` | 6.2.5 | `registerAll(UltiToolsPlugin)` | 0 |
 | `annotations.command.@OptionalParam` | 6.2.5 | 无替代——该注解从未实现，标注它不影响解析；改为每种可接受的参数形态各写一条 `@CmdMapping` | 0 |
 
 ### 版本适配

--- a/src/main/java/com/ultikits/ultitools/manager/CommandManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/CommandManager.java
@@ -113,7 +113,24 @@ public class CommandManager {
      *
      * @param plugin      UltiTools Plugin instance <br> 模块实例
      * @param packageName Package name <br> 包名
+     * @deprecated This overload casts every scanned class to {@link AbstractCommandExecutor},
+     *             which is itself scheduled for removal in 6.3.0. A command class written
+     *             against the current {@link com.ultikits.ultitools.abstracts.command.BaseCommandExecutor}
+     *             does not extend that type, so the cast throws {@link ClassCastException} —
+     *             and the surrounding catch lists only the four reflective checked exceptions,
+     *             so it escapes. Use {@link #registerAll(UltiToolsPlugin)}, which resolves
+     *             command classes as beans from the plugin's container and performs no cast.
+     *             See issue #272.
+     *             <p>
+     *             这个重载把扫描到的每个类都强转为 {@link AbstractCommandExecutor}，
+     *             而后者本身已计划在 6.3.0 移除。按当前推荐写法继承
+     *             {@link com.ultikits.ultitools.abstracts.command.BaseCommandExecutor}
+     *             的命令类不属于那个类型，强转必抛 {@link ClassCastException}，
+     *             且外层 catch 只列了四个反射类受检异常，异常会逃出去。
+     *             请改用 {@link #registerAll(UltiToolsPlugin)} —— 它从模块容器里按 bean
+     *             解析命令类，不做强转。见 issue #272。
      */
+    @Deprecated(since = "6.2.5", forRemoval = true)
     public void registerAll(UltiToolsPlugin plugin, String packageName) {
         Set<Class<?>> classes = PackageScanUtils.scanAnnotatedClasses(
                 CmdExecutor.class,

--- a/src/test/java/com/ultikits/ultitools/manager/CommandManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/CommandManagerTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Timeout;
 
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.AbstractCommandExecutor;
+import com.ultikits.ultitools.abstracts.command.BaseCommandExecutor;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.annotations.command.CmdExecutor;
 import com.ultikits.ultitools.annotations.command.CmdMapping;
@@ -1115,8 +1116,44 @@ class CommandManagerTest {
             
             // Act - 使用不存在的包名
             commandManager.registerAll(mockPlugin, "com.nonexistent.package");
-            
+
             // Assert - 不应该抛出异常
+        }
+
+        @Test
+        @DisplayName("BaseCommandExecutor 不属于本重载强转的类型——这是弃用它的全部依据")
+        void baseCommandExecutorIsNotAssignableToTheCastTarget() {
+            // 本重载把扫描到的每个类强转为 AbstractCommandExecutor。当代命令类继承的是
+            // BaseCommandExecutor，它 implements TabExecutor 而不继承前者，所以那次强转
+            // 必抛 ClassCastException——而外层 catch 只列了四个反射类受检异常，异常会逃出去。
+            //
+            // 这条断言钉住的是那个结论的**全部依据**：一条类型关系。不去跑真实包扫描，
+            // 因为那需要往测试树里放一个 @CmdExecutor 类，会被别的扫描测试捎带上，而这个
+            // 方法在 6.3.0 就删了，不值得为一个版本的寿命引入那种耦合。
+            //
+            // 如果哪天有人让 BaseCommandExecutor 继承了 AbstractCommandExecutor，弃用理由
+            // 就不再成立——这条会立刻变红，提醒去重新评估 issue #272 的结论。
+            assertThat(AbstractCommandExecutor.class.isAssignableFrom(BaseCommandExecutor.class))
+                    .as("BaseCommandExecutor 若继承了 AbstractCommandExecutor，#272 的弃用理由需重新评估")
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("本重载应当带着 forRemoval 标注，下游才会被 -Xlint:removal 点名")
+        void castingOverloadShouldBeMarkedForRemoval() throws Exception {
+            // COMPATIBILITY.md 把「你确实被点名警告过」定为可以移除的前提，而 javac 的
+            // -Xlint:removal 默认开启、-Xlint:deprecation 默认关闭。所以标注掉了不只是
+            // 文档不同步，是下游拿不到警告就被删了 API。
+            Method method = CommandManager.class.getDeclaredMethod(
+                    "registerAll", UltiToolsPlugin.class, String.class);
+            Deprecated deprecated = method.getAnnotation(Deprecated.class);
+
+            assertThat(deprecated)
+                    .as("registerAll(UltiToolsPlugin, String) 的 @Deprecated 标注不见了")
+                    .isNotNull();
+            assertThat(deprecated.forRemoval())
+                    .as("forRemoval 被改成了 false，下游将只收到不含 API 名的笼统提示")
+                    .isTrue();
         }
     }
 


### PR DESCRIPTION
处理 #272。

`registerAll(UltiToolsPlugin, String)` 把扫描到的每个类强转为 `AbstractCommandExecutor`，而**`AbstractCommandExecutor` 本身已经在 6.3.0 的移除清单里**（`COMPATIBILITY.md`，移除预告发自 6.2.1，下游 15 文件 / 6 仓库）。按当前推荐写法继承 `BaseCommandExecutor` 的命令类 implements `TabExecutor`、不继承那个类型，强转必抛 CCE —— 且外层 catch 只列了四个反射类受检异常，异常会逃出去。

**选弃用而不是修复，是从「这个方法是干什么的」推出来的**：它存在的唯一目的就是服务那个 legacy 基类。基类在 6.3.0 消失之后，一个「扫包并实例化它」的重载就无事可做了。`registerAll(UltiToolsPlugin)` 已经覆盖同样的场景 —— 从模块容器里按 bean 解析命令类，不做强转，而那正是模块加载实际走的路径。

**现在标、而不是 6.3.0 直接删，是关键**：`COMPATIBILITY.md` 把「你确实被点名警告过」定为移除的前提，而 javac 的 `-Xlint:removal` 默认开启、`-Xlint:deprecation` 默认关闭。不标的话，任何第三方调用者会**零警告**地迎接它的消失。

## 改动

- `CommandManager.registerAll(UltiToolsPlugin, String)` 加 `@Deprecated(since = "6.2.5", forRemoval = true)`，中英双语 javadoc 写明成因与替代
- `COMPATIBILITY.md` 的「命令」表加一行（移除预告发自 **6.2.5** · 替代 `registerAll(UltiToolsPlugin)` · 下游引用 **0**）

## 测试（2 条）

一条钉住 **CCE 断言的全部依据**——`AbstractCommandExecutor.isAssignableFrom(BaseCommandExecutor)` 为假。若哪天有人让 `BaseCommandExecutor` 继承了前者，弃用理由不再成立，这条会立刻变红而不是让理由静默失效。

⚠ **这一条我做不了负向对照**——要破坏它得真去改类继承关系。它是绊线不是回归测试，写在这里免得被当成对照证据。

另一条钉住**标注本身**。策略的执行点在编译器，而编译器对「有人把标注删了」无话可说。这条跑了两个负向对照，**分别命中不同断言行**：

| 对照 | 命中 |
|---|---|
| 标注整个去掉 | `:1153` 「@Deprecated 标注不见了」 |
| `forRemoval` 改成 `false` | `:1156` 「下游将只收到不含 API 名的笼统提示」 |

本地 `mvn clean verify`：**4276 用例 · 0 失败 · 0 错误 · 5 跳过**。

## 几个刻意的取舍

**不加任何 `@SuppressWarnings`。** 标注之后有 4 处产生 removal 警告（`PluginManager:730` 那条死路径调用 + 3 处测试）。仓库里现有 7 处 `@SuppressWarnings` 全是 `"deprecation"`、**零处 `"removal"`**，而构建里已有 96 条同类警告未被抑制。保持一致。

**不写复现 CCE 的集成测试。** 那需要往测试树里放一个 `@CmdExecutor` 类，会被别的包扫描测试捎带上；而这个方法一个 MINOR 之后就删了，不值得为一个版本的寿命引入那种耦合。

**`ListenerManager` 同路径的那个重载不在范围内**——查过了，它 cast 到 `Listener`，而 `@EventListener` 标注的类本来就必须实现 `Listener`，没有同类缺陷。

## 顺带说明现有测试的实际覆盖

`CommandManagerTest` 里原有 3 条「覆盖」这个重载的用例**全部传不存在或无命中的包名**，没有一条真正走到那行 cast。它们验证的是「不抛异常」，对 CCE 是真空通过的。这一点不改（它们仍是有效的健壮性用例），但记在这里，免得下次有人以为这个方法被测过了。