### PR TITLE
fix(websocket): 面板下发的配置更新不再被静默丢弃

### DIFF
--- a/src/main/java/com/ultikits/ultitools/abstracts/AbstractConfigEntity.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/AbstractConfigEntity.java
@@ -123,16 +123,29 @@ public abstract class AbstractConfigEntity {
      * <p>
      * 更新配置实体的属性。
      *
+     * <p>
+     * 字段的遍历方式与路径推导必须与 {@code init()} / {@code save()} / {@code reload()} 完全一致，
+     * 否则会出现「写进去了、其实没写」：这四个方法各自遍历 {@code @ConfigEntry} 字段，
+     * 而本方法过去两处都跟它们不一样 ——
+     * 用 {@code getDeclaredFields()} 而非 {@link ReflectionUtil#getFields(Class)}（漏掉父类字段），
+     * 且不把空的 {@code path} 归一到字段名。后者的后果最隐蔽：{@code @ConfigEntry} 不写
+     * {@code path} 是受支持的写法，{@code init}/{@code save} 会按字段名读写它，
+     * {@link #toJsonObject()} 也按字段名把它发给面板，而这里去 JSON 里找空字符串键，
+     * 永远找不到——字段被跳过，随后 {@code config.save} 照常执行，调用方收到成功。
+     *
      * @param jsonObject the JSON object containing the new properties <br> 包含新属性的JSON对象
      * @throws IOException if an I/O error occurs <br> 如果发生I/O错误
      */
     public void updateProperties(JsonObject jsonObject) throws IOException {
         Gson gson = new Gson();
-        for (Field field : this.getClass().getDeclaredFields()) {
+        for (Field field : ReflectionUtil.getFields(this.getClass())) {
             if (field.isAnnotationPresent(ConfigEntry.class)) {
                 field.setAccessible(true);
                 ConfigEntry annotation = field.getAnnotation(ConfigEntry.class);
                 String path = annotation.path();
+                if (path.isEmpty()) {
+                    path = field.getName();
+                }
                 if (jsonObject.has(path)) {
                     Object configValue = gson.fromJson(jsonObject.get(path), field.getType());
                     if (configValue != null) {
@@ -174,11 +187,17 @@ public abstract class AbstractConfigEntity {
      */
     public JsonObject getComments() {
         JsonObject jsonObject = new JsonObject();
-        Field[] declaredFields = this.getClass().getDeclaredFields();
-        for (Field field : declaredFields) {
+        // 与 updateProperties 同样的两处对齐：走完整字段树、空 path 归一到字段名。
+        // 不归一的话，没写 path 的字段其注释会被塞在 "" 这个键下，而 toJsonObject()
+        // 是按字段名发值的，面板两边对不上，那条注释永远显示不出来。
+        for (Field field : ReflectionUtil.getFields(this.getClass())) {
             if (field.isAnnotationPresent(ConfigEntry.class)) {
                 ConfigEntry annotation = field.getAnnotation(ConfigEntry.class);
-                jsonObject.addProperty(annotation.path(), annotation.comment());
+                String path = annotation.path();
+                if (path.isEmpty()) {
+                    path = field.getName();
+                }
+                jsonObject.addProperty(path, annotation.comment());
             }
         }
         return jsonObject;

--- a/src/main/java/com/ultikits/ultitools/manager/ConfigManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/ConfigManager.java
@@ -305,4 +305,55 @@ public class ConfigManager {
             }
         }
     }
+
+    /**
+     * Load a single config file from a JSON string.
+     * <br>
+     * 从JSON字符串加载单个配置文件
+     *
+     * <p>{@link #loadFromJson(String)} 接受的是 {@code {插件名: {配置路径: {配置项: 值}}}}
+     * 这样的全量嵌套结构，也就是 {@link #toJson()} 的产物。本方法接受的是最里面那一层
+     * ——某一个配置文件自己的 {@code {配置项: 值}}——由 {@code configFilePath} 指定写到哪。
+     * 面板按文件名下发单个配置时用的是后一种形状，见 issue #236。
+     *
+     * <p>配置路径在单个插件内唯一（{@code pluginConfigMap} 的内层 key 就是它），
+     * 跨插件则可能重名。找不到和命中多个都抛异常而不是静默跳过：
+     * 「调用方以为写了、实际什么也没发生」正是这条链路上原来的毛病。
+     *
+     * @param configFilePath config file path as registered, e.g. {@code config/lang.yml}
+     *                       <br> 注册时使用的配置文件路径
+     * @param json           JSON object of that file's entries <br> 该文件配置项的JSON对象
+     * @throws IOException if the path is blank, unknown, ambiguous, or the JSON is not an object,
+     *                     or if saving fails <br> 路径为空、找不到、跨插件重名、JSON不是对象或保存失败
+     * @since 6.2.5
+     */
+    public final void loadFromJson(String configFilePath, String json) throws IOException {
+        if (configFilePath == null || configFilePath.trim().isEmpty()) {
+            throw new IOException("Config file path is required");
+        }
+        JsonObject properties;
+        try {
+            properties = new Gson().fromJson(json, JsonObject.class);
+        } catch (RuntimeException e) {
+            throw new IOException("Config content is not valid JSON: " + configFilePath, e);
+        }
+        if (properties == null) {
+            throw new IOException("Config content is not a JSON object: " + configFilePath);
+        }
+
+        List<AbstractConfigEntity> matches = new ArrayList<>();
+        for (Map<String, AbstractConfigEntity> configMap : pluginConfigMap.values()) {
+            AbstractConfigEntity entity = configMap.get(configFilePath);
+            if (entity != null) {
+                matches.add(entity);
+            }
+        }
+        if (matches.isEmpty()) {
+            throw new IOException("No registered config matches path: " + configFilePath);
+        }
+        if (matches.size() > 1) {
+            throw new IOException("Config path is ambiguous across plugins: " + configFilePath);
+        }
+        matches.get(0).updateProperties(properties);
+    }
 }

--- a/src/main/java/com/ultikits/ultitools/utils/ConfigEditorUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/ConfigEditorUtils.java
@@ -55,4 +55,26 @@ public class ConfigEditorUtils {
         ConfigManager configManager = UltiTools.getInstance().getConfigManager();
         configManager.loadFromJson(configMapString);
     }
+
+    /**
+     * Update a single configuration file from a JSON string.
+     * <br>
+     * 从JSON字符串更新单个配置文件。
+     *
+     * <p>面板按文件名下发配置时走这条：{@code configMapString} 是该文件自己的
+     * {@code {配置项: 值}}，而不是 {@link #updateConfigMap(String)} 那种
+     * {@code {插件名: {配置路径: {...}}}} 的全量结构。两种形状对应面板上两个不同的入口，
+     * 混用会写不进去且不报错——见 issue #236。
+     *
+     * @param fileName        config file path as registered, e.g. {@code config/lang.yml}
+     *                        <br> 注册时使用的配置文件路径
+     * @param configMapString JSON string containing that file's entries <br> 该文件配置项的JSON字符串
+     * @throws IOException if the file is unknown or ambiguous, or the update fails
+     *                     <br> 如果文件找不到、跨插件重名或更新失败
+     * @since 6.2.5
+     */
+    protected static void updateConfigMap(String fileName, String configMapString) throws IOException {
+        ConfigManager configManager = UltiTools.getInstance().getConfigManager();
+        configManager.loadFromJson(fileName, configMapString);
+    }
 }

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
@@ -406,68 +406,154 @@ public class PluginInitiationUtils {
     }
     
     /**
-     * 处理配置更新
+     * 处理配置更新。
+     *
+     * <p>这条路径过去有三处与面板对不上，而且失败是静默的（issue #236）：面板在
+     * {@code data.configData} 里发内容、这里读 {@code data.config}；面板用
+     * {@code data.fileName} 指定文件、这里除 {@code server_properties} 外从不读它；
+     * 面板不发 {@code requestId}、这里以 {@code requestId} 存在与否作为「是不是一条请求」
+     * 的判据，缺了就只记一行 {@code Level.FINE} 然后丢弃——而 {@code FINE} 在默认日志
+     * 配置下不打印。于是面板收到 HTTP 200、服务器上什么也没变、两端都不报错。
+     *
+     * <p>现在的判据换成「有没有配置内容」：没有内容才是回声/回执，有内容就是一条请求，
+     * 缺 {@code requestId} 也照样应用，只是记 WARNING 说明结果无法回报。
+     *
+     * <p>包级可见而非 private —— 只为可测。
      */
-    private static void handleConfigUpdate(JsonObject data) {
-        if (data != null) {
-            // Route server_properties to dedicated manager
-            String fileName = (data.has("fileName") && !data.get("fileName").isJsonNull())
-                    ? data.get("fileName").getAsString() : null;
-            if ("server_properties".equals(fileName)) {
-                ServerPropertiesManager spm = UltiTools.getInstance().getServerPropertiesManager();
-                if (spm != null) {
-                    // Parse configData as JSON and forward as set_all action
-                    String configDataStr = (data.has("configData") && !data.get("configData").isJsonNull())
-                            ? data.get("configData").getAsString() : null;
-                    if (configDataStr != null) {
-                        JsonObject spData = new JsonObject();
-                        spData.addProperty("action", "set_all");
-                        spData.add("values", com.google.gson.JsonParser.parseString(configDataStr).getAsJsonObject());
-                        spm.handleServerProperties(spData);
-                    } else {
-                        // No configData means "get" request
-                        JsonObject spData = new JsonObject();
-                        spData.addProperty("action", "get");
-                        spm.handleServerProperties(spData);
-                    }
-                }
-                return;
-            }
-
-            // 只处理明确的配置更新请求（包含requestId），忽略服务器的确认消息
-            if (data.has("requestId")) {
-                String requestId = data.get("requestId").getAsString();
-                try {
-                    ConfigEditorUtils.updateConfigMap(data.get("config").getAsString());
-                    // 发送确认消息
-                    JsonObject response = new JsonObject();
-                    response.addProperty("type", "config_update_response");
-                    response.addProperty("status", "success");
-                    response.addProperty("serverId", panelWS.getServerId());
-                    response.addProperty("requestId", requestId);
-                    panelWS.sendMessage(response);
-                } catch (IOException e) {
-                    // 发送错误消息
-                    JsonObject response = new JsonObject();
-                    response.addProperty("type", "config_update_response");
-                    response.addProperty("status", "error");
-                    response.addProperty("error", e.getMessage());
-                    response.addProperty("serverId", panelWS.getServerId());
-                    response.addProperty("requestId", requestId);
-                    panelWS.sendMessage(response);
-                }
-            } else {
-                // 识别并忽略服务器确认消息
-                if (data.has("message")) {
-                    String message = data.get("message").getAsString();
-                    UltiTools.getInstance().getLogger().log(Level.FINE, 
-                        String.format("收到服务器配置更新确认: %s", message));
-                } else {
-                    UltiTools.getInstance().getLogger().log(Level.FINE, 
-                        "收到服务器配置更新消息，但不包含requestId，忽略处理");
-                }
-            }
+    static void handleConfigUpdate(JsonObject data) {
+        if (data == null) {
+            return;
         }
+
+        String fileName = readString(data, "fileName");
+        String requestId = readString(data, "requestId");
+        String configContent = readConfigContent(data);
+
+        // server_properties 的「取」请求：没有内容也是一条正当请求，不是回声。
+        if (SERVER_PROPERTIES_FILE.equals(fileName) && configContent == null) {
+            ServerPropertiesManager spm = UltiTools.getInstance().getServerPropertiesManager();
+            if (spm != null) {
+                JsonObject spData = new JsonObject();
+                spData.addProperty("action", "get");
+                spm.handleServerProperties(spData);
+            }
+            return;
+        }
+
+        // 没有配置内容 = 转发层回来的回执或本机自己发出去的回声。这是唯一一种
+        // 「什么都不做」还算正常的情况，所以保持 FINE。
+        if (configContent == null) {
+            if (data.has("message") && !data.get("message").isJsonNull()) {
+                UltiTools.getInstance().getLogger().log(Level.FINE,
+                        String.format("收到服务器配置更新确认: %s", data.get("message").getAsString()));
+            } else {
+                UltiTools.getInstance().getLogger().log(Level.FINE,
+                        "收到不含配置内容的 update_config 消息，按回声处理");
+            }
+            return;
+        }
+
+        if (requestId == null) {
+            // 以前这里直接 return。缺 requestId 是对端的协议缺陷，不是「这条消息不必处理」，
+            // 把它当成后者就是把缺陷伪装成正常路径。
+            UltiTools.getInstance().getLogger().log(Level.WARNING,
+                    "收到不含 requestId 的配置更新请求，仍会应用，但无法向面板回报结果");
+        }
+
+        try {
+            applyConfigUpdate(fileName, configContent);
+            sendConfigUpdateResponse(requestId, true, null);
+        } catch (IOException | RuntimeException e) {
+            // RuntimeException 也接：JsonParser 解析畸形 configData 抛的是它，
+            // 过去这类失败会一路冒到 handleInboundMessage 的 catch，记成
+            // 「处理消息类型 update_config 时发生错误」而面板永远等不到回复。
+            UltiTools.getInstance().getLogger().log(Level.WARNING,
+                    String.format("应用配置更新失败（文件: %s）: %s", fileName, e.getMessage()), e);
+            sendConfigUpdateResponse(requestId, false, e.getMessage());
+        }
+    }
+
+    /** {@code server_properties} 走独立管理器，不是一个真正的配置文件路径。 */
+    private static final String SERVER_PROPERTIES_FILE = "server_properties";
+
+    /** 读一个可能缺失、也可能是 JSON null 的字符串字段。 */
+    private static String readString(JsonObject data, String field) {
+        return (data.has(field) && !data.get(field).isJsonNull())
+                ? data.get(field).getAsString() : null;
+    }
+
+    /**
+     * 取配置内容，优先 {@code data.configData}。
+     *
+     * <p>{@code data.config} 是本方法过去唯一读的字段，但在树内找不到任何生产者——
+     * 面板一直发的是 {@code configData}。保留它只是为了兼容可能存在的第三方面板，
+     * 读到就记废弃日志。
+     */
+    private static String readConfigContent(JsonObject data) {
+        String configData = readString(data, "configData");
+        if (configData != null) {
+            return configData;
+        }
+        String legacy = readString(data, "config");
+        if (legacy != null) {
+            UltiTools.getInstance().getLogger().log(Level.WARNING,
+                    "update_config 使用了已废弃的 data.config 字段，请改用 data.configData");
+        }
+        return legacy;
+    }
+
+    /**
+     * 按 {@code fileName} 决定写到哪里。
+     *
+     * <p>三条分支对应三种载荷形状，这是原来「fileName 从不读」掩盖掉的东西：
+     * {@code server_properties} 是一份扁平的属性表，交给专用管理器；
+     * 指定了文件名就是那一个配置文件自己的 {@code {配置项: 值}}；
+     * 没有文件名才是 {@link com.ultikits.ultitools.manager.ConfigManager#toJson()}
+     * 那种全量嵌套结构。
+     */
+    private static void applyConfigUpdate(String fileName, String configContent) throws IOException {
+        if (SERVER_PROPERTIES_FILE.equals(fileName)) {
+            ServerPropertiesManager spm = UltiTools.getInstance().getServerPropertiesManager();
+            if (spm == null) {
+                throw new IOException("ServerPropertiesManager is not available");
+            }
+            JsonObject spData = new JsonObject();
+            spData.addProperty("action", "set_all");
+            spData.add("values", com.google.gson.JsonParser.parseString(configContent).getAsJsonObject());
+            spm.handleServerProperties(spData);
+            return;
+        }
+        if (fileName == null || fileName.trim().isEmpty()) {
+            ConfigEditorUtils.updateConfigMap(configContent);
+            return;
+        }
+        ConfigEditorUtils.updateConfigMap(fileName, configContent);
+    }
+
+    /**
+     * 回一条 {@code config_update_response}。
+     *
+     * <p>载荷放在 {@code data} 里，与其余所有 插件→Worker 的消息一致
+     * （见 {@code CommandExecutionManager.sendCommandResult}）。此前这一条是扁平写法，
+     * 字段直接挂在顶层；Worker 侧两种都读（ultipanel-api-worker#30），所以这次改动
+     * 不需要和面板同时上线。
+     */
+    private static void sendConfigUpdateResponse(String requestId, boolean success, String error) {
+        if (requestId == null || panelWS == null) {
+            return;
+        }
+        JsonObject payload = new JsonObject();
+        payload.addProperty("requestId", requestId);
+        payload.addProperty("status", success ? "success" : "error");
+        if (error != null) {
+            payload.addProperty("error", error);
+        }
+
+        JsonObject response = new JsonObject();
+        response.addProperty("type", "config_update_response");
+        response.add("data", payload);
+        response.addProperty("serverId", panelWS.getServerId());
+        panelWS.sendMessage(response);
     }
     
     // ========== 系统基础消息处理器 ==========

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
@@ -31,6 +31,9 @@ public class PluginInitiationUtils {
     /** Authentication token for API requests */
     private static TokenEntity token;
 
+    /** {@code server_properties} 走独立管理器，不是一个真正的配置文件路径。 */
+    private static final String SERVER_PROPERTIES_FILE = "server_properties";
+
     /**
      * 云连接是否处于「应当保持连接」的状态。
      * <p>
@@ -472,9 +475,6 @@ public class PluginInitiationUtils {
             sendConfigUpdateResponse(requestId, false, e.getMessage());
         }
     }
-
-    /** {@code server_properties} 走独立管理器，不是一个真正的配置文件路径。 */
-    private static final String SERVER_PROPERTIES_FILE = "server_properties";
 
     /** 读一个可能缺失、也可能是 JSON null 的字符串字段。 */
     private static String readString(JsonObject data, String field) {

--- a/src/test/java/com/ultikits/ultitools/abstracts/AbstractConfigEntityTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/AbstractConfigEntityTest.java
@@ -336,4 +336,107 @@ class AbstractConfigEntityTest {
             this.nonAnnotatedField = nonAnnotatedField;
         }
     }
+
+    // ==================== 四个遍历方法必须对得上 ====================
+    //
+    // init() / save() / reload() / updateProperties() 各自遍历 @ConfigEntry 字段。
+    // 只要它们对「遍历哪些字段」或「path 怎么推导」的答案不一致，就会出现
+    // 「更新成功但值没变」——updateProperties 跳过字段之后 config.save() 照常执行，
+    // 调用方拿不到任何失败信号。面板下发配置正是走这条路（issue #236）。
+
+    /** 不写 path 的 @ConfigEntry —— 受支持的写法，路径归一到字段名。 */
+    private static class DefaultPathConfigEntity extends AbstractConfigEntity {
+        @ConfigEntry(comment = "No explicit path")
+        private String implicitPath = "default";
+
+        public DefaultPathConfigEntity(String configFilePath) {
+            super(configFilePath);
+        }
+
+        public String getImplicitPath() {
+            return implicitPath;
+        }
+    }
+
+    /** @ConfigEntry 字段声明在父类上。 */
+    private static class InheritedFieldConfigEntity extends DefaultPathConfigEntity {
+        @ConfigEntry(path = "child.value", comment = "Declared on the subclass")
+        private String childValue = "child-default";
+
+        public InheritedFieldConfigEntity(String configFilePath) {
+            super(configFilePath);
+        }
+
+        public String getChildValue() {
+            return childValue;
+        }
+    }
+
+    @Test
+    @DisplayName("没写 path 的字段，updateProperties 也要按字段名认得出来")
+    void updatePropertiesHonoursTheDefaultPath() throws IOException {
+        DefaultPathConfigEntity entity = new DefaultPathConfigEntity("default-path.yml");
+        entity.init(mockPlugin);
+
+        // init/save 按字段名写盘，toJsonObject 也按字段名发给面板，所以面板回来的
+        // 就是这个键。updateProperties 过去找的是空字符串键，永远找不到。
+        JsonObject json = new JsonObject();
+        json.addProperty("implicitPath", "updated");
+
+        entity.updateProperties(json);
+
+        assertThat(entity.getImplicitPath()).isEqualTo("updated");
+        assertThat(YamlConfiguration.loadConfiguration(new File(tempDir.toFile(), "default-path.yml"))
+                .getString("implicitPath")).isEqualTo("updated");
+    }
+
+    @Test
+    @DisplayName("toJsonObject 发出去的键，updateProperties 必须原样收得回来")
+    void theJsonRoundTripIsClosed() throws IOException {
+        DefaultPathConfigEntity entity = new DefaultPathConfigEntity("round-trip.yml");
+        entity.init(mockPlugin);
+
+        // 这条断言的是「发出去什么、就能收回什么」，而不是某个具体键名——
+        // #236 那一族缺陷全都长在两条路径对同一个名字的理解不一致上。
+        JsonObject emitted = entity.toJsonObject();
+        assertThat(emitted.keySet()).contains("implicitPath");
+
+        emitted.addProperty("implicitPath", "round-tripped");
+        entity.updateProperties(emitted);
+
+        assertThat(entity.getImplicitPath()).isEqualTo("round-tripped");
+    }
+
+    @Test
+    @DisplayName("父类上声明的 @ConfigEntry 字段同样可更新")
+    void updatePropertiesCoversInheritedFields() throws IOException {
+        InheritedFieldConfigEntity entity = new InheritedFieldConfigEntity("inherited.yml");
+        entity.init(mockPlugin);
+
+        JsonObject json = new JsonObject();
+        json.addProperty("implicitPath", "from-parent");
+        json.addProperty("child.value", "from-child");
+
+        entity.updateProperties(json);
+
+        // init/save/reload 走的是完整字段树，updateProperties 过去只走
+        // getDeclaredFields()，于是父类字段读得出、写不进。
+        assertThat(entity.getImplicitPath()).isEqualTo("from-parent");
+        assertThat(entity.getChildValue()).isEqualTo("from-child");
+    }
+
+    @Test
+    @DisplayName("getComments 的键要和 toJsonObject 的键对得上")
+    void commentKeysMatchValueKeys() throws IOException {
+        InheritedFieldConfigEntity entity = new InheritedFieldConfigEntity("comments.yml");
+        entity.init(mockPlugin);
+
+        JsonObject comments = entity.getComments();
+
+        assertThat(comments.keySet())
+                .as("没写 path 的字段，注释不能被塞在空字符串键下")
+                .doesNotContain("")
+                .contains("implicitPath", "child.value");
+        assertThat(entity.toJsonObject().keySet()).containsAll(comments.keySet());
+    }
 }

--- a/src/test/java/com/ultikits/ultitools/manager/ConfigManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ConfigManagerTest.java
@@ -1,6 +1,7 @@
 package com.ultikits.ultitools.manager;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -834,6 +835,94 @@ class ConfigManagerTest {
             
             // Assert
             assertThat(config.getNumber()).isEqualTo(42);
+        }
+    }
+
+    /**
+     * {@code loadFromJson(configFilePath, json)} —— 面板按文件名下发单个配置时走的入口。
+     *
+     * <p>与单参重载的区别是载荷形状：单参吃的是 {@code toJson()} 那种
+     * {@code {插件名: {配置路径: {...}}}} 全量结构，双参吃的是最里面那一层。两种形状对应
+     * 面板上两个不同的入口，混用会写不进去且不报错——issue #236 的一半就是这个。
+     *
+     * <p>所以这里重点钉的是<b>失败必须响亮</b>：找不到、跨插件重名、载荷不是 JSON 对象，
+     * 三种都抛异常。静默跳过会让调用方以为写成功了，那正是要修的病。
+     */
+    @Nested
+    @DisplayName("loadFromJson(单个文件) 测试")
+    class LoadSingleConfigFileTests {
+
+        @SuppressWarnings("unchecked")
+        private Map<UltiToolsPlugin, Map<String, AbstractConfigEntity>> configMap() throws Exception {
+            Field mapField = ConfigManager.class.getDeclaredField("pluginConfigMap");
+            mapField.setAccessible(true);
+            return (Map<UltiToolsPlugin, Map<String, AbstractConfigEntity>>) mapField.get(configManager);
+        }
+
+        private AbstractConfigEntity register(UltiToolsPlugin plugin, String path) throws Exception {
+            AbstractConfigEntity entity = mock(AbstractConfigEntity.class);
+            Map<String, AbstractConfigEntity> entities = new HashMap<>();
+            entities.put(path, entity);
+            configMap().put(plugin, entities);
+            return entity;
+        }
+
+        @Test
+        @DisplayName("命中唯一配置时把解析后的属性交给它")
+        void appliesPropertiesToTheOnlyMatch() throws Exception {
+            AbstractConfigEntity entity = register(mockPlugin, "config/lang.yml");
+
+            configManager.loadFromJson("config/lang.yml", "{\"language\":\"zh\"}");
+
+            org.mockito.ArgumentCaptor<com.google.gson.JsonObject> captor =
+                    org.mockito.ArgumentCaptor.forClass(com.google.gson.JsonObject.class);
+            verify(entity).updateProperties(captor.capture());
+            assertThat(captor.getValue().get("language").getAsString()).isEqualTo("zh");
+        }
+
+        @Test
+        @DisplayName("路径找不到时抛异常，而不是什么也不做")
+        void unknownPathThrows() throws Exception {
+            register(mockPlugin, "config/lang.yml");
+
+            assertThatThrownBy(() -> configManager.loadFromJson("config/nope.yml", "{}"))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("config/nope.yml");
+        }
+
+        @Test
+        @DisplayName("同一路径出现在多个插件下时抛异常，而不是随便挑一个")
+        void ambiguousPathThrows() throws Exception {
+            // 配置路径只在单个插件内唯一（pluginConfigMap 的内层 key 就是它），
+            // 跨插件完全可能重名，而面板下发的 fileName 是不带插件名的裸路径。
+            UltiToolsPlugin otherPlugin = mock(UltiToolsPlugin.class);
+            when(otherPlugin.getPluginName()).thenReturn("OtherPlugin");
+            register(mockPlugin, "config/config.yml");
+            register(otherPlugin, "config/config.yml");
+
+            assertThatThrownBy(() -> configManager.loadFromJson("config/config.yml", "{}"))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("ambiguous");
+        }
+
+        @Test
+        @DisplayName("路径为空时抛异常")
+        void blankPathThrows() {
+            assertThatThrownBy(() -> configManager.loadFromJson("   ", "{}"))
+                    .isInstanceOf(IOException.class);
+            assertThatThrownBy(() -> configManager.loadFromJson(null, "{}"))
+                    .isInstanceOf(IOException.class);
+        }
+
+        @Test
+        @DisplayName("载荷不是 JSON 对象时抛异常，且不碰任何配置")
+        void nonObjectPayloadThrows() throws Exception {
+            AbstractConfigEntity entity = register(mockPlugin, "config/lang.yml");
+
+            assertThatThrownBy(() -> configManager.loadFromJson("config/lang.yml", "not json"))
+                    .isInstanceOf(IOException.class);
+
+            verify(entity, org.mockito.Mockito.never()).updateProperties(any());
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/utils/PluginInitiationUtilsConfigUpdateTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/PluginInitiationUtilsConfigUpdateTest.java
@@ -1,0 +1,316 @@
+package com.ultikits.ultitools.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.google.gson.JsonObject;
+import com.ultikits.ultitools.UltiTools;
+import com.ultikits.ultitools.manager.ConfigManager;
+import com.ultikits.ultitools.manager.ServerPropertiesManager;
+import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
+
+/**
+ * {@link PluginInitiationUtils#handleConfigUpdate(com.google.gson.JsonObject)} 的载荷契约。
+ *
+ * <p>issue #236：面板下发的配置更新被静默丢弃。三处字段与面板对不上——内容在
+ * {@code data.configData} 而这里读 {@code data.config}，文件在 {@code data.fileName}
+ * 而这里除 {@code server_properties} 外从不读，面板不发 {@code requestId} 而这里拿
+ * {@code requestId} 当「是不是一条请求」的判据。第一道就短路：进 else 分支，
+ * 记一行 {@code Level.FINE} 然后返回。{@code FINE} 在默认日志配置下不打印，
+ * 于是整条链路没有任何一处报错，用户看到「保存成功但没生效」。
+ *
+ * <p>这类缺陷读代码看不出来——两端各自都是自洽的，不一致只存在于两者之差。所以这里
+ * 断言的是「给定面板真实发出的那种消息，究竟有没有落到写配置的调用上」，而不是
+ * 某个分支内部的行为。
+ */
+@DisplayName("PluginInitiationUtils 配置更新载荷契约")
+class PluginInitiationUtilsConfigUpdateTest {
+
+    private Logger mockLogger;
+    private ConfigManager mockConfigManager;
+    private ServerPropertiesManager mockServerProperties;
+    private UltiPanelWebSocketClient mockWebSocket;
+    private Object previousPanelWs;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockLogger = mock(Logger.class);
+        mockConfigManager = mock(ConfigManager.class);
+        mockServerProperties = mock(ServerPropertiesManager.class);
+
+        // 必须用 Consumer 重载：先打桩、后发布。见 TestHelper 的 javadoc 与 issue #250。
+        TestHelper.mockUltiToolsInstance(ultiTools -> {
+            lenient().when(ultiTools.getLogger()).thenReturn(mockLogger);
+            lenient().when(ultiTools.getConfigManager()).thenReturn(mockConfigManager);
+            lenient().when(ultiTools.getServerPropertiesManager()).thenReturn(mockServerProperties);
+        });
+
+        mockWebSocket = mock(UltiPanelWebSocketClient.class);
+        lenient().when(mockWebSocket.getServerId()).thenReturn("srv-1");
+        previousPanelWs = setPanelWs(mockWebSocket);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        // panelWS 是静态字段，不还原会漏给同一个 JVM 里后面的测试类。
+        setPanelWs(previousPanelWs);
+        Field instanceField = UltiTools.class.getDeclaredField("ultiTools");
+        instanceField.setAccessible(true);
+        instanceField.set(null, null);
+    }
+
+    private Object setPanelWs(Object value) throws Exception {
+        Field field = PluginInitiationUtils.class.getDeclaredField("panelWS");
+        field.setAccessible(true);
+        Object previous = field.get(null);
+        field.set(null, value);
+        return previous;
+    }
+
+    /** 面板实际下发的那种消息。 */
+    private static JsonObject panelMessage(String fileName, String configData, String requestId) {
+        JsonObject data = new JsonObject();
+        if (fileName != null) {
+            data.addProperty("fileName", fileName);
+        }
+        if (configData != null) {
+            data.addProperty("configData", configData);
+        }
+        if (requestId != null) {
+            data.addProperty("requestId", requestId);
+        }
+        return data;
+    }
+
+    /** 取出所有以指定级别记录的日志正文，两参与三参重载都算。 */
+    private List<String> loggedAt(Level level) {
+        List<String> lines = new ArrayList<>();
+        ArgumentCaptor<String> twoArg = ArgumentCaptor.forClass(String.class);
+        verify(mockLogger, org.mockito.Mockito.atLeast(0)).log(eq(level), twoArg.capture());
+        lines.addAll(twoArg.getAllValues());
+        ArgumentCaptor<String> threeArg = ArgumentCaptor.forClass(String.class);
+        verify(mockLogger, org.mockito.Mockito.atLeast(0))
+                .log(eq(level), threeArg.capture(), any(Throwable.class));
+        lines.addAll(threeArg.getAllValues());
+        return lines;
+    }
+
+    private JsonObject capturedResponse() {
+        ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
+        verify(mockWebSocket).sendMessage(captor.capture());
+        return captor.getValue();
+    }
+
+    @Nested
+    @DisplayName("载荷字段")
+    class PayloadFields {
+
+        @Test
+        @DisplayName("configData 被读取，并按 fileName 写到对应的配置文件")
+        void configDataIsReadAndRoutedByFileName() throws Exception {
+            PluginInitiationUtils.handleConfigUpdate(
+                    panelMessage("config/lang.yml", "{\"language\":\"zh\"}", "req-1"));
+
+            // 这一句就是 #236 的全部：面板发的这条消息，过去一个写配置的调用都不会发生。
+            verify(mockConfigManager).loadFromJson("config/lang.yml", "{\"language\":\"zh\"}");
+        }
+
+        @Test
+        @DisplayName("没有 fileName 时按全量嵌套结构写，走单参入口")
+        void missingFileNameFallsBackToTheWholeMap() throws Exception {
+            String wholeMap = "{\"UltiTools\":{\"config/lang.yml\":{\"language\":\"zh\"}}}";
+            PluginInitiationUtils.handleConfigUpdate(panelMessage(null, wholeMap, "req-2"));
+
+            verify(mockConfigManager).loadFromJson(wholeMap);
+            verify(mockConfigManager, never()).loadFromJson(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("旧字段 data.config 仍可读，但记一条废弃 WARNING")
+        void legacyConfigFieldIsStillReadAndWarnedAbout() throws Exception {
+            JsonObject data = new JsonObject();
+            data.addProperty("config", "{\"UltiTools\":{}}");
+            data.addProperty("requestId", "req-3");
+
+            PluginInitiationUtils.handleConfigUpdate(data);
+
+            verify(mockConfigManager).loadFromJson("{\"UltiTools\":{}}");
+            assertThat(loggedAt(Level.WARNING))
+                    .anySatisfy(line -> assertThat(line).contains("data.config"));
+        }
+
+        @Test
+        @DisplayName("configData 与 config 同时存在时以 configData 为准，且不记废弃日志")
+        void configDataWinsOverLegacyField() throws Exception {
+            JsonObject data = panelMessage("config/lang.yml", "{\"new\":true}", "req-4");
+            data.addProperty("config", "{\"old\":true}");
+
+            PluginInitiationUtils.handleConfigUpdate(data);
+
+            verify(mockConfigManager).loadFromJson("config/lang.yml", "{\"new\":true}");
+            assertThat(loggedAt(Level.WARNING))
+                    .noneSatisfy(line -> assertThat(line).contains("data.config"));
+        }
+    }
+
+    @Nested
+    @DisplayName("requestId")
+    class RequestIdHandling {
+
+        @Test
+        @DisplayName("缺 requestId 的请求仍然被应用，不再静默丢弃")
+        void missingRequestIdNoLongerDiscardsTheUpdate() throws Exception {
+            PluginInitiationUtils.handleConfigUpdate(
+                    panelMessage("config/lang.yml", "{\"language\":\"zh\"}", null));
+
+            verify(mockConfigManager).loadFromJson("config/lang.yml", "{\"language\":\"zh\"}");
+        }
+
+        @Test
+        @DisplayName("缺 requestId 时的日志级别至少是 WARNING")
+        void missingRequestIdIsLoggedAtWarning() {
+            PluginInitiationUtils.handleConfigUpdate(
+                    panelMessage("config/lang.yml", "{\"language\":\"zh\"}", null));
+
+            // 原来这里是 FINE —— 默认日志配置不打印，所以「丢弃」这件事在服务器上不可见。
+            assertThat(loggedAt(Level.WARNING))
+                    .anySatisfy(line -> assertThat(line).contains("requestId"));
+        }
+
+        @Test
+        @DisplayName("缺 requestId 时不回响应，因为无从关联")
+        void missingRequestIdSendsNoResponse() {
+            PluginInitiationUtils.handleConfigUpdate(
+                    panelMessage("config/lang.yml", "{\"language\":\"zh\"}", null));
+
+            verify(mockWebSocket, never()).sendMessage(any(JsonObject.class));
+        }
+
+        @Test
+        @DisplayName("成功时回 config_update_response，载荷嵌在 data 里")
+        void successSendsANestedResponse() {
+            PluginInitiationUtils.handleConfigUpdate(
+                    panelMessage("config/lang.yml", "{\"language\":\"zh\"}", "req-5"));
+
+            JsonObject response = capturedResponse();
+            assertThat(response.get("type").getAsString()).isEqualTo("config_update_response");
+            assertThat(response.get("serverId").getAsString()).isEqualTo("srv-1");
+            // 嵌套而非扁平：其余所有 插件→Worker 的消息都把载荷放在 data 里。
+            JsonObject payload = response.getAsJsonObject("data");
+            assertThat(payload.get("requestId").getAsString()).isEqualTo("req-5");
+            assertThat(payload.get("status").getAsString()).isEqualTo("success");
+        }
+
+        @Test
+        @DisplayName("应用失败时回 error 并带上原因")
+        void failureSendsAnErrorResponse() throws Exception {
+            doThrow(new IOException("No registered config matches path: nope.yml"))
+                    .when(mockConfigManager).loadFromJson(anyString(), anyString());
+
+            PluginInitiationUtils.handleConfigUpdate(panelMessage("nope.yml", "{}", "req-6"));
+
+            JsonObject payload = capturedResponse().getAsJsonObject("data");
+            assertThat(payload.get("status").getAsString()).isEqualTo("error");
+            assertThat(payload.get("error").getAsString()).contains("nope.yml");
+        }
+
+        @Test
+        @DisplayName("configData 不是合法 JSON 时也回 error，而不是把异常抛给上层")
+        void malformedConfigDataStillAnswers() {
+            PluginInitiationUtils.handleConfigUpdate(
+                    panelMessage("server_properties", "not json at all", "req-7"));
+
+            JsonObject payload = capturedResponse().getAsJsonObject("data");
+            assertThat(payload.get("status").getAsString()).isEqualTo("error");
+        }
+    }
+
+    @Nested
+    @DisplayName("回声与回执")
+    class EchoesAndAcknowledgements {
+
+        @Test
+        @DisplayName("没有配置内容的消息不写任何配置，也不回响应")
+        void messageWithoutContentIsTreatedAsAnEcho() throws Exception {
+            JsonObject data = new JsonObject();
+            data.addProperty("message", "Configuration update command sent");
+
+            PluginInitiationUtils.handleConfigUpdate(data);
+
+            verify(mockConfigManager, never()).loadFromJson(anyString());
+            verify(mockConfigManager, never()).loadFromJson(anyString(), anyString());
+            verify(mockWebSocket, never()).sendMessage(any(JsonObject.class));
+        }
+
+        @Test
+        @DisplayName("带 requestId 但不带内容的消息同样按回声处理")
+        void requestIdAloneIsNotARequest() throws Exception {
+            JsonObject data = new JsonObject();
+            data.addProperty("requestId", "req-8");
+
+            PluginInitiationUtils.handleConfigUpdate(data);
+
+            verify(mockConfigManager, never()).loadFromJson(anyString());
+            verify(mockConfigManager, never()).loadFromJson(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("null data 不抛异常")
+        void nullDataIsSafe() throws Exception {
+            PluginInitiationUtils.handleConfigUpdate(null);
+
+            verify(mockConfigManager, never()).loadFromJson(anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("server_properties")
+    class ServerPropertiesRouting {
+
+        @Test
+        @DisplayName("带内容时转成 set_all 交给专用管理器，不走配置文件那条路")
+        void contentIsForwardedAsSetAll() throws Exception {
+            PluginInitiationUtils.handleConfigUpdate(
+                    panelMessage("server_properties", "{\"max-players\":\"30\"}", "req-9"));
+
+            ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
+            verify(mockServerProperties).handleServerProperties(captor.capture());
+            JsonObject forwarded = captor.getValue();
+            assertThat(forwarded.get("action").getAsString()).isEqualTo("set_all");
+            assertThat(forwarded.getAsJsonObject("values").get("max-players").getAsString()).isEqualTo("30");
+
+            verify(mockConfigManager, never()).loadFromJson(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("不带内容时是一条 get 请求，不是回声")
+        void withoutContentItIsAGetRequest() {
+            PluginInitiationUtils.handleConfigUpdate(panelMessage("server_properties", null, null));
+
+            ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
+            verify(mockServerProperties).handleServerProperties(captor.capture());
+            assertThat(captor.getValue().get("action").getAsString()).isEqualTo("get");
+        }
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/utils/PluginInitiationUtilsConfigUpdateTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/PluginInitiationUtilsConfigUpdateTest.java
@@ -45,6 +45,7 @@ import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
  * 某个分支内部的行为。
  */
 @DisplayName("PluginInitiationUtils 配置更新载荷契约")
+@SuppressWarnings("PMD.AvoidAccessibilityAlteration") // Test requires reflection for mocking internal state
 class PluginInitiationUtilsConfigUpdateTest {
 
     private Logger mockLogger;


### PR DESCRIPTION
关掉 #236。面板侧的对应改动在 `UltiKits/ultipanel-api-worker#30`，按 issue 里说的顺序，那边先。

## 判据换了一个

原来 `handleConfigUpdate` 拿 **`requestId` 存不存在** 当「这是不是一条请求」的判据。面板不发 `requestId`，于是控制流进 else 分支，写一行 `Level.FINE` 就返回 —— 而 `FINE` 在默认日志配置下不打印。第一道就短路，后面两处字段不一致（内容在 `data.configData` 而这里读 `data.config`、`fileName` 除 `server_properties` 外从不读）根本没机会暴露。面板收 200、文件没变、两边都不报错。

现在判据是 **有没有配置内容**：

- 没有内容 = 回声或回执，这是唯一一种「什么都不做」正确的情况，保持 `FINE`；
- 有内容 = 一条请求，**不管有没有 `requestId` 都应用**，缺 `requestId` 记 **WARNING**，说明结果无法回报。

缺 `requestId` 是对端的协议缺陷，不是「这条消息不必处理」。当成后者就是把缺陷伪装成正常路径。

## `fileName` 现在决定写到哪

这条得先纠正 issue 正文里的一句话：**「`ConfigEditorUtils.updateConfigMap(String)` 没有文件维度」不准确。** `ConfigManager.loadFromJson(String)` 吃的是 `{插件名: {配置路径: {配置项: 值}}}`，文件维度在载荷**里面**，不是不存在。

真正缺的是**另一种形状**：某一个配置文件自己的 `{配置项: 值}`，路径单独给。面板按文件名下发时发的就是这种（`server_properties` 那条现成的分支就是这么处理的，只是当时只对 `server_properties` 生效）。

所以 `ConfigManager` 加了双参 `loadFromJson(configFilePath, json)`。三条分支对应三种载荷形状：

| `fileName` | 载荷 | 去处 |
|---|---|---|
| `server_properties` | 扁平属性表 | `ServerPropertiesManager` 的 `set_all` |
| 其他非空值 | 该文件自己的 `{配置项: 值}` | 双参 `loadFromJson` |
| 空 / 缺失 | `toJson()` 那种全量嵌套 | 单参 `loadFromJson` |

双参那条在**路径找不到**和**跨插件重名**时抛异常，不静默跳过。配置路径只在单个插件内唯一（`pluginConfigMap` 的内层 key 就是它），而面板发的 `fileName` 是不带插件名的裸路径，所以重名是真会发生的。静默跳过等于把「调用方以为写了、实际什么也没发生」搬个地方重演。

## 其余两条

`data.config` 仍然读，读到记废弃 WARNING。**但树内找不到任何生产者** —— 面板一直发的是 `configData`，`config` 只是这个方法自己过去的期望。保留纯粹是给可能存在的第三方面板留条路。

响应改成嵌套在 `data` 里，和其余所有 插件→Worker 的消息一致（见 `CommandExecutionManager.sendCommandResult`）。原来是扁平的，而且 Worker 侧压根没有这个 type 的 case，会回一句「Unknown message type」—— 之所以从没人看见，是因为插件根本走不到发它的那行。Worker 侧两种形状都读（`ultipanel-api-worker#30`），所以不需要两边同时上线。

## 测试

`PluginInitiationUtilsConfigUpdateTest` 16 例 + `ConfigManagerTest` 里新的 `LoadSingleConfigFileTests` 5 例。断言的是「给定面板真实发出的那种消息，究竟有没有落到写配置的调用上」，不是某个分支内部的行为 —— 这类缺陷读代码看不出来，两端各自都自洽，不一致只存在于两者之差。

负向对照（临时回退，不入库）：

| 回退 | 失败的用例 |
|---|---|
| 缺 `requestId` 时恢复 `return` | 恰好 2 例，都是 requestId 那一维 |
| `fileName` 不再决定写入目标 | 4 例，全部是断言双参调用的那几条 |
| 不读 `configData`（只读 `config`） | 9 例 —— 面广是因为 `configData` 是几乎所有用例的输入，这条只证明断言确实依赖那次读取，不是单维切割 |

`mvn clean verify`：**4300 例，0 失败**（此前 4276）。

## 评审补充：`AbstractConfigEntity` 的同一个病，往下一层

Codex 在 `ConfigManager.java:357` 报了一条 P1，核实属实，而且比它描述的还宽一点。

`init()` / `save()` / `reload()` 三个都走 `ReflectionUtil.getFields(this.getClass())` 并把空的 `path()` 归一到字段名，只有 `updateProperties` 两处都不一样：用 `getDeclaredFields()`（父类上声明的 `@ConfigEntry` 字段读得出、写不进），且拿 `annotation.path()` 原样去 `jsonObject.has()`。而 `toJsonObject()` 是按 YAML 里的键发的，那些键是 `init`/`save` 用**归一后**的字段名写进去的 —— 于是面板收到 `{"myField": ...}`、原样发回来，这边去找 `""`，找不到，跳过，然后 `config.save()` 照常执行，**调用方收到成功**。

这段代码此前根本没人走到，所以从没暴露。本 PR 新加的 `loadFromJson(path, json)` 正是直通它 —— 不修的话，面板会继续报告没发生过的保存。`getComments()` 有同样两处遗漏，一并修了：它的键本来就该和 `toJsonObject()` 对得上，没写 `path` 的字段其注释被塞在 `""` 下，面板永远匹配不到自己要标注的那个值。

补了 4 条测试，其中一条不钉具体键名，只钉「`toJsonObject` 发出去什么、`updateProperties` 就能收回什么」。负向对照：只回退 `updateProperties` 那两处，恰好挂 3 条，`getComments` 那条仍绿 —— 两个维度分得开。

## 已知未修，另开 issue

`ServerPropertiesManager.handleSetAll` 无论实际写进去几个键，回的 `server_properties_result` 里 `success` 恒为 `true`（`SAFE_KEYS` 之外的键被 `setProperty` 静默跳过，只体现在 `updated` 计数里）。本 PR 给 `server_properties` 路径回的 `config_update_response` 因此继承了同一份乐观 —— 它报告的是「消息已交给属性管理器且没抛异常」。同一族毛病，单独跟。

Closes #236
