### PR TITLE
chore: 抑制三条 PMD 假阳性，让 Codacy 门禁反映真实状态

### DIFF
--- a/src/test/java/com/ultikits/ultitools/manager/ServerMonitorSnapshotTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ServerMonitorSnapshotTest.java
@@ -44,7 +44,12 @@ import org.mockbukkit.mockbukkit.ServerMock;
  */
 @DisplayName("服务器状态采样的线程契约")
 @Timeout(value = 30, unit = TimeUnit.SECONDS)
-@SuppressWarnings("PMD.AvoidAccessibilityAlteration") // 测试需要反射读任务句柄，与仓库其它测试类一致
+@SuppressWarnings({
+        "PMD.AvoidAccessibilityAlteration", // 测试需要反射读任务句柄，与仓库其它测试类一致
+        // PMD 只认 assert*/fail* 这类方法名，识别不了 AssertJ 的流式断言
+        // （doesNotSampleWithoutClient 断的是 assertThatCode(...).doesNotThrowAnyException()）。
+        "PMD.JUnitTestsShouldIncludeAssert"
+})
 class ServerMonitorSnapshotTest {
 
     private ServerMock server;

--- a/src/test/java/com/ultikits/ultitools/utils/PluginInitiationUtilsInboundMessageTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/PluginInitiationUtilsInboundMessageTest.java
@@ -44,6 +44,7 @@ import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
  * 「WebSocket消息解析失败」——而解析是成功的，于是消息被静默丢弃且诊断指错方向。
  */
 @DisplayName("PluginInitiationUtils 入站消息守卫")
+@SuppressWarnings("PMD.AvoidAccessibilityAlteration") // tearDown 需反射复位 UltiTools 单例（#250），与仓库其它测试类一致
 class PluginInitiationUtilsInboundMessageTest {
 
     private Logger mockLogger;

--- a/src/test/java/com/ultikits/ultitools/websocket/HeartbeatLivenessTest.java
+++ b/src/test/java/com/ultikits/ultitools/websocket/HeartbeatLivenessTest.java
@@ -28,6 +28,7 @@ import com.ultikits.ultitools.utils.TestHelper;
  * <p>全部用假时钟推进，不用 {@code Thread.sleep} —— 真等两个心跳周期是 120 秒。
  */
 @DisplayName("心跳存活判定")
+@SuppressWarnings("PMD.AvoidAccessibilityAlteration") // tearDown 需反射复位 UltiTools 单例（#250），与仓库其它测试类一致
 class HeartbeatLivenessTest {
 
     /** 假时钟，测试自己推进。 */


### PR DESCRIPTION
## 背景

promote PR #287 上 Codacy 报了 4 条新问题，导致该 PR `mergeStateStatus` 为 `UNSTABLE`。逐条核实后，**3 条是假阳性，1 条是真实技术债**。

## 逐条核实

| 文件 | 规则 | 级别 | 结论 |
|---|---|---|---|
| `PluginInitiationUtilsInboundMessageTest:62` | `AvoidAccessibilityAlteration` | Security/High | 假阳性 → 抑制 |
| `HeartbeatLivenessTest:55` | `AvoidAccessibilityAlteration` | Security/High | 假阳性 → 抑制 |
| `ServerMonitorSnapshotTest:309` | `JUnitTestsShouldIncludeAssert` | BestPractice | 假阳性 → 抑制 |
| `PluginInitiationUtils:201` | `NPathComplexity` 1514 | Complexity | **真实，不抑制** |

### 前两条

两处都是 `@AfterEach` 里反射复位 `UltiTools` 静态单例：

```java
Field instanceField = UltiTools.class.getDeclaredField("ultiTools");
instanceField.setAccessible(true);
instanceField.set(null, null);
```

surefire 未配 `forkCount`，全部测试跑在同一个 JVM 里，不复位就会跨测试类污染（见 #250）。这是既定手法——`CloudReconnectStateMachineTest` 与 `ServerMonitorSnapshotTest` 早已带着同一条抑制注解，本 PR 只是把漏掉的两个补齐。

### 第三条

`doesNotSampleWithoutClient` 断言的是：

```java
assertThatCode(fresh::refreshStateSnapshot).doesNotThrowAnyException();
```

PMD 按 `assert*` / `fail*` 的方法名识别断言，认不出 AssertJ 的流式 API。测试本身有断言。

### 第四条不在本 PR 处理

`handleInboundMessage` 的 NPath 复杂度 1514（阈值 200）是真实问题，但它是 WebSocket 入站消息分发的核心路径。在 6.2.5 发版前重构它，风险远大于收益。**不抑制、不掩盖**，另行开 issue 记为技术债。

## 影响面

纯 `@SuppressWarnings` 注解，零逻辑变更。三个测试类均通过。