### PR TITLE
fix: 玩家事件处理器单次读取客户端引用，消除与拆线的竞态 NPE

### DIFF
--- a/src/main/java/com/ultikits/ultitools/manager/PlayerEventManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PlayerEventManager.java
@@ -105,7 +105,12 @@ public class PlayerEventManager implements Listener {
      */
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerJoin(PlayerJoinEvent event) {
-        if (webSocketClient == null || !webSocketClient.isConnected()) {
+        // 单次读进局部变量，全程用同一个引用。字段是 volatile，检查与发送之间
+        // shutdown() 完全可以从另一条线程把它置空——重连预算耗尽时 disableCloud()
+        // 就跑在 WebSocket 线程上，而本方法跑在 Bukkit 主线程。
+        // HandlerList.unregisterAll() 只拦得住未来的派发，拦不住已经在栈上的这一次。
+        UltiPanelWebSocketClient client = webSocketClient;
+        if (client == null || !client.isConnected()) {
             return;
         }
         
@@ -117,7 +122,7 @@ public class PlayerEventManager implements Listener {
         data.addProperty("join_message", event.getJoinMessage());
         data.addProperty("online_count", Bukkit.getOnlinePlayers().size());
         
-        sendPlayerEvent(data);
+        sendPlayerEvent(client, data);
         
         // 同时发送日志流消息
         UltiTools.getInstance().getLogStreamManager().sendPlayerEventLog(
@@ -131,7 +136,12 @@ public class PlayerEventManager implements Listener {
      */
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerQuit(PlayerQuitEvent event) {
-        if (webSocketClient == null || !webSocketClient.isConnected()) {
+        // 单次读进局部变量，全程用同一个引用。字段是 volatile，检查与发送之间
+        // shutdown() 完全可以从另一条线程把它置空——重连预算耗尽时 disableCloud()
+        // 就跑在 WebSocket 线程上，而本方法跑在 Bukkit 主线程。
+        // HandlerList.unregisterAll() 只拦得住未来的派发，拦不住已经在栈上的这一次。
+        UltiPanelWebSocketClient client = webSocketClient;
+        if (client == null || !client.isConnected()) {
             return;
         }
         
@@ -143,7 +153,7 @@ public class PlayerEventManager implements Listener {
         data.addProperty("quit_message", event.getQuitMessage());
         data.addProperty("online_count", Math.max(0, Bukkit.getOnlinePlayers().size() - 1));
         
-        sendPlayerEvent(data);
+        sendPlayerEvent(client, data);
         
         // 同时发送日志流消息
         UltiTools.getInstance().getLogStreamManager().sendPlayerEventLog(
@@ -157,7 +167,12 @@ public class PlayerEventManager implements Listener {
      */
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerChat(PlayerChatEvent event) {
-        if (webSocketClient == null || !webSocketClient.isConnected()) {
+        // 单次读进局部变量，全程用同一个引用。字段是 volatile，检查与发送之间
+        // shutdown() 完全可以从另一条线程把它置空——重连预算耗尽时 disableCloud()
+        // 就跑在 WebSocket 线程上，而本方法跑在 Bukkit 主线程。
+        // HandlerList.unregisterAll() 只拦得住未来的派发，拦不住已经在栈上的这一次。
+        UltiPanelWebSocketClient client = webSocketClient;
+        if (client == null || !client.isConnected()) {
             return;
         }
         
@@ -169,7 +184,7 @@ public class PlayerEventManager implements Listener {
         data.addProperty("message", event.getMessage());
         data.addProperty("format", event.getFormat());
         
-        sendPlayerEvent(data);
+        sendPlayerEvent(client, data);
         
         // 同时发送日志流消息（聊天消息通常比较频繁，使用debug级别）
         UltiTools.getInstance().getLogStreamManager().sendCustomLog(
@@ -181,16 +196,22 @@ public class PlayerEventManager implements Listener {
     
     /**
      * 发送玩家事件到UltiPanel
+     * <p>
+     * 客户端由调用方传入，而不是在这里重新读 {@link #webSocketClient}：三个事件处理器各自
+     * 把那个 volatile 字段单次读进局部变量再一路传下来。否则「检查连接」与「真正发送」读到
+     * 的会是两个不同的值——{@code shutdown()} 恰好挤在中间的话，这里就是一个 NPE。
+     *
+     * @param client 事件处理器进入时读到的那个客户端
      * @param data 事件数据
      */
-    private void sendPlayerEvent(JsonObject data) {
+    private void sendPlayerEvent(UltiPanelWebSocketClient client, JsonObject data) {
         JsonObject message = new JsonObject();
         message.addProperty("type", "player_event");
         message.add("data", data);
         message.addProperty("timestamp", Instant.now().toEpochMilli());
-        message.addProperty("serverId", getServerId());
-        
-        webSocketClient.sendMessage(message);
+        message.addProperty("serverId", getServerId(client));
+
+        client.sendMessage(message);
     }
     
     /**
@@ -203,7 +224,7 @@ public class PlayerEventManager implements Listener {
      *
      * @return 服务器ID
      */
-    private String getServerId() {
-        return webSocketClient == null ? "unknown" : webSocketClient.getServerId();
+    private String getServerId(UltiPanelWebSocketClient client) {
+        return client == null ? "unknown" : client.getServerId();
     }
 }

--- a/src/test/java/com/ultikits/ultitools/manager/PlayerEventManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PlayerEventManagerTest.java
@@ -1,6 +1,7 @@
 package com.ultikits.ultitools.manager;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -110,6 +111,48 @@ class PlayerEventManagerTest {
             assertThat(initMethod).isNotNull();
             // Verify client mock was created successfully
             assertThat(client).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("拆线与在途事件的竞态")
+    class ShutdownRace {
+
+        /**
+         * 精确复现竞态窗口：{@code isConnected()} 返回 true 之后、真正发送之前，另一条线程
+         * 走完了 {@code shutdown()} 并把 {@code webSocketClient} 置空。
+         * <p>
+         * 真实触发路径是重连预算耗尽——{@code disableCloud()} 跑在 WebSocket 线程上，
+         * 而事件处理器跑在 Bukkit 主线程。{@code HandlerList.unregisterAll()} 只拦得住
+         * 未来的派发，拦不住已经在栈上跑着的这一次。
+         */
+        private void shutdownDuringConnectivityCheck() {
+            when(mockWebSocketClient.isConnected()).thenAnswer(invocation -> {
+                playerEventManager.shutdown();
+                return true;
+            });
+        }
+
+        @Test
+        @DisplayName("join：检查通过之后被 shutdown，不得抛 NPE")
+        void joinSurvivesConcurrentShutdown() {
+            PlayerMock player = server.addPlayer();
+            PlayerJoinEvent event = new PlayerJoinEvent(player, "joined");
+            shutdownDuringConnectivityCheck();
+
+            assertThatCode(() -> playerEventManager.onPlayerJoin(event))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("quit：检查通过之后被 shutdown，不得抛 NPE")
+        void quitSurvivesConcurrentShutdown() {
+            PlayerMock player = server.addPlayer();
+            PlayerQuitEvent event = new PlayerQuitEvent(player, "left");
+            shutdownDuringConnectivityCheck();
+
+            assertThatCode(() -> playerEventManager.onPlayerQuit(event))
+                    .doesNotThrowAnyException();
         }
     }
 
@@ -225,7 +268,10 @@ class PlayerEventManagerTest {
         @DisplayName("应该能够通过反射调用私有方法")
         void shouldCallPrivateMethod() throws Exception {
             // Arrange
-            Method method = PlayerEventManager.class.getDeclaredMethod("sendPlayerEvent", JsonObject.class);
+            // 客户端现在由调用方传入：三个事件处理器各自把 volatile 字段单次读进局部
+            // 变量再一路传下来，避免检查与发送之间被 shutdown() 置空。
+            Method method = PlayerEventManager.class.getDeclaredMethod(
+                    "sendPlayerEvent", UltiPanelWebSocketClient.class, JsonObject.class);
             method.setAccessible(true);
 
             JsonObject data = new JsonObject();
@@ -233,7 +279,7 @@ class PlayerEventManagerTest {
             when(mockWebSocketClient.isConnected()).thenReturn(true);
 
             // Act
-            method.invoke(playerEventManager, data);
+            method.invoke(playerEventManager, mockWebSocketClient, data);
 
             // Assert
             verify(mockWebSocketClient, atLeastOnce()).sendMessage(any(JsonObject.class));
@@ -332,11 +378,12 @@ class PlayerEventManagerTest {
         @DisplayName("应该能够调用私有方法")
         void shouldCallPrivateMethod() throws Exception {
             // Arrange
-            Method method = PlayerEventManager.class.getDeclaredMethod("getServerId");
+            Method method = PlayerEventManager.class.getDeclaredMethod(
+                    "getServerId", UltiPanelWebSocketClient.class);
             method.setAccessible(true);
 
             // Act
-            String result = (String) method.invoke(playerEventManager);
+            String result = (String) method.invoke(playerEventManager, mockWebSocketClient);
 
             // Assert
             assertThat(result).isNotNull();
@@ -346,11 +393,12 @@ class PlayerEventManagerTest {
         @DisplayName("应该返回非空字符串")
         void shouldReturnNonEmptyString() throws Exception {
             // Arrange
-            Method method = PlayerEventManager.class.getDeclaredMethod("getServerId");
+            Method method = PlayerEventManager.class.getDeclaredMethod(
+                    "getServerId", UltiPanelWebSocketClient.class);
             method.setAccessible(true);
 
             // Act
-            String result = (String) method.invoke(playerEventManager);
+            String result = (String) method.invoke(playerEventManager, mockWebSocketClient);
 
             // Assert
             assertThat(result).isNotBlank();


### PR DESCRIPTION
## 背景

promote PR #287 上 Codex 第四轮复审的 P2。核实属实。

## 问题

三个事件处理器都是同一个形状：

```java
public void onPlayerJoin(PlayerJoinEvent event) {
    if (webSocketClient == null || !webSocketClient.isConnected()) {   // 第 1 次读
        return;
    }
    ...
    sendPlayerEvent(data);          // 内部第 2 次读 → webSocketClient.sendMessage(...)
```

字段是 `volatile`，两次读之间 `shutdown()` 完全可以从另一条线程把它置空：

```java
public synchronized void shutdown() {
    HandlerList.unregisterAll(this);
    listenerRegistered = false;
    this.webSocketClient = null;    // ← 挤在两次读之间
}
```

于是第二次读拿到 `null`，`sendMessage` 抛 NPE，事件被丢掉。

两道看似存在的防线都不管用：

- `HandlerList.unregisterAll()` 只拦得住**未来**的派发，拦不住已经在栈上跑着的这一次；
- `shutdown()` 的 `synchronized` 也无济于事——事件处理器根本不获取同一把监视器。

`getServerId()` 有 `client == null ? "unknown"` 的保护，但 `sendPlayerEvent` 第 193 行的 `sendMessage` 没有。

## 这个窗口被 #288 放大了

在 #288 之前，`disableCloud()` 只从 `/ulticloud logout` 走**命令线程**调用。现在重连预算耗尽也会调它，而那条路径跑在 **WebSocket 线程**上——与主线程上的事件处理器真正并发。缺陷本身是既有的，触发面是新的。

## 改动

三个处理器入口各自把 volatile 字段**单次读进局部变量**，连通性检查、`serverId` 与发送全程用同一个引用。

`sendPlayerEvent` 与 `getServerId` 相应改为接收客户端参数——这样「只读一次」由方法签名强制，而不是靠下一个维护者记得。

## 测试

用 Mockito `answer` 在 `isConnected()` 内触发 `shutdown()`，**确定性地**复现该窗口而不依赖真实并发时序：

```java
when(mockWebSocketClient.isConnected()).thenAnswer(invocation -> {
    playerEventManager.shutdown();
    return true;
});
```

修复前两条均以 NPE 失败：

```
java.lang.NullPointerException: Cannot invoke
"...UltiPanelWebSocketClient.sendMessage(...)" because "this.webSocketClient" is null
```

三处既有反射测试（`sendPlayerEvent` ×1、`getServerId` ×2）随签名变更同步更新。

全量 **4324 tests, 0 failures**。