### PR TITLE
fix: 不再覆盖 release.sh 上传的 JAR，否则送 UAT 的 sha256 会失效

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -70,7 +70,11 @@ jobs:
       # 仓库里曾经有一个更完整的 release.yml，但一次都没被跑过，也没能挡住
       # （已随 #231 删除）。所以这一层要放在不依赖记性的地方。
       #
-      # --clobber 让它幂等：入口脚本已经传过同名附件时覆盖，而不是报错退出。
+      # 幂等的做法是「已存在就跳过」，不是 --clobber 覆盖。release.sh 走的是「本地
+      # clean build → 校验 JAR 内容 → 打印 sha256 → 连附件一起 create」这条路，它
+      # 打印的 sha256 会被拿去送真机 UAT。本步骤跑在 release:published 上重新构建，
+      # 语义相同但 ZIP 时间戳不同，hash 必然对不上——覆盖等于让 UAT 手里的 sha256
+      # 失效，且分发出去的构件不再是本地校验通过的那一个。
       env:
         VERSION: ${{ needs.validate.outputs.version }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -85,7 +89,17 @@ jobs:
           echo "::error::构建完成但找不到 ${JAR}。"
           exit 1
         fi
-        gh release upload "${GITHUB_REF_NAME}" "$JAR" --clobber
+        ASSET="$(basename "$JAR")"
+        # 管道在 if 条件里，errexit/pipefail 不会让脚本直接退出；gh 查不到就当作
+        # 附件不存在，落到 else 去补传，这个降级方向是安全的。
+        if gh release view "${GITHUB_REF_NAME}" --json assets \
+             --jq '.assets[].name' | grep -qxF "$ASSET"; then
+          echo "✅ ${ASSET} 已是 release 附件，保留不动。"
+          echo "   它来自 release.sh 的本地构建，其 sha256 已用于真机 UAT。"
+        else
+          echo "▶ release 上没有 ${ASSET}，补传本次 CI 构建的产物。"
+          gh release upload "${GITHUB_REF_NAME}" "$JAR"
+        fi
 
     - name: 📦 Publish to GitHub Packages
       id: publish-ghp


### PR DESCRIPTION
## 背景

promote PR #287 上 Codex 复审的 P2。核实属实，且直接影响 6.2.5 的发版链。

## 问题

`publish-packages.yml` 的「📎 Attach JAR to the release」跑在 `release: published` 事件上，重新构建 JAR 后：

```bash
gh release upload "${GITHUB_REF_NAME}" "$JAR" --clobber
```

`gh release upload --help` 明确写着 `--clobber` 会**先删除同名附件再上传**。

而主路径 `.github/scripts/release.sh` 做的是：

```
本地 clean build
  → 校验 JAR 内容（必须含 plugin.yml 与 UltiTools.class，防止误挑 sources jar）
  → 计算 sha256
  → 连附件一起 gh release create      ← 上传的是这一个
  → 打印 sha256
```

脚本自己在末尾写着：

> 附件 sha256 ...
> 送真机 UAT 时需要这个值，且必须是本次构建当场取的——
> ZIP 时间戳会让语义相同的重新构建产生不同 hash。

然后它触发的这个 workflow 把那个附件换掉了。两个后果：

1. **维护者拿去送 UAT 的 sha256 与实际下载到的附件对不上**，UAT 会 fail-closed；
2. **真正分发出去的构件不是本地那次通过内容校验的构建**。

## 意图没错，手段选反了

原注释：

> `--clobber` 让它幂等：入口脚本已经传过同名附件时覆盖，而不是报错退出。

要的是幂等（避免重复上传报错退出），但幂等在这里应当是**「已存在就跳过」**而不是「覆盖」。同一步骤的注释也写明自己是「兜底，不是主路径」——兜底不该覆盖主路径的产物。

## 改动

先查 release 上有没有同名附件：有就保留不动，没有才补传。

`v6.2.1`~`v6.2.4` 四个零附件 release 正是这一步存在的理由，**网页手工建 release 的兜底能力完全不受影响**。

## 验证

用桩 `gh` 提取 workflow 里的真实脚本实测三种场景：

| 场景 | 结果 |
|---|---|
| release.sh 已传同名附件 | ✅ 保留不动 |
| GitHub UI 手工建的 release，零附件 | ✅ 补传（兜底有效） |
| release 上只有无关附件（旧版本 JAR、checksums.txt） | ✅ 补传（`grep -qxF` 全行匹配未误判） |

- YAML 解析通过
- CRLF 行尾保持不变（diff 为 16 增 2 删，非整文件重写）
- `set -euo pipefail` 下管道位于 `if` 条件中，errexit 被抑制；`gh` 查询失败会降级为「当作附件不存在」并补传，方向安全