### PR TITLE
chore: 抑制 CloudLogoutCommandTest 的 PMD verify-only 假阳性

### DIFF
--- a/src/test/java/com/ultikits/ultitools/commands/CloudLogoutCommandTest.java
+++ b/src/test/java/com/ultikits/ultitools/commands/CloudLogoutCommandTest.java
@@ -28,6 +28,10 @@ import com.ultikits.ultitools.utils.PluginInitiationUtils;
  */
 @DisplayName("ulticloud logout 的拆线语义")
 @Timeout(value = 30, unit = TimeUnit.SECONDS)
+// 本类断言的是「拆线动作有没有被调用」，用的是 MockedStatic.verify 而不是 assert*；
+// PMD 只按 assert*/fail* 的方法名识别断言，认不出这种形式。与仓库其它 verify-only
+// 测试的处理一致。
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 class CloudLogoutCommandTest {
 
     /** 造一个已过期的 token：有 access_token，但 {@code hasValidToken()} 会判否。 */


### PR DESCRIPTION
## 背景

#295 合并后 Codacy 报 3 条新的 BestPractice medium，全部来自新增的 `CloudLogoutCommandTest`。

## 原因

三个测试断言的是「拆线动作有没有被调用」：

```java
init.verify(PluginInitiationUtils::disableCloud, times(1));
auth.verify(CloudAuthManager::clearToken, times(1));
```

PMD 的 `JUnitTestsShouldIncludeAssert` 只按 `assert*` / `fail*` 的方法名识别断言，认不出 `MockedStatic.verify` 这种形式。测试本身是有断言的。

## 处理

加类级 `@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")`，与仓库既有做法一致：

- `ServerMonitorSnapshotTest` — 类级注解（#289 加的）
- `PlayerEventManagerTest` — `// NOPMD - uses Mockito verify()` 行内注释

纯注解，无逻辑变更，测试全部通过。