### PR TITLE
fix: 拆线时停掉服务器监控，并让它的线程池可重启

### DIFF
--- a/src/main/java/com/ultikits/ultitools/manager/ServerMonitorManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/ServerMonitorManager.java
@@ -26,7 +26,13 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.Internal
 public class ServerMonitorManager {
     private UltiPanelWebSocketClient webSocketClient;
-    private final ScheduledExecutorService scheduler;
+    /**
+     * 发送线程池。<b>不能是 final</b>：{@link #stopMonitoring()} 会 shutdown 它，而
+     * {@code ScheduledExecutorService} 一经 shutdown 就永久失效。logout 之后再 login
+     * 是一条完全正常的路径，那时 {@link #startMonitoring()} 必须拿到一个可用的池，
+     * 否则 {@code scheduleAtFixedRate} 直接抛 {@code RejectedExecutionException}。
+     */
+    private ScheduledExecutorService scheduler;
     private boolean isMonitoring = false;
     private int tickCount = 0;
 
@@ -122,6 +128,10 @@ public class ServerMonitorManager {
         }
         
         isMonitoring = true;
+        // 上一轮 stopMonitoring 把池关掉了就换一个新的——见字段上的说明。
+        if (scheduler == null || scheduler.isShutdown()) {
+            scheduler = Executors.newScheduledThreadPool(2);
+        }
         UltiTools.getInstance().getLogger().log(Level.INFO, "启动服务器状态监控");
         
         // 等待WebSocket连接建立后，立即发送初始状态

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
@@ -1120,6 +1120,19 @@ public class PluginInitiationUtils {
                 "Error shutting down log stream manager: " + e.getMessage());
         }
 
+        // 停掉服务器监控。它自带一个 ScheduledExecutorService（每 5 秒 batch_update）
+        // 外加两个主线程 Bukkit 定时任务（1Hz 的 TPS/CPU、5 秒一次的世界/玩家/插件快照）。
+        // 在此之前 stopMonitoring() 在整个 src/main 里没有任何调用方：写好了、测过了，
+        // 就是没接线。不停的话，「云功能已关闭」之后主线程仍在按 5 秒遍历所有世界和区块。
+        try {
+            if (UltiTools.getInstance().getServerMonitorManager() != null) {
+                UltiTools.getInstance().getServerMonitorManager().stopMonitoring();
+            }
+        } catch (Exception e) {
+            UltiTools.getInstance().getLogger().log(Level.FINE,
+                "Error stopping server monitor: " + e.getMessage());
+        }
+
         // 摘掉玩家事件监听器。云关掉之后再收玩家事件是纯浪费——事件处理器里那句
         // isConnected() 判断只是让它不发消息，监听本身还在跑。见 issue #180。
         try {

--- a/src/test/java/com/ultikits/ultitools/manager/ServerMonitorSnapshotTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ServerMonitorSnapshotTest.java
@@ -352,6 +352,20 @@ class ServerMonitorSnapshotTest {
                     .isNull();
             assertThat(tpsField.get(manager)).isNull();
         }
+
+        @Test
+        @DisplayName("stopMonitoring 之后还能重新 startMonitoring")
+        void monitoringCanRestartAfterStop() {
+            manager.startMonitoring();
+            manager.stopMonitoring();
+
+            // ScheduledExecutorService 一经 shutdown 就永久失效，重启必须换一个新的。
+            // 否则「logout 之后再 login」这条完全正常的路径会在 scheduleAtFixedRate
+            // 上抛 RejectedExecutionException——而这正是把 stopMonitoring 接进
+            // disableCloud 拆线路径的前提。
+            org.assertj.core.api.Assertions.assertThatCode(manager::startMonitoring)
+                    .doesNotThrowAnyException();
+        }
     }
 
     @Nested

--- a/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
@@ -21,6 +21,7 @@ import org.mockito.Mockito;
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.handler.SystemLogHandler;
 import com.ultikits.ultitools.manager.LogStreamManager;
+import com.ultikits.ultitools.manager.ServerMonitorManager;
 
 /**
  * 云连接重连状态机的行为：全局预算、logout 的终止语义、以及成功日志的位置。
@@ -35,13 +36,16 @@ import com.ultikits.ultitools.manager.LogStreamManager;
 class CloudReconnectStateMachineTest {
 
     private Logger mockLogger;
+    private ServerMonitorManager mockMonitor;
 
     @BeforeEach
     void setUp() {
         mockLogger = mock(Logger.class);
+        mockMonitor = mock(ServerMonitorManager.class);
         // Consumer 重载：先打桩、后发布。见 TestHelper javadoc 与 issue #250。
         TestHelper.mockUltiToolsInstance(ultiTools -> {
             lenient().when(ultiTools.getLogger()).thenReturn(mockLogger);
+            lenient().when(ultiTools.getServerMonitorManager()).thenReturn(mockMonitor);
             // 必须是惰性 answer，不能 thenReturn(LogStreamManager.getInstance())：
             // 这个回调跑在 mock 被发布**之前**（见 TestHelper javadoc），而
             // LogStreamManager 的构造函数会调 UltiTools.getInstance().getLogger()，
@@ -182,6 +186,18 @@ class CloudReconnectStateMachineTest {
             assertThat(countFrameworkHandlersOnRootLogger())
                     .as("「云功能已关闭」应当包含不再劫持 root logger")
                     .isZero();
+        }
+
+        @Test
+        @DisplayName("disableCloud 会停掉服务器监控")
+        void disableCloudStopsServerMonitor() {
+            // ServerMonitorManager 自带一个 ScheduledExecutorService 加两个主线程 Bukkit
+            // 定时任务。在此之前 stopMonitoring() 在整个 src/main 里没有调用方——写好了、
+            // 测过了、就是没接线，于是「云功能已关闭」之后主线程仍在按 5 秒遍历所有世界。
+            // 这里验证的是接线；停下来之后到底停了什么由 ServerMonitorSnapshotTest 覆盖。
+            PluginInitiationUtils.disableCloud();
+
+            Mockito.verify(mockMonitor).stopMonitoring();
         }
 
         @Test
@@ -363,7 +379,10 @@ class CloudReconnectStateMachineTest {
 
             PluginInitiationUtils.initializeManagers();
 
-            Mockito.verify(UltiTools.getInstance(), Mockito.never()).getServerMonitorManager();
+            // 断言接线动作本身没发生，而不是数 getServerMonitorManager() 被取过几次：
+            // 拆线路径现在也要取这个 manager 来 stopMonitoring，调用计数已不能区分两者。
+            Mockito.verify(mockMonitor, Mockito.never()).setWebSocketClient(Mockito.any());
+            Mockito.verify(mockMonitor).stopMonitoring();
             assertThat(loggedAt(Level.FINE))
                     .anySatisfy(line -> assertThat(line).contains("跳过管理器初始化"));
         }


### PR DESCRIPTION
## 背景

promote PR #287 上 Codex 复审的 P2。核实属实。

## 问题

`ServerMonitorManager.stopMonitoring()` 在整个 `src/main` 里**没有任何调用方**：

```
$ grep -rn "stopMonitoring" src/main --include=*.java
ServerMonitorManager.java:64:  /** 主线程上的两个定时任务，{@link #stopMonitoring()} 需要能取消它们。 */
ServerMonitorManager.java:163: public void stopMonitoring() {
```

实现完整、被测试覆盖、注释里还记着 PR #265 的评审教训——就是从来没接线。

于是 `/ulticloud logout` 或重连预算耗尽（#288）之后，`doDisableCloud()` 关掉了日志流、玩家监听、socket 与 token 调度，唯独监控还在跑：

| 任务 | 线程 | 频率 |
|---|---|---|
| `scheduler.scheduleAtFixedRate(sendBatchUpdate)` | 自有线程池 | 5 秒 |
| `tpsTask` — TPS/CPU 采样 | **主线程** | 1 Hz |
| `snapshotTask` — 遍历所有世界与已加载区块 | **主线程** | 5 秒 |

最后一项尤其贵（`world.getLoadedChunks()` 要分配装下全部已加载区块的数组），而且长在主线程上。「云功能已关闭」之后，服务器仍在为一个不存在的面板付这份开销。

## 修复分两半，缺一不可

**1.** `doDisableCloud()` 接上 `stopMonitoring()`。

**2.** `ServerMonitorManager.scheduler` 去掉 `final`，`startMonitoring()` 时若已 shutdown 就重建。

第 2 步不是锦上添花：`ScheduledExecutorService` 一经 `shutdown()` 即永久失效。只做第 1 步的话，`logout → login` 这条完全正常的路径会炸——已用测试实证：

```
java.util.concurrent.RejectedExecutionException: Task ... rejected from
java.util.concurrent.ScheduledThreadPoolExecutor@47a05ad8[Terminated, pool size = 0, ...]
```

## 顺带修正一处失效的断言

`managersAreNotWiredWhenCloudDisabled` 原先用 `verify(never()).getServerMonitorManager()` 作为「未接线」的**代理证据**——因为 `wireManagers()` 第一件事就是取这个 manager。拆线路径现在也要取它，调用计数不再能区分两者。

改为直接断言接线动作 `setWebSocketClient(...)` 未发生，并额外断言拆线确实发生了。比原来更强，也不再依赖代理指标。

## 测试

- `monitoringCanRestartAfterStop` — 覆盖 executor 重启（修复前实测 `RejectedExecutionException`）
- `disableCloudStopsServerMonitor` — 覆盖拆线接线
- 全量 **4320 tests, 0 failures**