### PR TITLE
fix: 新模块激活成功之后才卸掉被它取代的旧版本

### DIFF
--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -482,7 +482,12 @@ public class PluginManager {
     }
 
     /**
-     * 卸掉被本次加载取代的旧版本。必须等新模块初始化成功之后才调用。
+     * 卸掉被本次加载取代的旧版本。
+     * <p>
+     * <b>只能在新模块的 {@code registerSelf()} 返回 true 之后调用</b>——不是「容器建好之后」。
+     * 两者差着一步：容器建好只说明 bean 图能构造，模块尚未激活；而 {@code registerSelf()}
+     * 返回 false 或抛异常时，调用方会关掉新容器。若旧版本已经在此之前被卸，这个模块就
+     * 两头落空，而它原本正在正常运行。
      */
     private void unregisterSupersededVersions(UltiToolsPlugin plugin) {
         for (UltiToolsPlugin existing : pluginList) {
@@ -505,11 +510,17 @@ public class PluginManager {
     }
 
     private boolean attemptPluginRegistration(UltiToolsPlugin plugin) {
-        // 到这一步新模块已经初始化成功，可以安全地把它取代掉的旧版本卸下来了。
-        unregisterSupersededVersions(plugin);
         try {
             boolean registerSelf = plugin.registerSelf();
             if (registerSelf) {
+                // 卸旧只能放在这里：容器建好了不等于模块活了，registerSelf() 才是模块
+                // 宣告自己激活成功的那一步。放在它之前的话，registerSelf 返回 false 或
+                // 抛异常时，旧版本已经被卸、新版本的 context 又被 close——这个模块两头
+                // 落空，而它原本正在正常运行。
+                //
+                // 放这里不会与旧版本抢命令：真正注册 Bukkit 命令的 registerBukkit() 在
+                // 本方法返回之后才被调用，此刻新版本一条命令都还没注册。
+                unregisterSupersededVersions(plugin);
                 onPluginRegistered(plugin);
             } else {
                 plugin.getContext().close();

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerTest.java
@@ -900,6 +900,39 @@ class PluginManagerTest {
         }
 
         @Test
+        @DisplayName("新模块 registerSelf 返回 false 时不得卸掉旧版本")
+        void failedRegisterSelfShouldNotUnregisterTheOlderVersion() throws Exception {
+            // 卸旧必须等到新版本真正激活成功。放在 registerSelf() 之前的话，一旦它返回
+            // false，旧版本已经被卸、新版本的 context 又被 close——这个模块两头落空，
+            // 而它原本是在正常运行的。
+            UltiToolsPlugin older = modules("Dup", "com.example.Dup", "1.0.0", CURRENT_API_VERSION);
+            UltiToolsPlugin newer = modules("Dup", "com.example.Dup", "2.0.0", CURRENT_API_VERSION);
+            when(newer.isNewerVersionThan(older)).thenReturn(true);
+            when(newer.registerSelf()).thenReturn(false);
+            pluginManager.getPluginList().add(older);
+
+            boolean result = pluginManager.register(newer);
+
+            assertThat(result).isFalse();
+            verify(older, never()).unregisterSelf();
+        }
+
+        @Test
+        @DisplayName("新模块 registerSelf 抛异常时同样不得卸掉旧版本")
+        void throwingRegisterSelfShouldNotUnregisterTheOlderVersion() throws Exception {
+            UltiToolsPlugin older = modules("Dup", "com.example.Dup", "1.0.0", CURRENT_API_VERSION);
+            UltiToolsPlugin newer = modules("Dup", "com.example.Dup", "2.0.0", CURRENT_API_VERSION);
+            when(newer.isNewerVersionThan(older)).thenReturn(true);
+            when(newer.registerSelf()).thenThrow(new java.io.IOException("激活失败"));
+            pluginManager.getPluginList().add(older);
+
+            boolean result = pluginManager.register(newer);
+
+            assertThat(result).isFalse();
+            verify(older, never()).unregisterSelf();
+        }
+
+        @Test
         @DisplayName("新模块因版本不兼容被拒时不应该顺手卸掉已加载的旧版本")
         void rejectedModuleShouldNotUnregisterTheLoadedOlderVersion() {
             // Arrange - 新版本更高但要求的 API 太新：拒它，同时不能动线上正在跑的那个


### PR DESCRIPTION
## 背景

promote PR #287 上 Codex 第三轮复审的 **P1**。核实属实。

## 问题

`attemptPluginRegistration` 的第一行就卸掉旧版本，然后才激活新版本：

```java
private boolean attemptPluginRegistration(UltiToolsPlugin plugin) {
    // 到这一步新模块已经初始化成功，可以安全地把它取代掉的旧版本卸下来了。
    unregisterSupersededVersions(plugin);          // ← 旧版本的命令/监听器没了
    try {
        boolean registerSelf = plugin.registerSelf();
        if (registerSelf) {
            onPluginRegistered(plugin);
        } else {
            plugin.getContext().close();           // ← 新版本也没了
            ...
```

`registerSelf()` 返回 false 或抛异常时，**两个版本都不可用**，而旧版本原本正在正常运行。

触发条件很平常：`plugins/` 目录里同一模块留着两个版本的 JAR（更新时忘了删旧的），且新版本激活失败。

## 根因是一句措辞

那句注释「到这一步新模块已经**初始化成功**」正是位置放错的原因。容器建好 ≠ 模块活了，两者差着一步：

| 阶段 | 含义 |
|---|---|
| `initializePlugin()` 成功 | bean 图能构造、`@PostConstruct` 跑完 |
| `registerSelf()` 返回 true | **模块宣告自己激活成功** |

引入这行的 f94ca87 在 commit message 里写的意图是对的——「after the new module is up」——只是落地时把它放在了 `registerSelf()` 之前。

## 改动

把 `unregisterSupersededVersions(plugin)` 移到 `registerSelf()` 返回 true 之后。`unregisterSupersededVersions` 的 javadoc 一并改掉，免得下一个人照着旧措辞再放回去。

**不会与旧版本抢命令**：真正注册 Bukkit 命令的 `registerBukkit()` 在 `attemptPluginRegistration` 返回之后才调用（三处调用点均为 `if (result) { registerBukkit(...) }`），此刻新版本一条命令都还没注册。

## 这不是 alpha 引入的

`main` 上 `existing.unregisterSelf()` 藏在 `hasNewerVersionLoaded()` 这个**查询函数**里，同样跑在 `registerSelf()` 之前：

```java
private boolean hasNewerVersionLoaded(UltiToolsPlugin plugin) {   // main
    ...
    } else if (plugin.isNewerVersionThan(existing)) {
        existing.unregisterSelf();                                 // ← mutation 藏在查询里
    }
```

f94ca87 只是把它挪到了更诚实的位置，顺序没变。所以这是既有缺陷，promote 不会让它变坏——但既然发现了就一并修掉。

## 测试

新增两个回归测试，修复前均失败：

- `failedRegisterSelfShouldNotUnregisterTheOlderVersion` — `registerSelf()` 返回 false
- `throwingRegisterSelfShouldNotUnregisterTheOlderVersion` — `registerSelf()` 抛 `IOException`

既有的 `olderVersionShouldBeUnregisteredOnlyAfterInitialization`（`InOrder` 断言 `setContext` 先于 `unregisterSelf`）继续通过。

全量 **4322 tests, 0 failures**。