### PR TITLE
test: 清掉四处从未生效的 nosemgrep 抑制注释

### DIFF
--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/BackendIdContractTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/BackendIdContractTest.java
@@ -92,8 +92,6 @@ class BackendIdContractTest {
         // 刻意不调用 setPassword：内存库首次连接时就以「无口令」创建，
         // 传一个空字符串反而会被静态分析当成硬编码口令（Codacy/Opengrep 的
         // Semgrep_java_password_rule-HardcodePassword）。这里没有凭据可言。
-        // 顺带说明：别的测试类里那条 `// nosemgrep: java.lang.security.audit.hardcoded-password`
-        // 其实抑制不了它，规则 id 对不上——只是存量问题不进 PR diff 所以没人发现。
         dataSource = new HikariDataSource(config);
     }
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/TransactionDataOperatorTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/TransactionDataOperatorTest.java
@@ -33,7 +33,6 @@ import lombok.EqualsAndHashCode;
 @DisplayName("Transaction & Batch Operations - SQL Integration Tests")
 class TransactionDataOperatorTest {
 
-    private static final String H2_AUTH = "";
     private static DataSource dataSource;
     private SQLiteDataOperator<TestEntity> operator;
 
@@ -65,7 +64,9 @@ class TransactionDataOperatorTest {
         HikariConfig config = new HikariConfig();
         config.setJdbcUrl("jdbc:h2:mem:txtest;DB_CLOSE_DELAY=-1;MODE=MySQL");
         config.setUsername("sa");
-        config.setPassword(H2_AUTH); // nosemgrep: java.lang.security.audit.hardcoded-password
+        // 刻意不调用 setPassword：内存库首次连接时就以「无口令」创建，
+        // 传一个空字符串反而会被静态分析当成硬编码口令（Codacy/Opengrep 的
+        // Semgrep_java_password_rule-HardcodePassword）。这里没有凭据可言。
         dataSource = new HikariDataSource(config);
     }
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataOperatorTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataOperatorTest.java
@@ -32,7 +32,6 @@ import lombok.EqualsAndHashCode;
 @DisplayName("MysqlDataOperator 测试")
 class MysqlDataOperatorTest {
 
-    private static final String H2_AUTH = "";
     private static DataSource dataSource;
     private MysqlDataOperator<TestEntity> operator;
 
@@ -67,7 +66,9 @@ class MysqlDataOperatorTest {
         HikariConfig config = new HikariConfig();
         config.setJdbcUrl("jdbc:h2:mem:mysqltest;DB_CLOSE_DELAY=-1;MODE=MySQL");
         config.setUsername("sa");
-        config.setPassword(H2_AUTH); // nosemgrep: java.lang.security.audit.hardcoded-password
+        // 刻意不调用 setPassword：内存库首次连接时就以「无口令」创建，
+        // 传一个空字符串反而会被静态分析当成硬编码口令（Codacy/Opengrep 的
+        // Semgrep_java_password_rule-HardcodePassword）。这里没有凭据可言。
         dataSource = new HikariDataSource(config);
     }
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataOperatorTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataOperatorTest.java
@@ -32,7 +32,6 @@ import lombok.EqualsAndHashCode;
 @DisplayName("SQLiteDataOperator 测试")
 class SQLiteDataOperatorTest {
 
-    private static final String H2_AUTH = "";
     private static DataSource dataSource;
     private SQLiteDataOperator<TestEntity> operator;
 
@@ -70,7 +69,9 @@ class SQLiteDataOperatorTest {
         // Use H2 in MySQL compatibility mode for backtick support
         config.setJdbcUrl("jdbc:h2:mem:sqlitetest;DB_CLOSE_DELAY=-1;MODE=MySQL");
         config.setUsername("sa");
-        config.setPassword(H2_AUTH); // nosemgrep: java.lang.security.audit.hardcoded-password
+        // 刻意不调用 setPassword：内存库首次连接时就以「无口令」创建，
+        // 传一个空字符串反而会被静态分析当成硬编码口令（Codacy/Opengrep 的
+        // Semgrep_java_password_rule-HardcodePassword）。这里没有凭据可言。
         dataSource = new HikariDataSource(config);
     }
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
@@ -44,7 +44,6 @@ import lombok.EqualsAndHashCode;
 @DisplayName("SQLiteDataStore 测试")
 class SQLiteDataStoreTest {
 
-    private static final String H2_AUTH = "";
 
     @TempDir
     File tempDir;
@@ -108,7 +107,9 @@ class SQLiteDataStoreTest {
         // Use H2 in MySQL compatibility mode for backtick support
         config.setJdbcUrl("jdbc:h2:mem:sqlitestoretest" + System.nanoTime() + ";DB_CLOSE_DELAY=-1;MODE=MySQL");
         config.setUsername("sa");
-        config.setPassword(H2_AUTH); // nosemgrep: java.lang.security.audit.hardcoded-password
+        // 刻意不调用 setPassword：内存库首次连接时就以「无口令」创建，
+        // 传一个空字符串反而会被静态分析当成硬编码口令（Codacy/Opengrep 的
+        // Semgrep_java_password_rule-HardcodePassword）。这里没有凭据可言。
         return new HikariDataSource(config);
     }
 


### PR DESCRIPTION
处理 #277。

四个测试类都带着同一行：

```java
config.setPassword(H2_AUTH); // nosemgrep: java.lang.security.audit.hardcoded-password
```

那条注释写的规则 id 不是实际运行的规则。Codacy 跑的是 Opengrep 的 `Semgrep_java_password_rule-HardcodePassword` —— 所以告警**从来没有被抑制过**，只是**存量问题不进 PR diff**，所以没人看见。它在 #275 新写的测试类照抄这一行的那一刻立刻现形。

**真正该删的不是那条告警，是那句注释。** 它告诉每一个读到它的人「这个情况已经评估过、豁免了」，而这是假的。我自己就是因为它才照抄的 —— 一个失效的抑制注释会自我复制，这就是它的传播方式。

## 改动

`H2_AUTH` 是空字符串，而 H2 内存库首次连接时本就以「无口令」创建，那行**从一开始就什么也没做**。删掉调用之后既没有硬编码口令、也不需要任何抑制。四处各删三样：`setPassword` 调用、失效注释、随之不再被引用的 `H2_AUTH` 常量，换成与 `JsonQuerySemanticsTest` **逐字相同**的说明注释，六处读起来一致。

顺带修了 `BackendIdContractTest` 里我在 #276 留的一句话——它当时说「别的测试类里那条注释抑制不了它」，现在那些注释没了，那句话过时了。

## 验证

| | |
|---|---|
| 全仓 `nosemgrep` | **0**（原 5） |
| 全仓 `H2_AUTH` | **0**（原 8） |
| `src/main` 的 `setPassword` | 只剩 `MysqlDataStore:28`，那是真实生产口令，未动 |
| `mvn clean verify` | **4276 用例 · 0 失败 · 0 错误 · 5 跳过**，用例数与改动前完全一致 |

## 关于负向对照

**这条没有另造对照，因为对照是内建的。** 如果 `setPassword("")` 曾经承载任何东西，删掉它会让这四个类的每一次 H2 连接立刻失败。全绿本身就是那个证据。

需要另造对照的是「新增行为」和「修改行为」——既有测试对新维度是沉默的；而「删除疑似无用的代码」这一类，既有测试的通过与否就是对照。

## 范围

不改任何被测代码，不动 H2 连接串或 `MODE=MySQL` 设定，不碰 `src/main`。