### PR TITLE
fix: server.properties 批量设置报告真实结果，不再写死 success (#281)

### DIFF
--- a/src/main/java/com/ultikits/ultitools/manager/ServerPropertiesManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/ServerPropertiesManager.java
@@ -4,14 +4,20 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.logging.Level;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -61,16 +67,33 @@ public class ServerPropertiesManager {
     }
 
     public boolean setProperty(String key, String value) {
-        if (!SAFE_KEYS.contains(key)) return false;
+        return writeProperty(key, value) == WriteOutcome.WRITTEN;
+    }
+
+    /**
+     * Why this exists next to {@link #setProperty(String, String)}: the boolean is lossy.
+     * A {@code false} could mean "the key is not on the whitelist", "there is no
+     * server.properties to write to", or "the write itself failed" — three situations
+     * with three different fixes, collapsed into one value. The batch path has to tell
+     * the caller which one happened, so the real outcome is produced here and
+     * {@code setProperty} keeps its original contract by narrowing it.
+     * <p>
+     * 为什么要在 {@link #setProperty(String, String)} 旁边多这一个：那个布尔值是有损的。
+     * {@code false} 可能是「键不在白名单」「没有 server.properties 可写」或「写入本身失败」，
+     * 三种处置完全不同的情况被压成了同一个值。批量路径必须告诉调用方是哪一种，
+     * 所以真实结果在这里产生，{@code setProperty} 通过收窄它来保持原有契约。
+     */
+    private WriteOutcome writeProperty(String key, String value) {
+        if (!SAFE_KEYS.contains(key)) return WriteOutcome.REJECTED;
 
         File propsFile = new File(serverRoot, "server.properties");
-        if (!propsFile.exists()) return false;
+        if (!propsFile.exists()) return WriteOutcome.FAILED;
 
         Properties props = new Properties();
         try (FileInputStream fis = new FileInputStream(propsFile)) {
             props.load(fis);
         } catch (IOException e) {
-            return false;
+            return WriteOutcome.FAILED;
         }
 
         props.setProperty(key, value);
@@ -78,9 +101,91 @@ public class ServerPropertiesManager {
         try (FileOutputStream fos = new FileOutputStream(propsFile)) {
             props.store(fos, null);
         } catch (IOException e) {
-            return false;
+            return WriteOutcome.FAILED;
         }
-        return true;
+        return WriteOutcome.WRITTEN;
+    }
+
+    /** What actually happened to one key. 一个键的真实去向。 */
+    private enum WriteOutcome {
+        /** Written to disk. 已写入。 */
+        WRITTEN,
+        /** Not on {@link #SAFE_KEYS}; never attempted. 不在白名单，根本没尝试。 */
+        REJECTED,
+        /** On the whitelist, but reading or writing the file failed. 在白名单里，但读写失败。 */
+        FAILED
+    }
+
+    /**
+     * Outcome of one {@code set_all} batch.
+     * <p>
+     * {@link #isSuccess()} means <em>every key the caller asked for is now on disk</em>,
+     * which is the batch analogue of what {@code action: "set"} already reports for a
+     * single key. Keys carrying an explicit JSON {@code null} are not part of that
+     * promise — a {@code null} reads as "leave this one alone", so it is recorded in
+     * {@link #getSkipped()} for visibility but never fails the batch.
+     * <p>
+     * 一次 {@code set_all} 的结果。{@link #isSuccess()} 的含义是
+     * <em>调用方要求写的每一个键现在都在磁盘上</em>，也就是单键 {@code set} 早就在报的那件事的批量版。
+     * 值为 JSON {@code null} 的键不在这个承诺范围内 —— {@code null} 读作「这个别动」，
+     * 因此它只被记进 {@link #getSkipped()} 以便可见，不会让整批失败。
+     */
+    @ApiStatus.Internal
+    public static final class SetAllResult {
+        private final List<String> updated;
+        private final List<String> rejected;
+        private final List<String> failed;
+        private final List<String> skipped;
+
+        /**
+         * Public so callers outside this package can build one. Each list is copied before
+         * being wrapped — {@code unmodifiableList} is a view, so wrapping the caller's list
+         * directly would leave this "immutable" object mutable through the original reference.
+         * <p>
+         * 公开是为了包外也能构造。每个列表都先复制再包装 —— {@code unmodifiableList} 是视图，
+         * 直接包装调用方的列表会让这个「不可变」对象仍能通过原引用被改。
+         */
+        public SetAllResult(List<String> updated, List<String> rejected, List<String> failed, List<String> skipped) {
+            this.updated = Collections.unmodifiableList(new ArrayList<>(updated));
+            this.rejected = Collections.unmodifiableList(new ArrayList<>(rejected));
+            this.failed = Collections.unmodifiableList(new ArrayList<>(failed));
+            this.skipped = Collections.unmodifiableList(new ArrayList<>(skipped));
+        }
+
+        /** Keys written to disk. 已写入磁盘的键。 */
+        public List<String> getUpdated() { return updated; }
+
+        /** Keys refused because they are not on the whitelist. 因不在白名单而被拒的键。 */
+        public List<String> getRejected() { return rejected; }
+
+        /** Whitelisted keys whose write failed. 在白名单里但写入失败的键。 */
+        public List<String> getFailed() { return failed; }
+
+        /** Keys whose value was an explicit JSON null. 值为 JSON null 因而被跳过的键。 */
+        public List<String> getSkipped() { return skipped; }
+
+        /** Every requested key was written. 要求写的键全部写成功。 */
+        public boolean isSuccess() {
+            return rejected.isEmpty() && failed.isEmpty();
+        }
+
+        /**
+         * One line naming what went wrong, for a log record or an error response.
+         * Returns {@code null} when nothing went wrong.
+         * <p>
+         * 一句话说明哪里没成，用于日志或错误响应；全部成功时返回 {@code null}。
+         */
+        public String describeFailure() {
+            if (isSuccess()) return null;
+            StringBuilder sb = new StringBuilder("server.properties 批量设置未完全生效");
+            if (!rejected.isEmpty()) {
+                sb.append("；不在白名单因而被拒的键: ").append(String.join(", ", rejected));
+            }
+            if (!failed.isEmpty()) {
+                sb.append("；写入失败的键: ").append(String.join(", ", failed));
+            }
+            return sb.toString();
+        }
     }
 
     /**
@@ -134,21 +239,96 @@ public class ServerPropertiesManager {
             ? data.getAsJsonObject("values") : null;
         if (values == null) return;
 
-        int updated = 0;
+        applySetAll(values);
+    }
+
+    /**
+     * Apply a batch of properties, report it over the socket, and hand the outcome back.
+     * <p>
+     * The return value is the point. {@code handleSetAll} does not need it — it only ever
+     * builds a message — but {@code update_config} with
+     * {@code fileName: server_properties} routes through here too, and its
+     * {@code config_update_response} is supposed to distinguish "delivered" from
+     * "took effect". Before this returned anything, that path had no way to learn the
+     * answer and reported success unconditionally.
+     * <p>
+     * 应用一批属性、把结果发回面板，并把结果交还给调用方。
+     * <b>返回值才是重点</b>：{@code handleSetAll} 用不到它（它只负责拼一条消息），
+     * 但 {@code fileName: server_properties} 的 {@code update_config} 也走这里，
+     * 而它的 {@code config_update_response} 要区分「已下发」和「已生效」。
+     * 在这个方法有返回值之前，那条路径没有任何途径知道答案，只能无条件报成功。
+     *
+     * @param values key → value, an explicit JSON null meaning "leave this key alone"
+     * @return what happened to each key
+     */
+    public SetAllResult applySetAll(JsonObject values) {
+        List<String> updated = new ArrayList<>();
+        List<String> rejected = new ArrayList<>();
+        List<String> failed = new ArrayList<>();
+        List<String> skipped = new ArrayList<>();
+
         for (String key : values.keySet()) {
             if (values.get(key).isJsonNull()) {
+                skipped.add(key);
                 continue;
             }
-            if (setProperty(key, values.get(key).getAsString())) {
-                updated++;
+            switch (writeProperty(key, values.get(key).getAsString())) {
+                case WRITTEN:
+                    updated.add(key);
+                    break;
+                case REJECTED:
+                    rejected.add(key);
+                    break;
+                default:
+                    failed.add(key);
+                    break;
             }
         }
+
+        SetAllResult result = new SetAllResult(updated, rejected, failed, skipped);
+        warnIfIncomplete(result);
+        sendResponse(buildSetAllResponse(result));
+        return result;
+    }
+
+    private JsonObject buildSetAllResponse(SetAllResult result) {
         JsonObject response = new JsonObject();
         response.addProperty("type", "server_properties_result");
         response.addProperty("action", "set_all");
-        response.addProperty("success", true);
-        response.addProperty("updated", updated);
-        sendResponse(response);
+        response.addProperty("success", result.isSuccess());
+        // updated 保持数字，面板一直读的是这个字段；被挡下的键走新增的数组字段。
+        response.addProperty("updated", result.getUpdated().size());
+        response.add("rejected", toJsonArray(result.getRejected()));
+        response.add("failed", toJsonArray(result.getFailed()));
+        response.add("skipped", toJsonArray(result.getSkipped()));
+        return response;
+    }
+
+    private static JsonArray toJsonArray(List<String> keys) {
+        JsonArray array = new JsonArray();
+        for (String key : keys) {
+            array.add(key);
+        }
+        return array;
+    }
+
+    /**
+     * The response above is what the panel reads; this is what a server operator reads.
+     * Both are needed: someone changing a setting that silently does not apply otherwise
+     * finds nothing on either side.
+     * <p>
+     * 上面那条响应是给面板读的，这条是给服主读的。两边都要有：
+     * 否则改了个设置没生效的人，面板和服务器日志两头都查不到原因。
+     */
+    private void warnIfIncomplete(SetAllResult result) {
+        String failure = result.describeFailure();
+        if (failure == null) return;
+        // 这个管理器由 initWebSocketManagers() 在 onEnable 里构造，生产环境下单例一定就绪；
+        // 判空是为了让纯文件逻辑的单元测试不必先装一个全局单例。
+        UltiTools instance = UltiTools.getInstance();
+        if (instance != null && instance.getLogger() != null) {
+            instance.getLogger().log(Level.WARNING, failure);
+        }
     }
 
     private void sendResponse(JsonObject response) {

--- a/src/main/java/com/ultikits/ultitools/manager/ServerPropertiesManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/ServerPropertiesManager.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import java.util.logging.Level;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
@@ -136,6 +137,7 @@ public class ServerPropertiesManager {
         private final List<String> rejected;
         private final List<String> failed;
         private final List<String> skipped;
+        private final List<String> malformed;
 
         /**
          * Public so callers outside this package can build one. Each list is copied before
@@ -145,11 +147,13 @@ public class ServerPropertiesManager {
          * 公开是为了包外也能构造。每个列表都先复制再包装 —— {@code unmodifiableList} 是视图，
          * 直接包装调用方的列表会让这个「不可变」对象仍能通过原引用被改。
          */
-        public SetAllResult(List<String> updated, List<String> rejected, List<String> failed, List<String> skipped) {
+        public SetAllResult(List<String> updated, List<String> rejected, List<String> failed,
+                            List<String> skipped, List<String> malformed) {
             this.updated = Collections.unmodifiableList(new ArrayList<>(updated));
             this.rejected = Collections.unmodifiableList(new ArrayList<>(rejected));
             this.failed = Collections.unmodifiableList(new ArrayList<>(failed));
             this.skipped = Collections.unmodifiableList(new ArrayList<>(skipped));
+            this.malformed = Collections.unmodifiableList(new ArrayList<>(malformed));
         }
 
         /** Keys written to disk. 已写入磁盘的键。 */
@@ -164,16 +168,27 @@ public class ServerPropertiesManager {
         /** Keys whose value was an explicit JSON null. 值为 JSON null 因而被跳过的键。 */
         public List<String> getSkipped() { return skipped; }
 
+        /** Keys whose value was not a JSON primitive. 值不是 JSON 原始值因而无法作为属性写入的键。 */
+        public List<String> getMalformed() { return malformed; }
+
         /** Every requested key was written. 要求写的键全部写成功。 */
         public boolean isSuccess() {
-            return rejected.isEmpty() && failed.isEmpty();
+            return rejected.isEmpty() && failed.isEmpty() && malformed.isEmpty();
         }
 
         /**
          * One line naming what went wrong, for a log record or an error response.
          * Returns {@code null} when nothing went wrong.
          * <p>
+         * The three categories stay separate because they need three different actions:
+         * a rejected key means stop asking for it, a failed key means look at the disk,
+         * and a malformed key means fix the payload. Collapsing them into one label would
+         * send the reader looking in the wrong place — which is the failure mode this
+         * whole change exists to remove.
+         * <p>
          * 一句话说明哪里没成，用于日志或错误响应；全部成功时返回 {@code null}。
+         * 三类分开写，是因为它们要三种不同的处置：被拒 = 别再要这个键，写入失败 = 去看磁盘，
+         * 畸形 = 去修载荷。合成一个标签会把人指向错误的方向，而那正是这次改动要消灭的失败形态。
          */
         public String describeFailure() {
             if (isSuccess()) return null;
@@ -183,6 +198,9 @@ public class ServerPropertiesManager {
             }
             if (!failed.isEmpty()) {
                 sb.append("；写入失败的键: ").append(String.join(", ", failed));
+            }
+            if (!malformed.isEmpty()) {
+                sb.append("；值不是字符串或数字因而无法写入的键: ").append(String.join(", ", malformed));
             }
             return sb.toString();
         }
@@ -266,13 +284,35 @@ public class ServerPropertiesManager {
         List<String> rejected = new ArrayList<>();
         List<String> failed = new ArrayList<>();
         List<String> skipped = new ArrayList<>();
+        List<String> malformed = new ArrayList<>();
 
         for (String key : values.keySet()) {
-            if (values.get(key).isJsonNull()) {
+            JsonElement value = values.get(key);
+            if (value.isJsonNull()) {
                 skipped.add(key);
                 continue;
             }
-            switch (writeProperty(key, values.get(key).getAsString())) {
+            // server.properties is a flat string table, so anything that is not a JSON
+            // primitive is a malformed request rather than a value. Gson does not fail
+            // uniformly on those, which is why the guard has to come first:
+            // a JsonObject throws UnsupportedOperationException, an empty or multi-element
+            // JsonArray throws IllegalStateException, and a single-element JsonArray does
+            // not throw at all — it silently unwraps, so {"motd": ["Hello"]} would have
+            // been written as motd=Hello. One malformed key used to abort the whole batch
+            // before any response was built, which is the same "nobody can tell why"
+            // shape this issue is about.
+            //
+            // server.properties 是一张扁平的字符串表，所以非 JSON 原始值不是「值」而是畸形请求。
+            // 守卫必须放在取值之前，因为 Gson 的失败方式并不统一：JsonObject 抛
+            // UnsupportedOperationException，空数组和多元素数组抛 IllegalStateException，
+            // 而**单元素数组根本不抛** —— 它静默拆包，{"motd": ["Hello"]} 会被写成 motd=Hello。
+            // 而且过去一个畸形键就会在任何响应被构造之前中断整批，正是本 issue 说的那种
+            // 「没人查得到原因」的形状。
+            if (!value.isJsonPrimitive()) {
+                malformed.add(key);
+                continue;
+            }
+            switch (writeProperty(key, value.getAsString())) {
                 case WRITTEN:
                     updated.add(key);
                     break;
@@ -285,7 +325,7 @@ public class ServerPropertiesManager {
             }
         }
 
-        SetAllResult result = new SetAllResult(updated, rejected, failed, skipped);
+        SetAllResult result = new SetAllResult(updated, rejected, failed, skipped, malformed);
         warnIfIncomplete(result);
         sendResponse(buildSetAllResponse(result));
         return result;
@@ -301,6 +341,7 @@ public class ServerPropertiesManager {
         response.add("rejected", toJsonArray(result.getRejected()));
         response.add("failed", toJsonArray(result.getFailed()));
         response.add("skipped", toJsonArray(result.getSkipped()));
+        response.add("malformed", toJsonArray(result.getMalformed()));
         return response;
     }
 

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
@@ -517,10 +517,17 @@ public class PluginInitiationUtils {
             if (spm == null) {
                 throw new IOException("ServerPropertiesManager is not available");
             }
-            JsonObject spData = new JsonObject();
-            spData.addProperty("action", "set_all");
-            spData.add("values", com.google.gson.JsonParser.parseString(configContent).getAsJsonObject());
-            spm.handleServerProperties(spData);
+            // 走 applySetAll 而不是 handleServerProperties，是为了拿到返回值。
+            // 后者是 void，于是这条路径过去只能无条件报成功——面板拿到的 status
+            // 表达的是「消息处理完了」，不是「配置生效了」，而这两件事在
+            // SAFE_KEYS 白名单挡下某个键时就分岔了。见 issue #281。
+            // 两条消息都还在发：applySetAll 自己发 server_properties_result，
+            // 这里抛出的异常由调用方转成 config_update_response 的 error。
+            ServerPropertiesManager.SetAllResult result = spm.applySetAll(
+                    com.google.gson.JsonParser.parseString(configContent).getAsJsonObject());
+            if (!result.isSuccess()) {
+                throw new IOException(result.describeFailure());
+            }
             return;
         }
         if (fileName == null || fileName.trim().isEmpty()) {

--- a/src/test/java/com/ultikits/ultitools/manager/ServerPropertiesManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ServerPropertiesManagerTest.java
@@ -1,10 +1,27 @@
 package com.ultikits.ultitools.manager;
 
 import static org.assertj.core.api.Assertions.*;
-import java.io.*;
-import java.util.*;
-import org.junit.jupiter.api.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import java.io.*;
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
+
+import com.google.gson.JsonObject;
+import com.ultikits.ultitools.UltiTools;
+import com.ultikits.ultitools.utils.TestHelper;
+import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
+
+@SuppressWarnings("PMD.AvoidAccessibilityAlteration") // Test requires reflection to clear the global singleton
 class ServerPropertiesManagerTest {
 
     private File tempDir;
@@ -32,9 +49,49 @@ class ServerPropertiesManagerTest {
     }
 
     @AfterEach
-    void tearDown() {
+    void tearDown() throws Exception {
         propsFile.delete();
         tempDir.delete();
+        // UltiTools.ultiTools 是全局静态字段。只有部分用例会装它，但不还原就会漏给
+        // 同一个 JVM 里后面的测试类。无条件清空，不去判断本用例装没装过。
+        Field instanceField = UltiTools.class.getDeclaredField("ultiTools");
+        instanceField.setAccessible(true);
+        instanceField.set(null, null);
+    }
+
+    /** 装一个只会发消息的 socket，并把发出去的那条抓回来。 */
+    private UltiPanelWebSocketClient attachSocket() {
+        UltiPanelWebSocketClient socket = mock(UltiPanelWebSocketClient.class);
+        lenient().when(socket.getServerId()).thenReturn("srv-1");
+        manager.setWebSocketClient(socket);
+        return socket;
+    }
+
+    private static JsonObject captureMessage(UltiPanelWebSocketClient socket) {
+        ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
+        verify(socket).sendMessage(captor.capture());
+        return captor.getValue();
+    }
+
+    private static List<String> stringsOf(JsonObject message, String field) {
+        List<String> values = new ArrayList<>();
+        message.getAsJsonArray(field).forEach(element -> values.add(element.getAsString()));
+        return values;
+    }
+
+    private static JsonObject setAllRequest(Map<String, String> values) {
+        JsonObject payload = new JsonObject();
+        for (Map.Entry<String, String> entry : values.entrySet()) {
+            if (entry.getValue() == null) {
+                payload.add(entry.getKey(), com.google.gson.JsonNull.INSTANCE);
+            } else {
+                payload.addProperty(entry.getKey(), entry.getValue());
+            }
+        }
+        JsonObject data = new JsonObject();
+        data.addProperty("action", "set_all");
+        data.add("values", payload);
+        return data;
     }
 
     @Test
@@ -64,5 +121,166 @@ class ServerPropertiesManagerTest {
     void shouldRejectUnsafeProperty() {
         boolean result = manager.setProperty("rcon.password", "hacked");
         assertThat(result).isFalse();
+    }
+
+    /**
+     * issue #281：{@code set_all} 的 {@code success} 曾经是写死的 {@code true}，与实际写进去几个键无关。
+     *
+     * <p>这里断言的对象刻意是**发回面板的那条消息**，而不是内部计数器。真相当时其实存在于
+     * {@code updated} 字段里，缺陷是没有人保证调用方会去看它，而 {@code success} 这个名字
+     * 明确在说另一件事。所以要证明修好了，就得证明那个名字现在说的是真话。
+     */
+    @Nested
+    @DisplayName("set_all 的结果必须是真的（#281）")
+    class SetAllReportsTheTruth {
+
+        @Test
+        @DisplayName("全部键都在白名单外：success 为 false，一个都没写进去")
+        void allKeysRejected() {
+            UltiPanelWebSocketClient socket = attachSocket();
+            Map<String, String> request = new LinkedHashMap<>();
+            request.put("rcon.password", "hacked");
+            request.put("server-port", "1337");
+
+            manager.handleServerProperties(setAllRequest(request));
+
+            JsonObject message = captureMessage(socket);
+            assertThat(message.get("success").getAsBoolean()).isFalse();
+            assertThat(message.get("updated").getAsInt()).isZero();
+            assertThat(stringsOf(message, "rejected")).containsExactly("rcon.password", "server-port");
+
+            // 负向对照：被拒不只是「没报成功」，磁盘上确实没被改。
+            assertThat(manager.getSafeProperties()).doesNotContainKey("rcon.password");
+        }
+
+        @Test
+        @DisplayName("部分命中：success 为 false，写进去的和被拒的分别列出来")
+        void partiallyRejected() {
+            UltiPanelWebSocketClient socket = attachSocket();
+            Map<String, String> request = new LinkedHashMap<>();
+            request.put("motd", "Half applied");
+            request.put("rcon.password", "hacked");
+
+            manager.handleServerProperties(setAllRequest(request));
+
+            JsonObject message = captureMessage(socket);
+            assertThat(message.get("success").getAsBoolean()).isFalse();
+            assertThat(message.get("updated").getAsInt()).isEqualTo(1);
+            assertThat(stringsOf(message, "rejected")).containsExactly("rcon.password");
+            // 命中的那个确实写进去了——部分失败不等于整批回滚，响应说的就是这个。
+            assertThat(manager.getSafeProperties().get("motd")).isEqualTo("Half applied");
+        }
+
+        @Test
+        @DisplayName("全部命中：success 为 true，rejected 与 failed 都是空的")
+        void allKeysApplied() {
+            UltiPanelWebSocketClient socket = attachSocket();
+            Map<String, String> request = new LinkedHashMap<>();
+            request.put("motd", "Fully applied");
+            request.put("max-players", "64");
+
+            manager.handleServerProperties(setAllRequest(request));
+
+            JsonObject message = captureMessage(socket);
+            assertThat(message.get("success").getAsBoolean()).isTrue();
+            assertThat(message.get("updated").getAsInt()).isEqualTo(2);
+            assertThat(stringsOf(message, "rejected")).isEmpty();
+            assertThat(stringsOf(message, "failed")).isEmpty();
+            assertThat(manager.getSafeProperties().get("max-players")).isEqualTo("64");
+        }
+
+        @Test
+        @DisplayName("值是 JSON null 的键记进 skipped，但不让整批失败")
+        void explicitNullsAreVisibleButHarmless() {
+            UltiPanelWebSocketClient socket = attachSocket();
+            Map<String, String> request = new LinkedHashMap<>();
+            request.put("motd", "Applied");
+            request.put("pvp", null);
+
+            manager.handleServerProperties(setAllRequest(request));
+
+            JsonObject message = captureMessage(socket);
+            // null 读作「这个别动」，所以它不算失败；但它此前既不计数也不上报，
+            // 是第四类隐形跳过，现在至少看得见。
+            assertThat(message.get("success").getAsBoolean()).isTrue();
+            assertThat(stringsOf(message, "skipped")).containsExactly("pvp");
+            assertThat(message.get("updated").getAsInt()).isEqualTo(1);
+            assertThat(manager.getSafeProperties().get("pvp")).isEqualTo("true");
+        }
+
+        @Test
+        @DisplayName("白名单里的键写不进去时算 failed，与「被白名单拒了」分开报")
+        void writeFailuresAreDistinctFromRejections() {
+            // server.properties 不存在 = 写不进去，但键本身是合法的。
+            // 这两种情况过去都只是 setProperty 返回 false，调用方分不出来，而处置完全不同。
+            assertThat(propsFile.delete()).isTrue();
+            UltiPanelWebSocketClient socket = attachSocket();
+            Map<String, String> request = new LinkedHashMap<>();
+            request.put("motd", "Never lands");
+            request.put("rcon.password", "hacked");
+
+            manager.handleServerProperties(setAllRequest(request));
+
+            JsonObject message = captureMessage(socket);
+            assertThat(message.get("success").getAsBoolean()).isFalse();
+            assertThat(stringsOf(message, "failed")).containsExactly("motd");
+            assertThat(stringsOf(message, "rejected")).containsExactly("rcon.password");
+        }
+
+        @Test
+        @DisplayName("没提供 values 时既不写也不回消息")
+        void missingValuesIsNotARequest() {
+            UltiPanelWebSocketClient socket = attachSocket();
+            JsonObject data = new JsonObject();
+            data.addProperty("action", "set_all");
+
+            manager.handleServerProperties(data);
+
+            verify(socket, never()).sendMessage(org.mockito.ArgumentMatchers.any(JsonObject.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("被挡下的键在服务器日志里也要看得见（#281）")
+    class OperatorVisibleLogging {
+
+        @Test
+        @DisplayName("有键被挡下时记一条 WARNING，并点名是哪个键")
+        void rejectedKeysAreLoggedAtWarning() {
+            Logger logger = mock(Logger.class);
+            // 必须用 Consumer 重载：先打桩、后发布。见 TestHelper 的 javadoc 与 issue #250。
+            TestHelper.mockUltiToolsInstance(ultiTools -> lenient().when(ultiTools.getLogger()).thenReturn(logger));
+            attachSocket();
+
+            manager.handleServerProperties(setAllRequest(Collections.singletonMap("rcon.password", "hacked")));
+
+            ArgumentCaptor<String> line = ArgumentCaptor.forClass(String.class);
+            verify(logger).log(eq(Level.WARNING), line.capture());
+            assertThat(line.getValue()).contains("rcon.password");
+        }
+
+        @Test
+        @DisplayName("全部成功时不记 WARNING")
+        void nothingIsLoggedWhenEverythingApplies() {
+            Logger logger = mock(Logger.class);
+            TestHelper.mockUltiToolsInstance(ultiTools -> lenient().when(ultiTools.getLogger()).thenReturn(logger));
+            attachSocket();
+
+            manager.handleServerProperties(setAllRequest(Collections.singletonMap("motd", "Fine")));
+
+            verify(logger, never()).log(eq(Level.WARNING), org.mockito.ArgumentMatchers.anyString());
+        }
+
+        @Test
+        @DisplayName("没有全局单例时不抛异常——这个类的文件逻辑不该依赖它")
+        void missingSingletonDoesNotBreakTheBatch() {
+            // 负向对照。生产环境下 UltiTools.getInstance() 一定就绪（管理器在 onEnable 里构造），
+            // 但纯文件逻辑的用例不该被迫先装一个全局单例才能跑。
+            UltiPanelWebSocketClient socket = attachSocket();
+
+            manager.handleServerProperties(setAllRequest(Collections.singletonMap("rcon.password", "hacked")));
+
+            assertThat(captureMessage(socket).get("success").getAsBoolean()).isFalse();
+        }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/manager/ServerPropertiesManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ServerPropertiesManagerTest.java
@@ -227,6 +227,100 @@ class ServerPropertiesManagerTest {
             assertThat(stringsOf(message, "rejected")).containsExactly("rcon.password");
         }
 
+        /**
+         * 值不是 JSON 原始值时，`getAsString()` 在结果被构造之前就炸了，于是整批中断、
+         * 一条响应都发不出去——面板永远等不到回复。而 Gson 的失败方式并不统一，
+         * 所以三种载荷各测一次，实测（gson 2.8.9）：
+         *
+         * <pre>
+         * {}            → UnsupportedOperationException
+         * []            → IllegalStateException
+         * ["Hello"]     → 不抛，静默拆包成 "Hello"
+         * </pre>
+         *
+         * 最后一种最隐蔽：它不是崩溃，是畸形载荷被悄悄接受并写进磁盘。
+         */
+        @Test
+        @DisplayName("值是 JSON 对象：算 malformed，不中断整批，也不写磁盘")
+        void objectValuesAreMalformedNotFatal() {
+            UltiPanelWebSocketClient socket = attachSocket();
+            JsonObject payload = new JsonObject();
+            payload.add("motd", new JsonObject());
+            payload.addProperty("max-players", "64");
+            JsonObject data = new JsonObject();
+            data.addProperty("action", "set_all");
+            data.add("values", payload);
+
+            manager.handleServerProperties(data);
+
+            JsonObject message = captureMessage(socket);
+            assertThat(message.get("success").getAsBoolean()).isFalse();
+            assertThat(stringsOf(message, "malformed")).containsExactly("motd");
+            // 后面的键仍然被处理了——一个畸形键不该毁掉整批。
+            assertThat(message.get("updated").getAsInt()).isEqualTo(1);
+            assertThat(manager.getSafeProperties().get("motd")).isEqualTo("A Minecraft Server");
+            assertThat(manager.getSafeProperties().get("max-players")).isEqualTo("64");
+        }
+
+        @Test
+        @DisplayName("值是空数组：算 malformed（Gson 这里抛的是另一种异常）")
+        void emptyArrayValuesAreMalformed() {
+            UltiPanelWebSocketClient socket = attachSocket();
+            JsonObject payload = new JsonObject();
+            payload.add("motd", new com.google.gson.JsonArray());
+            JsonObject data = new JsonObject();
+            data.addProperty("action", "set_all");
+            data.add("values", payload);
+
+            manager.handleServerProperties(data);
+
+            assertThat(stringsOf(captureMessage(socket), "malformed")).containsExactly("motd");
+        }
+
+        @Test
+        @DisplayName("值是单元素数组：算 malformed，而不是被静默拆包写进去")
+        void singleElementArraysAreNotSilentlyUnwrapped() {
+            // 这一条是三种里唯一不抛异常的：Gson 的 JsonArray.getAsString() 在长度为 1 时
+            // 返回该元素的字符串。也就是说没有守卫的话，{"motd": ["Hello"]} 会被当成
+            // motd=Hello 写进磁盘——畸形载荷被悄悄接受，而不是被拒绝。
+            UltiPanelWebSocketClient socket = attachSocket();
+            com.google.gson.JsonArray wrapped = new com.google.gson.JsonArray();
+            wrapped.add("Hello");
+            JsonObject payload = new JsonObject();
+            payload.add("motd", wrapped);
+            JsonObject data = new JsonObject();
+            data.addProperty("action", "set_all");
+            data.add("values", payload);
+
+            manager.handleServerProperties(data);
+
+            JsonObject message = captureMessage(socket);
+            assertThat(message.get("success").getAsBoolean()).isFalse();
+            assertThat(stringsOf(message, "malformed")).containsExactly("motd");
+            assertThat(manager.getSafeProperties().get("motd")).isEqualTo("A Minecraft Server");
+        }
+
+        @Test
+        @DisplayName("非字符串的原始值仍然可以写（数字、布尔）")
+        void nonStringPrimitivesStillWork() {
+            UltiPanelWebSocketClient socket = attachSocket();
+            JsonObject payload = new JsonObject();
+            payload.addProperty("max-players", 64);
+            payload.addProperty("pvp", false);
+            JsonObject data = new JsonObject();
+            data.addProperty("action", "set_all");
+            data.add("values", payload);
+
+            manager.handleServerProperties(data);
+
+            // 负向对照：守卫拦的是「不是原始值」，不是「不是字符串」。
+            // 面板发数字和布尔是正常的，拦下它们会是一个新的回归。
+            JsonObject message = captureMessage(socket);
+            assertThat(message.get("success").getAsBoolean()).isTrue();
+            assertThat(manager.getSafeProperties().get("max-players")).isEqualTo("64");
+            assertThat(manager.getSafeProperties().get("pvp")).isEqualTo("false");
+        }
+
         @Test
         @DisplayName("没提供 values 时既不写也不回消息")
         void missingValuesIsNotARequest() {

--- a/src/test/java/com/ultikits/ultitools/utils/PluginInitiationUtilsConfigUpdateTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/PluginInitiationUtilsConfigUpdateTest.java
@@ -353,7 +353,28 @@ class PluginInitiationUtilsConfigUpdateTest {
         private void stubSetAllResult(List<String> updated, List<String> rejected, List<String> failed) {
             lenient().when(mockServerProperties.applySetAll(any(JsonObject.class)))
                     .thenReturn(new ServerPropertiesManager.SetAllResult(
-                            updated, rejected, failed, emptyList()));
+                            updated, rejected, failed, emptyList(), emptyList()));
+        }
+
+        /**
+         * 值不是 JSON 原始值时（对象、数组）同样让响应变成 error。这条与上面几条不同的地方在于
+         * 它在**取值之前**就分岔了：`getAsString()` 对 JsonObject 抛
+         * {@code UnsupportedOperationException}，对空数组和多元素数组抛
+         * {@code IllegalStateException}，而单元素数组根本不抛、静默拆包。
+         */
+        @Test
+        @DisplayName("值不是原始值的键让响应变成 error")
+        void malformedValuesMakeTheResponseAnError() throws Exception {
+            lenient().when(mockServerProperties.applySetAll(any(JsonObject.class)))
+                    .thenReturn(new ServerPropertiesManager.SetAllResult(
+                            emptyList(), emptyList(), emptyList(), emptyList(), singletonList("motd")));
+
+            PluginInitiationUtils.handleConfigUpdate(
+                    panelMessage("server_properties", "{\"motd\":{}}", "req-13"));
+
+            JsonObject payload = capturedResponse().getAsJsonObject("data");
+            assertThat(payload.get("status").getAsString()).isEqualTo("error");
+            assertThat(payload.get("error").getAsString()).contains("motd");
         }
 
         @Test

--- a/src/test/java/com/ultikits/ultitools/utils/PluginInitiationUtilsConfigUpdateTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/PluginInitiationUtilsConfigUpdateTest.java
@@ -1,5 +1,7 @@
 package com.ultikits.ultitools.utils;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -292,16 +294,66 @@ class PluginInitiationUtilsConfigUpdateTest {
         @Test
         @DisplayName("带内容时转成 set_all 交给专用管理器，不走配置文件那条路")
         void contentIsForwardedAsSetAll() throws Exception {
+            stubSetAllResult(singletonList("max-players"), emptyList(), emptyList());
+
             PluginInitiationUtils.handleConfigUpdate(
                     panelMessage("server_properties", "{\"max-players\":\"30\"}", "req-9"));
 
             ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
-            verify(mockServerProperties).handleServerProperties(captor.capture());
-            JsonObject forwarded = captor.getValue();
-            assertThat(forwarded.get("action").getAsString()).isEqualTo("set_all");
-            assertThat(forwarded.getAsJsonObject("values").get("max-players").getAsString()).isEqualTo("30");
+            verify(mockServerProperties).applySetAll(captor.capture());
+            assertThat(captor.getValue().get("max-players").getAsString()).isEqualTo("30");
 
             verify(mockConfigManager, never()).loadFromJson(anyString(), anyString());
+        }
+
+        /**
+         * issue #281：这条路径此前必报成功。{@code applyConfigUpdate} 调的是 {@code void} 的
+         * {@code handleServerProperties}，真相在调用链上根本没有返回路径，于是面板拿到的
+         * {@code status} 表达的是「消息处理完了」而不是「配置生效了」——而这两件事在
+         * 白名单挡下某个键时就分岔了。
+         */
+        @Test
+        @DisplayName("白名单挡下键时回 error，并点名是哪个键")
+        void rejectedKeysMakeTheResponseAnError() throws Exception {
+            stubSetAllResult(emptyList(), singletonList("rcon.password"), emptyList());
+
+            PluginInitiationUtils.handleConfigUpdate(
+                    panelMessage("server_properties", "{\"rcon.password\":\"hacked\"}", "req-10"));
+
+            JsonObject payload = capturedResponse().getAsJsonObject("data");
+            assertThat(payload.get("status").getAsString()).isEqualTo("error");
+            assertThat(payload.get("error").getAsString()).contains("rcon.password");
+        }
+
+        @Test
+        @DisplayName("全部生效时才回 success")
+        void fullyAppliedBatchReportsSuccess() throws Exception {
+            stubSetAllResult(singletonList("motd"), emptyList(), emptyList());
+
+            PluginInitiationUtils.handleConfigUpdate(
+                    panelMessage("server_properties", "{\"motd\":\"hi\"}", "req-11"));
+
+            JsonObject payload = capturedResponse().getAsJsonObject("data");
+            assertThat(payload.get("status").getAsString()).isEqualTo("success");
+        }
+
+        @Test
+        @DisplayName("写入失败的键同样让响应变成 error")
+        void writeFailuresMakeTheResponseAnError() throws Exception {
+            stubSetAllResult(emptyList(), emptyList(), singletonList("motd"));
+
+            PluginInitiationUtils.handleConfigUpdate(
+                    panelMessage("server_properties", "{\"motd\":\"hi\"}", "req-12"));
+
+            JsonObject payload = capturedResponse().getAsJsonObject("data");
+            assertThat(payload.get("status").getAsString()).isEqualTo("error");
+            assertThat(payload.get("error").getAsString()).contains("motd");
+        }
+
+        private void stubSetAllResult(List<String> updated, List<String> rejected, List<String> failed) {
+            lenient().when(mockServerProperties.applySetAll(any(JsonObject.class)))
+                    .thenReturn(new ServerPropertiesManager.SetAllResult(
+                            updated, rejected, failed, emptyList()));
         }
 
         @Test


### PR DESCRIPTION
Closes #281.

`set_all` 回给面板的 `success` 是写死的 `true`，与实际写进去几个键无关。面板提交一批全在 `SAFE_KEYS` 之外的属性，拿到的是 `success: true, updated: 0` —— 一条都没写，但报告成功。单键的 `set` 那条本来就是对的，只有批量把 `setProperty` 的返回值丢了。

## 根因在响应之前一层

`setProperty` 把三种情况压成同一个 `false`：**键不在白名单**、**没有 server.properties 可写**、**写入本身失败**。三种处置完全不同，值却只有一个。所以就算把 `success` 改成「至少写进去一个」也还是在猜。

真实结果现在由私有的 `writeProperty` 产出（`WRITTEN` / `REJECTED` / `FAILED`），`setProperty` 通过收窄它保持原有契约、签名一字未动。`success` 的含义和单键路径对齐：**调用方要求写的每一个键现在都在磁盘上**。

响应新增三个数组字段，被挡下的键从此有名有姓：

```json
{ "action": "set_all", "success": false, "updated": 1,
  "rejected": ["rcon.password"], "failed": [], "skipped": ["pvp"] }
```

`updated` 保持数字不动，面板一直读的是它。

## 顺带一个第四类隐形跳过

值为 JSON `null` 的键此前直接 `continue`，既不计数也不上报。`null` 读作「这个别动」，所以它现在进 `skipped` 让人看得见，但**不让整批失败** —— 把它算成失败会改变面板已有的语义。

## `config_update_response` 那半是结构性的

`fileName: server_properties` 的 `update_config` 走的是 `void` 的 `handleServerProperties`，**真相在调用链上根本没有返回路径**，所以那条响应的 `status` 表达的是「消息处理完了」而不是「配置生效了」——而这两件事恰恰在白名单挡下某个键时分岔。改成调 `applySetAll` 拿返回值，不成功就抛 `IOException`，由调用方既有的 catch 转成 `error`。**两条消息都还在发**：`applySetAll` 自己发 `server_properties_result`，`config_update_response` 由上层发，面板不需要同时改。

## 验证

`mvn -B clean verify` 通过，测试 **4300 → 4312**（+12，是先 stash 改动实测的基线，不是估的）。

负向对照**分两半各做一次**，因为这是两个独立的缺陷：

| 单独还原的东西 | 挂掉的用例 | 另一半 |
|---|---|---|
| `success` 改回写死 `true` | `allKeysRejected` · `partiallyRejected` · `writeFailuresAreDistinctFromRejections` · `missingSingletonDoesNotBreakTheBatch` | `config_update_response` 那 5 条**全绿** |
| 去掉 `!isSuccess()` 时的 throw | `rejectedKeysMakeTheResponseAnError` · `writeFailuresMakeTheResponseAnError` | `set_all` 那些**全绿** |

两半互不遮蔽，各自的用例真的咬住了各自的缺陷。

## 验收对照

- [x] `set_all` 的 `success` 反映实际结果，不再写死
- [x] 被白名单挡下的键对调用方可见 —— 响应的 `rejected` 数组**加上** WARNING 日志（issue 说「或」，两个都做了：面板读前者，服主读后者，缺一头就还是查不到原因）
- [x] `config_update_response` 在 server_properties 路径上能报出真实结果
- [x] 覆盖「全部键都在白名单外」与「部分命中」两种情形，另加全部命中、JSON null、写入失败与白名单拒绝的区分、缺 `values`

## 一处判断请复核

`ServerPropertiesManager` 此前对 `UltiTools.getInstance()` **零依赖**，加 WARNING 日志会引入它。我按兄弟 manager 的写法用了 `UltiTools.getInstance().getLogger()`，但加了判空，好让这个类纯文件逻辑的用例不必先装全局静态单例——生产环境下管理器在 `onEnable` 的 `initWebSocketManagers()` 里构造，单例一定就绪。判空本身有一条负向对照用例守着（`missingSingletonDoesNotBreakTheBatch`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzTkgBjRdaTcLrbvkoaFkp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detailed results for bulk server-property updates, including updated, rejected, failed, and skipped settings.
  - WebSocket responses now report whether configuration changes succeeded or encountered issues.
  - Configuration updates now surface meaningful failure details instead of always reporting success.

- **Bug Fixes**
  - Prevented partially applied or failed server-property updates from being treated as successful.
  - Improved handling of missing, rejected, and unwritable settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->