### PR TITLE
fix: 拆线路径健壮性两则（logout 门禁 · 握手回调引用竞态）

### DIFF
--- a/src/main/java/com/ultikits/ultitools/commands/CloudLoginCommand.java
+++ b/src/main/java/com/ultikits/ultitools/commands/CloudLoginCommand.java
@@ -60,10 +60,17 @@ public class CloudLoginCommand extends AbstractCommandExecutor {
 
     @CmdMapping(format = "logout")
     public void logout(@CmdSender CommandSender sender) {
-        if (!CloudAuthManager.hasValidToken()) {
-            sender.sendMessage(ChatColor.YELLOW + "Not currently logged in to UltiCloud.");
-            return;
-        }
+        // 这里刻意**不**用 hasValidToken() 做门禁。
+        //
+        // 它要求 token 未过期，而「access token 过期了但一切还在跑」恰恰是最需要 logout
+        // 生效的场景：主动刷新反复失败之后，socket、监控任务、root logger 上的日志 handler、
+        // 玩家事件监听器与刷新调度可能全都还活着，而 logout 是操作员唯一的停止手段。
+        // 旧实现在这一刻回一句「Not currently logged in」就退出，把人堵死在只能重启。
+        //
+        // 凭证的有效性不能作为生命周期拆解的门禁。改为看「有没有东西可清」：
+        // 拆线无条件执行（disableCloud 的每一步对「本来就没起来」都幂等），
+        // 清凭证只在确实存着凭证时做。
+        TokenEntity existing = CloudAuthManager.getCurrentToken();
 
         try {
             // 先拆状态机，再清凭证。
@@ -72,6 +79,13 @@ public class CloudLoginCommand extends AbstractCommandExecutor {
             // 用已作废的凭证敲面板，401 循环照跑，实测只有重新 login 或重启服务器才停得下来。
             // 「Cloud features are now disabled」这句话此前是不成立的。见 issue #223。
             PluginInitiationUtils.disableCloud();
+
+            if (existing == null) {
+                sender.sendMessage(ChatColor.YELLOW + "Not currently logged in to UltiCloud.");
+                sender.sendMessage(ChatColor.GRAY + "Cloud features have been stopped regardless.");
+                return;
+            }
+
             CloudAuthManager.clearToken();
             sender.sendMessage(ChatColor.GREEN + "Successfully logged out of UltiCloud. Cloud features are now disabled.");
             sender.sendMessage(ChatColor.GRAY + "Use /ulticloud login to re-authenticate.");

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
@@ -148,40 +148,61 @@ public class PluginInitiationUtils {
         // 现在只有显式动作才开启：启动时的 UltiTools.onEnable、以及 magic-link 登录成功后
         // 的 CloudAuthManager，两处都调 enableCloud()。见 issue #223 的 PR 评审。
 
-        panelWS = getPanelWebsocketClient();
+        // 全程用局部引用挂接线，不要边写静态字段边读它：下面注册的回调是异步触发的，
+        // 触发时静态 panelWS 可能已经不是这一个了。
+        UltiPanelWebSocketClient client = getPanelWebsocketClient();
+        panelWS = client;
 
         // 设置消息处理器
-        panelWS.setMessageHandler(PluginInitiationUtils::handleInboundMessage);
+        client.setMessageHandler(PluginInitiationUtils::handleInboundMessage);
 
         // 设置连接成功处理器
-        panelWS.setOnConnectHandler(() -> {
-            UltiTools.getInstance().getLogger().log(Level.FINE, UltiTools.getInstance().i18n("Websocket已连接!"));
-
-            // 握手真正成功了，这里才是「重连成功」这句话唯一站得住的位置。
-            // 外层预算也只在这里清零——若在 reinitWebSocket 里清，「造出了一个客户端」
-            // 就会被当成成功，预算永远用不完。见 issue #181 / #223。
-            onWebSocketConnected();
-            UltiTools.getInstance().getLogger().log(Level.INFO,
-                "WebSocket connected to UltiPanel");
-
-            // 订阅当前服务器
-            panelWS.subscribeToServer(panelWS.getServerId());
-            
-            // 初始化所有管理器
-            initializeManagers();
-            
-            // 上传配置
-            uploadConfig();
-
-            // 上传服务器属性到云端
-            uploadServerProperties();
-        });
+        client.setOnConnectHandler(() -> onWebSocketOpened(client));
 
         // 设置重连耗尽处理器 — 尝试刷新令牌并重新建立连接
-        panelWS.setOnReconnectExhaustedHandler(PluginInitiationUtils::reinitWebSocket);
+        client.setOnReconnectExhaustedHandler(PluginInitiationUtils::reinitWebSocket);
 
         // 连接到WebSocket服务器
-        panelWS.connect();
+        client.connect();
+    }
+
+    /**
+     * 握手成功之后的接线动作。
+     * <p>
+     * <b>参数就是这次握手自己的客户端，方法体内绝不重读静态 {@code panelWS}。</b>
+     * onOpen 是异步回调：跑到这里时 {@code disableCloud()} 可能已经把静态字段置空
+     * （{@code /ulticloud logout}，或重连预算耗尽——后者跑在 WebSocket 线程上），
+     * 也可能 {@code reinitWebSocket} 已经把它换成了另一个实例。重读静态字段的话，
+     * {@code subscribeToServer} / {@code uploadConfig} / {@code uploadServerProperties}
+     * 三处都会踩空——{@link #initializeManagers()} 有持锁复查护着，它前后的代码没有。
+     * <p>
+     * 往一个已断开的客户端发消息是安全的：{@code sendMessage} 在未连接时打一条 WARNING
+     * 就返回。真正危险的是空引用，所以这里解决的是引用稳定性，不是连接状态。
+     * <p>
+     * 包级可见而非 private —— 只为可测。要在测试里触发它，否则得有真实的鉴权 token
+     * 与真实的 WebSocket 握手；与 {@link #handleInboundMessage} 同一处理。
+     */
+    static void onWebSocketOpened(UltiPanelWebSocketClient client) {
+        UltiTools.getInstance().getLogger().log(Level.FINE, UltiTools.getInstance().i18n("Websocket已连接!"));
+
+        // 握手真正成功了，这里才是「重连成功」这句话唯一站得住的位置。
+        // 外层预算也只在这里清零——若在 reinitWebSocket 里清，「造出了一个客户端」
+        // 就会被当成成功，预算永远用不完。见 issue #181 / #223。
+        onWebSocketConnected();
+        UltiTools.getInstance().getLogger().log(Level.INFO,
+            "WebSocket connected to UltiPanel");
+
+        // 订阅当前服务器
+        client.subscribeToServer(client.getServerId());
+
+        // 初始化所有管理器
+        initializeManagers();
+
+        // 上传配置
+        uploadConfig(client);
+
+        // 上传服务器属性到云端
+        uploadServerProperties(client);
     }
     
     /**
@@ -937,7 +958,7 @@ public class PluginInitiationUtils {
     /**
      * 上传本地配置到服务器
      */
-    private static void uploadConfig() {
+    private static void uploadConfig(UltiPanelWebSocketClient client) {
         JsonObject configMessage = new JsonObject();
         configMessage.addProperty("type", "upload_config");
         
@@ -948,20 +969,20 @@ public class PluginInitiationUtils {
         data.addProperty("format", "yaml");                // 添加格式信息
         data.addProperty("backup", true);                  // 添加备份标志
         data.addProperty("comment", ConfigEditorUtils.getCommentMapString());
-        data.addProperty("serverId", panelWS.getServerId());
+        data.addProperty("serverId", client.getServerId());
         
         configMessage.add("data", data);
-        configMessage.addProperty("serverId", panelWS.getServerId());
+        configMessage.addProperty("serverId", client.getServerId());
         
         UltiTools.getInstance().getLogger().log(Level.FINE, UltiTools.getInstance().i18n("正在上传本地配置..."));
-        panelWS.sendMessage(configMessage);
+        client.sendMessage(configMessage);
         UltiTools.getInstance().getLogger().log(Level.FINE, UltiTools.getInstance().i18n("配置上传成功!"));
     }
 
     /**
      * Upload server.properties safe keys to cloud for panel editing.
      */
-    private static void uploadServerProperties() {
+    private static void uploadServerProperties(UltiPanelWebSocketClient client) {
         ServerPropertiesManager spm = UltiTools.getInstance().getServerPropertiesManager();
         if (spm == null) return;
 
@@ -975,12 +996,12 @@ public class PluginInitiationUtils {
 
         JsonObject message = new JsonObject();
         message.addProperty("type", "server_properties_result");
-        message.addProperty("serverId", panelWS.getServerId());
+        message.addProperty("serverId", client.getServerId());
 
         message.add("data", propsJson);
 
         UltiTools.getInstance().getLogger().log(Level.FINE, "正在上传服务器属性配置...");
-        panelWS.sendMessage(message);
+        client.sendMessage(message);
         UltiTools.getInstance().getLogger().log(Level.FINE, "服务器属性配置上传成功!");
     }
 

--- a/src/test/java/com/ultikits/ultitools/commands/CloudLogoutCommandTest.java
+++ b/src/test/java/com/ultikits/ultitools/commands/CloudLogoutCommandTest.java
@@ -1,0 +1,113 @@
+package com.ultikits.ultitools.commands;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.util.concurrent.TimeUnit;
+
+import org.bukkit.command.CommandSender;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.MockedStatic;
+
+import com.ultikits.ultitools.entities.TokenEntity;
+import com.ultikits.ultitools.utils.CloudAuthManager;
+import com.ultikits.ultitools.utils.PluginInitiationUtils;
+
+/**
+ * {@code /ulticloud logout} 的拆线语义。
+ *
+ * <p>核心命题只有一条：<b>凭证的有效性不能作为生命周期拆解的门禁。</b>
+ * access token 过期（例如主动刷新反复失败）之后，WebSocket、监控任务、日志 handler
+ * 与玩家监听器可能全都还在跑，而 logout 是操作员唯一的停止手段——那正是最需要它
+ * 生效的时刻，却恰恰是旧实现拒绝执行的时刻。
+ */
+@DisplayName("ulticloud logout 的拆线语义")
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+class CloudLogoutCommandTest {
+
+    /** 造一个已过期的 token：有 access_token，但 {@code hasValidToken()} 会判否。 */
+    private TokenEntity expiredToken() {
+        TokenEntity token = new TokenEntity();
+        token.setAccess_token("expired-access-token");
+        token.setRefresh_token("some-refresh-token");
+        // exp 落在过去 → isExpired() 为真
+        token.setExp((System.currentTimeMillis() / 1000) - 3600);
+        return token;
+    }
+
+    private TokenEntity validToken() {
+        TokenEntity token = new TokenEntity();
+        token.setAccess_token("good-access-token");
+        token.setRefresh_token("some-refresh-token");
+        token.setExp((System.currentTimeMillis() / 1000) + 3600);
+        return token;
+    }
+
+    @Nested
+    @DisplayName("凭证有效性不得阻断拆线")
+    class TeardownIsNotGatedByCredentials {
+
+        @Test
+        @DisplayName("access token 已过期时，logout 仍必须拆线并清凭证")
+        void expiredTokenStillTearsDown() throws Exception {
+            CommandSender sender = mock(CommandSender.class);
+
+            try (MockedStatic<CloudAuthManager> auth = mockStatic(CloudAuthManager.class);
+                 MockedStatic<PluginInitiationUtils> init = mockStatic(PluginInitiationUtils.class)) {
+
+                auth.when(CloudAuthManager::hasValidToken).thenReturn(false);
+                auth.when(CloudAuthManager::getCurrentToken).thenReturn(expiredToken());
+
+                new CloudLoginCommand().logout(sender);
+
+                // socket、监控任务、日志 handler、玩家监听器都只有这一条路能停下来
+                init.verify(PluginInitiationUtils::disableCloud, times(1));
+                auth.verify(CloudAuthManager::clearToken, times(1));
+            }
+        }
+
+        @Test
+        @DisplayName("token 有效时照常拆线")
+        void validTokenTearsDownAsBefore() throws Exception {
+            CommandSender sender = mock(CommandSender.class);
+
+            try (MockedStatic<CloudAuthManager> auth = mockStatic(CloudAuthManager.class);
+                 MockedStatic<PluginInitiationUtils> init = mockStatic(PluginInitiationUtils.class)) {
+
+                auth.when(CloudAuthManager::hasValidToken).thenReturn(true);
+                auth.when(CloudAuthManager::getCurrentToken).thenReturn(validToken());
+
+                new CloudLoginCommand().logout(sender);
+
+                init.verify(PluginInitiationUtils::disableCloud, times(1));
+                auth.verify(CloudAuthManager::clearToken, times(1));
+            }
+        }
+
+        @Test
+        @DisplayName("从未登录过时不必清凭证，但拆线仍是无害且必要的")
+        void neverLoggedInStillStopsAnythingLeftRunning() throws Exception {
+            CommandSender sender = mock(CommandSender.class);
+
+            try (MockedStatic<CloudAuthManager> auth = mockStatic(CloudAuthManager.class);
+                 MockedStatic<PluginInitiationUtils> init = mockStatic(PluginInitiationUtils.class)) {
+
+                auth.when(CloudAuthManager::hasValidToken).thenReturn(false);
+                auth.when(CloudAuthManager::getCurrentToken).thenReturn(null);
+
+                new CloudLoginCommand().logout(sender);
+
+                // disableCloud 的每一步都对「本来就没起来」幂等，所以照调不误：
+                // 判断「有没有东西在跑」比判断「凭证还在不在」可靠得多。
+                init.verify(PluginInitiationUtils::disableCloud, times(1));
+                // 没有凭证就没什么可清的，不必去碰磁盘
+                auth.verify(CloudAuthManager::clearToken, never());
+            }
+        }
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
@@ -22,6 +22,7 @@ import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.handler.SystemLogHandler;
 import com.ultikits.ultitools.manager.LogStreamManager;
 import com.ultikits.ultitools.manager.ServerMonitorManager;
+import com.ultikits.ultitools.websocket.UltiPanelWebSocketClient;
 
 /**
  * 云连接重连状态机的行为：全局预算、logout 的终止语义、以及成功日志的位置。
@@ -396,6 +397,31 @@ class CloudReconnectStateMachineTest {
             PluginInitiationUtils.initializeManagers();
 
             Mockito.verify(UltiTools.getInstance(), Mockito.atLeastOnce()).getServerMonitorManager();
+        }
+
+        @Test
+        @DisplayName("拆线之后到达的握手回调不得踩空静态 panelWS")
+        void lateHandshakeDoesNotDereferenceClearedClient() {
+            // onOpen 是异步的：跑到回调里时 disableCloud() 可能已经把静态 panelWS 置空
+            //（logout，或重连预算耗尽——后者跑在 WebSocket 线程上）。回调若重读静态字段，
+            // subscribeToServer / uploadConfig / uploadServerProperties 三处都会 NPE；
+            // 只有 initializeManagers 有持锁复查护着，它前后的代码没有。
+            UltiPanelWebSocketClient handshakeClient = mock(UltiPanelWebSocketClient.class);
+            lenient().when(handshakeClient.getServerId()).thenReturn("srv-1");
+
+            PluginInitiationUtils.disableCloud();   // 静态 panelWS 变 null
+
+            try {
+                PluginInitiationUtils.onWebSocketOpened(handshakeClient);
+            } catch (Exception ignored) {
+                // 本测试环境没有 ConfigManager 之类的下游依赖，走到 uploadConfig 会失败。
+                // 那与本用例无关——要钉住的是引用来源，不是这条链能否跑完。
+            }
+
+            // 关键断言：若回调重读静态 panelWS，第一处解引用
+            // （panelWS.subscribeToServer(panelWS.getServerId())）就已经 NPE，
+            // 根本走不到这里。能验到调用，就说明用的是回调自己那个引用。
+            Mockito.verify(handshakeClient).subscribeToServer("srv-1");
         }
 
         @Test


### PR DESCRIPTION
promote PR #287 上 Codex 第五轮复审的两条 P2。均核实属实，同属「拆线路径健壮性」，各一个 commit。

---

## 1. logout 不再被凭证有效性挡住（`d570c2e`）

`/ulticloud logout` 的第一行：

```java
if (!CloudAuthManager.hasValidToken()) {
    sender.sendMessage("Not currently logged in to UltiCloud.");
    return;
}
```

而 `hasValidToken()` 要求 `!currentToken.isExpired()`。

于是「access token 过期了但一切还在跑」——主动刷新反复失败之后的典型状态——恰恰是它拒绝执行的时刻。此时 socket、监控任务、root logger 上的日志 handler、玩家事件监听器与 token 刷新调度可能全都还活着，而 **logout 是操作员唯一的停止手段**。旧实现在这一刻只回一句「Not currently logged in」就退出，把人堵死在只能重启服务器。

**凭证的有效性不能作为生命周期拆解的门禁。** 改为看「有没有东西可清」：

- 拆线**无条件执行** —— `disableCloud()` 的每一步对「本来就没起来」都幂等（`isMonitoring` 为 false 直接返回、`panelWS` 为 null 直接返回、调度器字段为 null 时 no-op）
- 清凭证只在确实存着凭证时做，提示语相应区分

新增 `CloudLogoutCommandTest` 覆盖三种状态（token 过期 / token 有效 / 从未登录）。修复前第一、三条失败于 `Wanted but not invoked: disableCloud`。

---

## 2. 握手回调全程用自己的客户端引用（`91d9069`）

`onConnectHandler` 里四处动作，三处直接解引用静态 `panelWS`：

| 动作 | 是否受 `cloudLifecycleLock` 保护 |
|---|---|
| `panelWS.subscribeToServer(panelWS.getServerId())` | ❌ |
| `initializeManagers()` | ✅ 持锁复查 |
| `uploadConfig()` → `panelWS.sendMessage(...)` | ❌ |
| `uploadServerProperties()` → `panelWS.sendMessage(...)` | ❌ |

`onOpen` 是异步回调。跑到它时静态字段可能已被 `disableCloud()` 置空（logout，或重连预算耗尽——后者跑在 WebSocket 线程上），也可能被 `reinitWebSocket` 换成了另一个实例。于是一次迟到的握手会在 `initializeManagers` 的守卫**之外**抛出未捕获的 NPE。

把回调体提取为包级可见的 `onWebSocketOpened(client)`，参数即这次握手自己的客户端，方法体内绝不重读静态字段；`uploadConfig` / `uploadServerProperties` 相应改为接收该引用。`initWebsocket` 也改为先拿局部引用再赋静态字段，避免边写边读。

**这里解决的是引用稳定性，不是连接状态**：往一个已断开的客户端发消息本来就安全，`sendMessage` 在未连接时打一条 WARNING 就返回。危险的只有空引用——所以不需要为此把网络操作圈进锁里。

回归测试在 `disableCloud()` 之后直接调 `onWebSocketOpened`，断言 `subscribeToServer` 落在传入的那个客户端上：若回调重读静态 `panelWS`，第一处解引用就 NPE，根本走不到断言。

---

全量 **4328 tests, 0 failures**。