### PR TITLE
fix: 重连预算耗尽时走完整拆线路径，而不只是翻一个标志

### DIFF
--- a/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
@@ -1005,11 +1005,21 @@ public class PluginInitiationUtils {
         // 闸门二：全局预算。客户端自身的 5 次上限是每实例的，而这里每次都造新实例，
         // 所以那个上限对整体等于不存在。见 issue #181。
         if (!reinitBackoff.shouldContinue()) {
-            cloudEnabled.set(false);
+            // 先把话说完再拆线：下面的 disableCloud() 会关掉日志上传通道，这句得赶在那之前发出去。
             UltiTools.getInstance().getLogger().log(Level.WARNING, String.format(
                 "WebSocket re-initialization gave up after %d attempts. Cloud features are now idle. "
                     + "Run /ulticloud login to retry, or restart the server.",
                 MAX_REINIT_ATTEMPTS));
+            // 「now idle」必须是真的。曾经这里只有一句 cloudEnabled.set(false)：状态机确实停了，
+            // 但心跳线程、日志传输器与 root logger handler、玩家事件监听器、token 刷新调度
+            // 以及静态 panelWS/token 引用全都留着继续跑——日志宣告空转，实际在漏。
+            // 终态与 logout 是同一件事，就该走同一条拆线路径。
+            //
+            // 复用 disableCloud() 是安全的：它第一件事就是把 cloudEnabled 置否，所以其中的
+            // stopWebsocket() 即使触发 onClose→重连链，也会被本方法开头的闸门一挡回去；
+            // 它顺带做的 reinitBackoff.reset() 同样无害——闸门一已经拦死，预算再也消耗不到，
+            // 而恢复只能靠 /ulticloud login，那条路本来就会 reset。
+            disableCloud();
             return;
         }
 

--- a/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
@@ -102,6 +102,36 @@ class CloudReconnectStateMachineTest {
         }
 
         @Test
+        @DisplayName("预算耗尽进入终态时，拆线动作必须与 logout 一致")
+        void exhaustedBudgetTearsDownCloudResources() {
+            // 先让云侧真正接上线，否则下面断言的是一个空集合，测试等于什么都没测。
+            LogStreamManager manager = LogStreamManager.getInstance();
+            try {
+                manager.initialize(null);
+            } catch (Exception ignored) {
+                // 传 null 客户端时下游可能抛，但 handler 的挂载必须已经发生
+            }
+            assertThat(countFrameworkHandlersOnRootLogger())
+                    .as("前置条件：日志 handler 应当已挂在 root logger 上")
+                    .isEqualTo(1);
+
+            for (int i = 0; i < 15; i++) {
+                PluginInitiationUtils.reinitWebSocket();
+            }
+
+            assertThat(PluginInitiationUtils.isCloudEnabled())
+                    .as("预算耗尽之后必须进入 disabled 终态")
+                    .isFalse();
+
+            // 终态的日志原文是 "Cloud features are now idle"。只翻 cloudEnabled 标志的话，
+            // 日志传输器与 root logger handler、玩家事件监听器、token 刷新调度以及静态
+            // panelWS/token 引用会全部留着继续跑——那句话就成了谎。
+            assertThat(countFrameworkHandlersOnRootLogger())
+                    .as("既然已宣告 cloud features are now idle，root logger 就不该还挂着框架 handler")
+                    .isZero();
+        }
+
+        @Test
         @DisplayName("握手成功会把预算清零，使长期运行的服务器不会耗尽额度")
         void successfulHandshakeResetsBudget() {
             for (int i = 0; i < 5; i++) {


### PR DESCRIPTION
## 背景

来自 promote PR #287 上 Codex 的 P2 评审意见。属实，且是真实的资源泄漏。

## 问题

`reinitWebSocket()` 的外层预算（`MAX_REINIT_ATTEMPTS = 10`）耗尽后，终态分支只做了 `cloudEnabled.set(false)` 就 return。日志宣告 **"Cloud features are now idle"**，但 `doDisableCloud()` 的七件事一件都没做：

| `doDisableCloud()` 做的事 | 耗尽路径 |
|---|---|
| `cloudEnabled.set(false)` | ✅ |
| `reinitBackoff.reset()` | ❌ |
| `LogStreamManager.shutdown()`（含 root logger handler） | ❌ |
| `PlayerEventManager.shutdown()` | ❌ |
| `stopWebsocket()` + `panelWS = null` | ❌ |
| `token = null` | ❌ |
| `CloudAuthManager.stopTokenRefreshScheduler()` | ❌ |

后果：日志传输器线程、root logger 上的 `SystemLogHandler`、注册在 `HandlerList` 上的玩家事件监听器、旧 `panelWS` 实例及其心跳 executor、token 刷新调度——全部无限期存活，只能靠重启服务器回收。那句日志是假的。

这是面板长时间不可达时**必然**走到的路径，不是边缘情况。

## 改动

终态与 logout 本来就是同一件事，改为复用 `disableCloud()`。

**复用安全性论证**（已逐条验证）：

- **不会自我复活**：`doDisableCloud()` 第一件事就是 `cloudEnabled.set(false)`，因此其中的 `stopWebsocket()` 即便触发 `onClose` → 重连链，也会被 `reinitWebSocket` 开头的闸门一挡回去。
- **`reinitBackoff.reset()` 无害**：闸门一已拦死，预算再也消耗不到；恢复只能靠 `/ulticloud login`，而 `enableCloud()` 本就会 reset。
- **线程安全**：拆线动作全是 `ScheduledExecutorService.shutdown()` 与 `HandlerList.unregisterAll()`（static synchronized），不触碰主线程限定的 Bukkit API，因此从 WebSocket 重连线程调用是安全的。`reinitWebSocket` 在正常路径下本来就已在该线程调 `panelWS.disconnect()`。
- **日志顺序**：WARNING 先于拆线发出，避免被 `LogStreamManager.shutdown()` 掐掉上传通道。

## 测试

新增 `exhaustedBudgetTearsDownCloudResources`，断言终态下 root logger 上的框架 handler 归零——即那句日志为真。

- 修复前：`expected: 0 but was: 1`（已实测 RED）
- 修复后：通过
- 全量：**4318 tests, 0 failures**

## 影响面

`src/main` 仅 `PluginInitiationUtils.java` 一处分支，11 行（含注释）。无 API 变更，无行为回退——原本就应当发生的拆线现在真的发生了。