### PR TITLE
fix: logout 之后到达的凭证结果不得把服务器登回去

### DIFF
--- a/src/main/java/com/ultikits/ultitools/commands/CloudLoginCommand.java
+++ b/src/main/java/com/ultikits/ultitools/commands/CloudLoginCommand.java
@@ -70,8 +70,6 @@ public class CloudLoginCommand extends AbstractCommandExecutor {
         // 凭证的有效性不能作为生命周期拆解的门禁。改为看「有没有东西可清」：
         // 拆线无条件执行（disableCloud 的每一步对「本来就没起来」都幂等），
         // 清凭证只在确实存着凭证时做。
-        TokenEntity existing = CloudAuthManager.getCurrentToken();
-
         try {
             // 先拆状态机，再清凭证。
             //
@@ -79,6 +77,13 @@ public class CloudLoginCommand extends AbstractCommandExecutor {
             // 用已作废的凭证敲面板，401 循环照跑，实测只有重新 login 或重启服务器才停得下来。
             // 「Cloud features are now disabled」这句话此前是不成立的。见 issue #223。
             PluginInitiationUtils.disableCloud();
+
+            // 凭证必须在拆线**之后**读。拆线之前读的话拿到的是一份可能过时的快照：
+            // 一次在途的 magic-link 轮询完全可以在这中间提交成功，于是「拆线前没有凭证」
+            // 的判断把我们送进不清凭证的分支，而 data.json 里已经躺着一份可用的 token，
+            // 重启即自动重连。disableCloud() 第一件事就是作废在途操作，因此拆线返回之后
+            // 读到的就是最终状态。
+            TokenEntity existing = CloudAuthManager.getCurrentToken();
 
             if (existing == null) {
                 sender.sendMessage(ChatColor.YELLOW + "Not currently logged in to UltiCloud.");

--- a/src/main/java/com/ultikits/ultitools/utils/CloudAuthManager.java
+++ b/src/main/java/com/ultikits/ultitools/utils/CloudAuthManager.java
@@ -200,6 +200,10 @@ public class CloudAuthManager {
      * Clear the saved token (logout).
      */
     public static synchronized void clearToken() throws IOException {
+        // 清凭证本身就意味着「此前的一切凭证操作作废」。再推一次代际是第二道关门：
+        // 拆线时推的那一次，与拆线中途才启动的生产者之间仍可能有缝，而这一次发生在
+        // 生产者全部停掉之后，任何仍在途的结果到这里都已过期。
+        credentialGeneration.incrementAndGet();
         currentToken = null;
         Map<String, Object> data = readDataFile();
         data.remove("cloud_token");
@@ -272,6 +276,11 @@ public class CloudAuthManager {
      * @return the magic link URL, or null on failure
      */
     public static String requestMagicLink(Consumer<String> errorCallback) {
+        // 代际必须在**这里**捕获，而不是等到 startPolling()。下面那次 POST 是阻塞的，
+        // logout 完全可以整个发生在它的往返期间；等 POST 回来才读代际的话，读到的是
+        // 已经递增过的那一代，这次登录于是"看起来是新的"，它后来拿到的 token 会被接受、
+        // activateCloudIfCurrent() 会把服务器重新连上——而这次 logout 从头到尾都没看见它。
+        final long generation = credentialGeneration.get();
         String apiUrl = HttpRequestUtils.getBaseUrl();
         if (apiUrl == null || apiUrl.trim().isEmpty()) {
             errorCallback.accept("API URL not configured");
@@ -309,7 +318,7 @@ public class CloudAuthManager {
                 String url = responseBody.has("url") ? responseBody.get("url").getAsString() : null;
                 if (url != null) {
                     // Store requestId for polling
-                    startPolling(requestId, null);
+                    startPolling(requestId, null, generation);
                     return url;
                 }
                 errorCallback.accept("Invalid response from API (missing url)");
@@ -331,13 +340,25 @@ public class CloudAuthManager {
      * @param onComplete called when auth succeeds (with the token), or null if no callback needed
      */
     public static void startPolling(String requestId, Consumer<TokenEntity> onComplete) {
+        startPolling(requestId, onComplete, credentialGeneration.get());
+    }
+
+    /**
+     * 带显式代际的轮询入口。
+     * <p>
+     * 代际由<b>发起整次登录的那一刻</b>决定，不能在这里就地读：调用方在到达这里之前
+     * 通常已经做过一次阻塞的 HTTP 请求，那段时间里发生的 logout 必须对这次登录可见。
+     *
+     * @param requestId magic-link 请求 ID
+     * @param onComplete 登录完成回调，可为 null
+     * @param generation 发起这次登录时的凭证代际
+     */
+    public static void startPolling(String requestId, Consumer<TokenEntity> onComplete,
+                                    final long generation) {
         stopPolling();
 
         pollExecutor = Executors.newSingleThreadScheduledExecutor();
         final int[] attempts = {0};
-        // 本次 magic-link 登录所属的代际。logout 推进代际之后，这一轮的结果一律作废——
-        // stopPolling() 的 cancel(false) 拦不住一个已经进了 HTTP 请求的轮询周期。
-        final long generation = credentialGeneration.get();
 
         pollTask = pollExecutor.scheduleWithFixedDelay(() -> {
             attempts[0]++;

--- a/src/main/java/com/ultikits/ultitools/utils/CloudAuthManager.java
+++ b/src/main/java/com/ultikits/ultitools/utils/CloudAuthManager.java
@@ -367,76 +367,91 @@ public class CloudAuthManager {
                 stopPolling();
                 return;
             }
-
-            try {
-                String apiUrl = HttpRequestUtils.getBaseUrl().trim();
-                Map<String, String> headers = new HashMap<>();
-                headers.put("Content-Type", "application/json");
-
-                SimpleHttpClient.Response response = SimpleHttpClient.get(
-                    apiUrl + "/auth/server-login/status?requestId=" + requestId,
-                    headers
-                );
-
-                if (response.isOk()) {
-                    JsonObject responseBody = JsonParser.parseString(response.body()).getAsJsonObject();
-                    String status = responseBody.has("status") ? responseBody.get("status").getAsString() : "pending";
-
-                    if ("completed".equals(status)) {
-                        // Extract token from response
-                        String tokenJson = responseBody.has("token") ? GSON.toJson(responseBody.getAsJsonObject("token")) : null;
-                        if (tokenJson != null) {
-                            TokenEntity token = GSON.fromJson(tokenJson, TokenEntity.class);
-                            if (token != null && token.getAccess_token() != null) {
-                                token.decodeJwtPayload();
-                                // logout 可能发生在「本次轮询发出」与「本次轮询拿到 completed」之间。
-                                // 直接往下走的话，下面的 enableCloud() + initWebsocket() 会把服务器
-                                // 悄悄登回去——而 logout 刚刚才报告过云功能已停止。
-                                if (!commitTokenIfCurrent(token, generation)) {
-                                    stopPolling();
-                                    return;
-                                }
-
-                                UltiTools.getInstance().getLogger().log(Level.INFO,
-                                    "UltiCloud login successful! Welcome, " +
-                                    (token.getUser_name() != null ? token.getUser_name() : "user") + "!");
-
-                                // Reset rate limiter on successful login
-                                ApiRateLimiter.reset("login");
-
-                                if (onComplete != null) {
-                                    onComplete.accept(token);
-                                }
-
-                                // Try to initialize cloud features
-                                try {
-                                    // 锁外：一次 HTTP 往返，只向面板注册服务器，不改本地状态。
-                                    PluginInitiationUtils.loginWithToken(token);
-                                    // 锁内：复查代际之后再开状态机、建连、起刷新调度。
-                                    // 提交凭证那一步对 logout 原子还不够——真正把服务器连回去的
-                                    // 是这一串，logout 挤在两者之间的话照样会被撤销。
-                                    if (!PluginInitiationUtils.activateCloudIfCurrent(generation)) {
-                                        stopPolling();
-                                        return;
-                                    }
-                                } catch (Exception e) {
-                                    UltiTools.getInstance().getLogger().log(Level.WARNING,
-                                        "Cloud features initialization failed: " + e.getMessage());
-                                }
-                            }
-                        }
-                        stopPolling();
-                    } else if ("expired".equals(status) || "error".equals(status)) {
-                        String error = responseBody.has("message") ? responseBody.get("message").getAsString() : "Unknown error";
-                        UltiTools.getInstance().getLogger().log(Level.WARNING, "Magic link login failed: " + error);
-                        stopPolling();
-                    }
-                    // "pending" — keep polling
-                }
-            } catch (Exception e) {
-                UltiTools.getInstance().getLogger().log(Level.FINE, "Magic link poll failed: " + e.getMessage());
-            }
+            pollLoginStatusOnce(requestId, onComplete, generation);
         }, POLL_INTERVAL_MS, POLL_INTERVAL_MS, TimeUnit.MILLISECONDS);
+    }
+
+    /** 查一次登录状态。任何异常都只记 FINE——轮询要继续，直到超时或拿到终态。 */
+    private static void pollLoginStatusOnce(String requestId, Consumer<TokenEntity> onComplete,
+                                            long generation) {
+        try {
+            String apiUrl = HttpRequestUtils.getBaseUrl().trim();
+            Map<String, String> headers = new HashMap<>();
+            headers.put("Content-Type", "application/json");
+
+            SimpleHttpClient.Response response = SimpleHttpClient.get(
+                apiUrl + "/auth/server-login/status?requestId=" + requestId,
+                headers
+            );
+            if (!response.isOk()) {
+                return;
+            }
+
+            JsonObject responseBody = JsonParser.parseString(response.body()).getAsJsonObject();
+            String status = responseBody.has("status") ? responseBody.get("status").getAsString() : "pending";
+
+            if ("completed".equals(status)) {
+                completeMagicLinkLogin(responseBody, onComplete, generation);
+                stopPolling();
+            } else if ("expired".equals(status) || "error".equals(status)) {
+                String error = responseBody.has("message") ? responseBody.get("message").getAsString() : "Unknown error";
+                UltiTools.getInstance().getLogger().log(Level.WARNING, "Magic link login failed: " + error);
+                stopPolling();
+            }
+            // "pending" — keep polling
+        } catch (Exception e) {
+            UltiTools.getInstance().getLogger().log(Level.FINE, "Magic link poll failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 处理一次拿到 {@code completed} 的登录：落凭证、再激活云功能。
+     * <p>
+     * 两步都要对 logout 设防，而且是两道不同的闸：
+     * {@link #commitTokenIfCurrent(TokenEntity, long)} 保证凭证不会在 logout 之后被写回；
+     * {@code activateCloudIfCurrent} 保证连接不会在 logout 之后被重新建起来。只有前者是
+     * 不够的——真正把服务器连回去的是后面那一串。
+     *
+     * @throws IOException 凭证落盘失败
+     */
+    private static void completeMagicLinkLogin(JsonObject responseBody,
+                                               Consumer<TokenEntity> onComplete,
+                                               long generation) throws IOException {
+        String tokenJson = responseBody.has("token") ? GSON.toJson(responseBody.getAsJsonObject("token")) : null;
+        if (tokenJson == null) {
+            return;
+        }
+        TokenEntity token = GSON.fromJson(tokenJson, TokenEntity.class);
+        if (token == null || token.getAccess_token() == null) {
+            return;
+        }
+        token.decodeJwtPayload();
+
+        // logout 可能发生在「本次登录发起」与「本次轮询拿到 completed」之间。
+        if (!commitTokenIfCurrent(token, generation)) {
+            return;
+        }
+
+        UltiTools.getInstance().getLogger().log(Level.INFO,
+            "UltiCloud login successful! Welcome, "
+                + (token.getUser_name() != null ? token.getUser_name() : "user") + "!");
+
+        // Reset rate limiter on successful login
+        ApiRateLimiter.reset("login");
+
+        if (onComplete != null) {
+            onComplete.accept(token);
+        }
+
+        try {
+            // 锁外：一次 HTTP 往返，只向面板注册服务器，不改本地状态。
+            PluginInitiationUtils.loginWithToken(token);
+            // 锁内：复查代际之后再开状态机、建连、起刷新调度。
+            PluginInitiationUtils.activateCloudIfCurrent(generation);
+        } catch (Exception e) {
+            UltiTools.getInstance().getLogger().log(Level.WARNING,
+                "Cloud features initialization failed: " + e.getMessage());
+        }
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/utils/CloudAuthManager.java
+++ b/src/main/java/com/ultikits/ultitools/utils/CloudAuthManager.java
@@ -50,6 +50,29 @@ public class CloudAuthManager {
     private static ScheduledFuture<?> refreshTask;
 
     /**
+     * 凭证的生命周期代际。
+     * <p>
+     * 存在的理由只有一句：<b>取消不等于失效。</b>{@link #stopTokenRefreshScheduler()} 与
+     * {@link #stopPolling()} 用的是 {@code cancel(false)} 加 {@code shutdown()}，两者都只
+     * 承诺不再调度新的执行，对一个已经进入 HTTP 请求的任务毫无约束——而
+     * {@link #refreshToken(String)} 在返回<b>之前</b>就 {@link #saveToken(TokenEntity)} 写盘。
+     * 于是这样的时序完全成立：
+     * <pre>
+     *   1. 刷新任务发出 HTTP 请求（网络往返，秒级）
+     *   2. 管理员 /ulticloud logout → 停调度器 → clearToken() 清掉 data.json
+     *   3. HTTP 返回 → saveToken() 把新凭证写回 data.json
+     *   4. 重启服务器 → 读到有效凭证 → 自动登录
+     * </pre>
+     * logout 于是成了一条没有效果的命令，而它恰恰是安全语义的。
+     * <p>
+     * 规则：一切在途的异步凭证操作出发时记下当时的代际，提交结果之前用
+     * {@link #commitTokenIfCurrent(TokenEntity, long)} 比对；拆线路径调
+     * {@link #invalidateCredentialOperations()} 推进代际，迟到的结果一律作废。
+     */
+    private static final java.util.concurrent.atomic.AtomicLong credentialGeneration =
+            new java.util.concurrent.atomic.AtomicLong();
+
+    /**
      * Try to load a saved token from data.json on startup.
      * If the access token is expired but a refresh token exists, attempts automatic refresh.
      * Returns the token if valid, null otherwise.
@@ -108,6 +131,8 @@ public class CloudAuthManager {
      * @return a new TokenEntity with fresh access and refresh tokens, or null on failure
      */
     public static TokenEntity refreshToken(String refreshTokenValue) {
+        // 出发时记下代际。整个 HTTP 往返期间 logout 都可能发生，而下面的提交必须能看见。
+        final long generation = credentialGeneration.get();
         String apiUrl = HttpRequestUtils.getBaseUrl();
         if (apiUrl == null || apiUrl.trim().isEmpty()) {
             UltiTools.getInstance().getLogger().log(Level.WARNING, "Cannot refresh token: API URL not configured");
@@ -133,7 +158,11 @@ public class CloudAuthManager {
                 TokenEntity newToken = GSON.fromJson(response.body(), TokenEntity.class);
                 if (newToken != null && newToken.getAccess_token() != null) {
                     newToken.decodeJwtPayload();
-                    saveToken(newToken);
+                    // 不能直接 saveToken：这次请求可能是在 logout 之前发出、logout 之后才回来的。
+                    // 直接写盘会把刚被 clearToken() 清掉的凭证原样填回 data.json，重启后自动重连。
+                    if (!commitTokenIfCurrent(newToken, generation)) {
+                        return null;
+                    }
                     return newToken;
                 }
                 UltiTools.getInstance().getLogger().log(Level.WARNING, "Token refresh returned invalid token data");
@@ -170,11 +199,53 @@ public class CloudAuthManager {
     /**
      * Clear the saved token (logout).
      */
-    public static void clearToken() throws IOException {
+    public static synchronized void clearToken() throws IOException {
         currentToken = null;
         Map<String, Object> data = readDataFile();
         data.remove("cloud_token");
         writeDataFile(data);
+    }
+
+    /**
+     * 取当前的凭证代际。异步凭证操作在<b>出发时</b>调它记下自己那一代。
+     *
+     * @return 当前代际
+     */
+    public static long currentCredentialGeneration() {
+        return credentialGeneration.get();
+    }
+
+    /**
+     * 让一切在途的凭证操作作废。
+     * <p>
+     * 拆线路径（{@code disableCloud()} / {@code /ulticloud logout}）必须调它。只停调度器
+     * 是不够的——见 {@link #credentialGeneration} 上的说明。
+     */
+    public static synchronized void invalidateCredentialOperations() {
+        credentialGeneration.incrementAndGet();
+    }
+
+    /**
+     * 仅当代际未变时才提交凭证。
+     * <p>
+     * 与 {@link #invalidateCredentialOperations()} 和 {@link #clearToken()} 同步在类锁上，
+     * 因此「比对代际」与「写入」之间不存在窗口：拆线要么整个发生在提交之前（这次提交被
+     * 拒），要么整个发生在提交之后（拆线把刚写的清掉）。两种都是干净的。
+     *
+     * @param token 待提交的凭证
+     * @param generation 调用方出发时记下的代际
+     * @return 已提交返回 true；代际已变、结果被丢弃则返回 false
+     * @throws IOException 写入失败
+     */
+    public static synchronized boolean commitTokenIfCurrent(TokenEntity token, long generation)
+            throws IOException {
+        if (generation != credentialGeneration.get()) {
+            UltiTools.getInstance().getLogger().log(Level.FINE,
+                "Discarding a credential result that arrived after logout (generation changed)");
+            return false;
+        }
+        saveToken(token);
+        return true;
     }
 
     /**
@@ -264,6 +335,9 @@ public class CloudAuthManager {
 
         pollExecutor = Executors.newSingleThreadScheduledExecutor();
         final int[] attempts = {0};
+        // 本次 magic-link 登录所属的代际。logout 推进代际之后，这一轮的结果一律作废——
+        // stopPolling() 的 cancel(false) 拦不住一个已经进了 HTTP 请求的轮询周期。
+        final long generation = credentialGeneration.get();
 
         pollTask = pollExecutor.scheduleWithFixedDelay(() -> {
             attempts[0]++;
@@ -294,7 +368,13 @@ public class CloudAuthManager {
                             TokenEntity token = GSON.fromJson(tokenJson, TokenEntity.class);
                             if (token != null && token.getAccess_token() != null) {
                                 token.decodeJwtPayload();
-                                saveToken(token);
+                                // logout 可能发生在「本次轮询发出」与「本次轮询拿到 completed」之间。
+                                // 直接往下走的话，下面的 enableCloud() + initWebsocket() 会把服务器
+                                // 悄悄登回去——而 logout 刚刚才报告过云功能已停止。
+                                if (!commitTokenIfCurrent(token, generation)) {
+                                    stopPolling();
+                                    return;
+                                }
 
                                 UltiTools.getInstance().getLogger().log(Level.INFO,
                                     "UltiCloud login successful! Welcome, " +

--- a/src/main/java/com/ultikits/ultitools/utils/CloudAuthManager.java
+++ b/src/main/java/com/ultikits/ultitools/utils/CloudAuthManager.java
@@ -389,11 +389,15 @@ public class CloudAuthManager {
 
                                 // Try to initialize cloud features
                                 try {
+                                    // 锁外：一次 HTTP 往返，只向面板注册服务器，不改本地状态。
                                     PluginInitiationUtils.loginWithToken(token);
-                                    // 显式开启：logout 之后重新 login 必须能把状态机拉回来。
-                                    PluginInitiationUtils.enableCloud();
-                                    PluginInitiationUtils.initWebsocket();
-                                    startTokenRefreshScheduler();
+                                    // 锁内：复查代际之后再开状态机、建连、起刷新调度。
+                                    // 提交凭证那一步对 logout 原子还不够——真正把服务器连回去的
+                                    // 是这一串，logout 挤在两者之间的话照样会被撤销。
+                                    if (!PluginInitiationUtils.activateCloudIfCurrent(generation)) {
+                                        stopPolling();
+                                        return;
+                                    }
                                 } catch (Exception e) {
                                     UltiTools.getInstance().getLogger().log(Level.WARNING,
                                         "Cloud features initialization failed: " + e.getMessage());

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
@@ -1127,20 +1127,35 @@ public class PluginInitiationUtils {
 
     /** {@link #disableCloud()} 的实际拆线动作。调用方必须持有 {@link #cloudLifecycleLock}。 */
     private static void doDisableCloud() {
-        // 第一件事就让在途的凭证操作作废，而不是等拆线跑完。
+        // 前三步的顺序是这条方法里最容易写反的地方，写反了两个方向都会漏：
         //
-        // 拆线本身要关日志流、停监控、摘监听器、断 socket、停调度器，是个不短的过程；
-        // 把作废放在末尾的话，这段时间里一次在途的 magic-link 轮询完全可以先提交成功，
-        // 而后来的作废并不会删掉已经写进 data.json 的那份凭证。调用方（logout 命令）
-        // 也就跟着看到一份「拆线之前不存在、拆线之后存在」的凭证。
+        //   1. 关闸——cloudEnabled 置否，reinit 链不再产生新的刷新。
+        //   2. 停生产者——停掉刷新调度与 magic-link 轮询，不再有新任务被派出去。
+        //   3. 作废在途——推进凭证代际，让已经在 HTTP 请求里的那些结果一律过期。
         //
-        // 放在最前面之后，整个拆线期间任何提交都会被拒；调用方只要在拆线**之后**读一次
-        // 凭证，看到的就是最终状态。
-        teardownStep("invalidating in-flight credential operations",
-            CloudAuthManager::invalidateCredentialOperations);
-
+        // 作废**必须**排在停生产者之后。反过来（先作废再停）的话，两者之间启动的新任务
+        // 会快照到已经递增的那一代，于是它反而「合法」了，延迟返回的响应照样把凭证写回
+        // data.json——这正是把作废提到最前面时踩到的坑。
+        //
+        // 而作废也不能等到整个拆线跑完：拆线还要关日志流、停监控、摘监听器、断 socket，
+        // 是个不短的过程，这段时间里一次在途的轮询完全可以先提交成功，调用方（logout
+        // 命令）就会看到一份「拆线之前不存在、拆线之后存在」的凭证。
+        //
+        // 最后一道保险在 clearToken() 里：它自己也推进一次代际，那一次发生在生产者全部
+        // 停掉之后，任何仍在途的结果到那里都已过期。
         cloudEnabled.set(false);
         reinitBackoff.reset();
+
+        teardownStep("stopping token refresh scheduler",
+            CloudAuthManager::stopTokenRefreshScheduler);
+
+        // 停掉还没走完的 magic-link 轮询。不停的话，一次「login 之后马上改主意 logout」
+        // 会在轮询下一周期拿到 completed 时把服务器悄悄登回去——那条分支自己会
+        // enableCloud() 加 initWebsocket()。
+        teardownStep("stopping magic-link polling", CloudAuthManager::stopPolling);
+
+        teardownStep("invalidating in-flight credential operations",
+            CloudAuthManager::invalidateCredentialOperations);
 
         // 顺序有讲究：先关日志传输器，再断开 socket。
         // 反过来的话，传输器 flush 时 socket 已经断了，sendBatch() 会一条都发不出去。
@@ -1173,14 +1188,6 @@ public class PluginInitiationUtils {
         // 清掉本类持有的 token。它与 CloudAuthManager 清掉的凭证是**两份**，
         // 不清的话，一个正在途中的 reinit 仍然握着可用的 refresh token。
         token = null;
-
-        teardownStep("stopping token refresh scheduler",
-            CloudAuthManager::stopTokenRefreshScheduler);
-
-        // 停掉还没走完的 magic-link 轮询。不停的话，一次「login 之后马上改主意 logout」
-        // 会在轮询下一周期拿到 completed 时把服务器悄悄登回去——那条分支自己会
-        // enableCloud() 加 initWebsocket()。
-        teardownStep("stopping magic-link polling", CloudAuthManager::stopPolling);
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
@@ -1136,12 +1136,8 @@ public class PluginInitiationUtils {
         //
         // 放在最前面之后，整个拆线期间任何提交都会被拒；调用方只要在拆线**之后**读一次
         // 凭证，看到的就是最终状态。
-        try {
-            CloudAuthManager.invalidateCredentialOperations();
-        } catch (Exception e) {
-            UltiTools.getInstance().getLogger().log(Level.FINE,
-                "Error invalidating in-flight credential operations: " + e.getMessage());
-        }
+        teardownStep("invalidating in-flight credential operations",
+            CloudAuthManager::invalidateCredentialOperations);
 
         cloudEnabled.set(false);
         reinitBackoff.reset();
@@ -1150,36 +1146,26 @@ public class PluginInitiationUtils {
         // 反过来的话，传输器 flush 时 socket 已经断了，sendBatch() 会一条都发不出去。
         // （flushLogs 本身也已改成有界，两层都要有——顺序对了是让排队的日志还有机会送出去，
         //  有界是为了 socket 本来就断着的情况。）
-        try {
-            UltiTools.getInstance().getLogStreamManager().shutdown();
-        } catch (Exception e) {
-            UltiTools.getInstance().getLogger().log(Level.FINE,
-                "Error shutting down log stream manager: " + e.getMessage());
-        }
+        teardownStep("shutting down log stream manager",
+            () -> UltiTools.getInstance().getLogStreamManager().shutdown());
 
         // 停掉服务器监控。它自带一个 ScheduledExecutorService（每 5 秒 batch_update）
         // 外加两个主线程 Bukkit 定时任务（1Hz 的 TPS/CPU、5 秒一次的世界/玩家/插件快照）。
         // 在此之前 stopMonitoring() 在整个 src/main 里没有任何调用方：写好了、测过了，
         // 就是没接线。不停的话，「云功能已关闭」之后主线程仍在按 5 秒遍历所有世界和区块。
-        try {
+        teardownStep("stopping server monitor", () -> {
             if (UltiTools.getInstance().getServerMonitorManager() != null) {
                 UltiTools.getInstance().getServerMonitorManager().stopMonitoring();
             }
-        } catch (Exception e) {
-            UltiTools.getInstance().getLogger().log(Level.FINE,
-                "Error stopping server monitor: " + e.getMessage());
-        }
+        });
 
         // 摘掉玩家事件监听器。云关掉之后再收玩家事件是纯浪费——事件处理器里那句
         // isConnected() 判断只是让它不发消息，监听本身还在跑。见 issue #180。
-        try {
+        teardownStep("shutting down player event manager", () -> {
             if (UltiTools.getInstance().getPlayerEventManager() != null) {
                 UltiTools.getInstance().getPlayerEventManager().shutdown();
             }
-        } catch (Exception e) {
-            UltiTools.getInstance().getLogger().log(Level.FINE,
-                "Error shutting down player event manager: " + e.getMessage());
-        }
+        });
 
         stopWebsocket();
         panelWS = null;
@@ -1188,21 +1174,31 @@ public class PluginInitiationUtils {
         // 不清的话，一个正在途中的 reinit 仍然握着可用的 refresh token。
         token = null;
 
-        try {
-            CloudAuthManager.stopTokenRefreshScheduler();
-        } catch (Exception e) {
-            UltiTools.getInstance().getLogger().log(Level.FINE,
-                "Error stopping token refresh scheduler: " + e.getMessage());
-        }
+        teardownStep("stopping token refresh scheduler",
+            CloudAuthManager::stopTokenRefreshScheduler);
 
         // 停掉还没走完的 magic-link 轮询。不停的话，一次「login 之后马上改主意 logout」
         // 会在轮询下一周期拿到 completed 时把服务器悄悄登回去——那条分支自己会
         // enableCloud() 加 initWebsocket()。
+        teardownStep("stopping magic-link polling", CloudAuthManager::stopPolling);
+    }
+
+    /**
+     * 跑一步拆线动作，失败只记 FINE 不向外抛。
+     * <p>
+     * 拆线的每一步都必须尽力执行完：任何一步抛出去都会让它后面的步骤被跳过，而那些
+     * 步骤正是「云功能已关闭」这句话的组成部分。原先这是六段一模一样的 try/catch，
+     * 提取出来只是把那个不变量说清楚一次，行为不变。
+     *
+     * @param what 失败时写进日志的动作描述
+     * @param action 拆线动作
+     */
+    private static void teardownStep(String what, Runnable action) {
         try {
-            CloudAuthManager.stopPolling();
+            action.run();
         } catch (Exception e) {
             UltiTools.getInstance().getLogger().log(Level.FINE,
-                "Error stopping magic-link polling: " + e.getMessage());
+                "Error " + what + ": " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
@@ -1127,6 +1127,22 @@ public class PluginInitiationUtils {
 
     /** {@link #disableCloud()} 的实际拆线动作。调用方必须持有 {@link #cloudLifecycleLock}。 */
     private static void doDisableCloud() {
+        // 第一件事就让在途的凭证操作作废，而不是等拆线跑完。
+        //
+        // 拆线本身要关日志流、停监控、摘监听器、断 socket、停调度器，是个不短的过程；
+        // 把作废放在末尾的话，这段时间里一次在途的 magic-link 轮询完全可以先提交成功，
+        // 而后来的作废并不会删掉已经写进 data.json 的那份凭证。调用方（logout 命令）
+        // 也就跟着看到一份「拆线之前不存在、拆线之后存在」的凭证。
+        //
+        // 放在最前面之后，整个拆线期间任何提交都会被拒；调用方只要在拆线**之后**读一次
+        // 凭证，看到的就是最终状态。
+        try {
+            CloudAuthManager.invalidateCredentialOperations();
+        } catch (Exception e) {
+            UltiTools.getInstance().getLogger().log(Level.FINE,
+                "Error invalidating in-flight credential operations: " + e.getMessage());
+        }
+
         cloudEnabled.set(false);
         reinitBackoff.reset();
 
@@ -1188,17 +1204,6 @@ public class PluginInitiationUtils {
             UltiTools.getInstance().getLogger().log(Level.FINE,
                 "Error stopping magic-link polling: " + e.getMessage());
         }
-
-        // 最后推进凭证代际，让一切**已经在途**的凭证操作作废。
-        // 上面那些 stop* 用的都是 cancel(false)，只承诺不再调度新的执行，拦不住一个已经
-        // 进了 HTTP 请求的任务；而刷新与轮询都会在返回前写 currentToken 与 data.json。
-        // 没有这一步，logout 会被一个迟到几秒的刷新原地撤销，重启后自动重连。
-        try {
-            CloudAuthManager.invalidateCredentialOperations();
-        } catch (Exception e) {
-            UltiTools.getInstance().getLogger().log(Level.FINE,
-                "Error invalidating in-flight credential operations: " + e.getMessage());
-        }
     }
 
     /**
@@ -1209,6 +1214,41 @@ public class PluginInitiationUtils {
      */
     static void onWebSocketConnected() {
         reinitBackoff.reset();
+    }
+
+    /**
+     * 在云生命周期锁内，原子地「复查代际 → 开启状态机 → 建连 → 起刷新调度」。
+     * <p>
+     * 只让写凭证那一步对 logout 原子是不够的：magic-link 轮询在提交凭证之后还要做
+     * {@code enableCloud()} + {@code initWebsocket()} + {@code startTokenRefreshScheduler()}，
+     * 这一串才是真正把服务器连回去的动作。logout 挤在「提交成功」与「开始激活」之间的话，
+     * 拆线拆的是一个还没建起来的连接，随后轮询线程照样把它建起来——logout 于是被撤销。
+     * <p>
+     * 这里与 {@code disableCloud()} 抢同一把 {@link #cloudLifecycleLock}，因此二者只能整体
+     * 先后发生：要么先激活再被拆掉（干净），要么先拆线、本方法持锁复查代际时看到已变而
+     * 直接返回 false（也干净）。
+     * <p>
+     * 锁内刻意<b>不</b>做 {@code loginWithToken()} —— 那是一次 HTTP 往返，持锁做会让
+     * {@code /ulticloud logout} 在主线程上阻塞数秒。它只向面板注册服务器，不改本地状态，
+     * 放在锁外重复执行也无害。
+     *
+     * @param generation 调用方出发时记下的凭证代际
+     * @return 已激活返回 true；代际已变、激活被放弃则返回 false
+     * @throws IOException 建连失败
+     */
+    public static boolean activateCloudIfCurrent(long generation) throws IOException {
+        synchronized (cloudLifecycleLock) {
+            if (generation != CloudAuthManager.currentCredentialGeneration()) {
+                UltiTools.getInstance().getLogger().log(Level.INFO,
+                    "Cloud activation aborted — a logout happened while this login was completing");
+                return false;
+            }
+            // 显式开启：logout 之后重新 login 必须能把状态机拉回来。
+            enableCloud();
+            initWebsocket();
+            CloudAuthManager.startTokenRefreshScheduler();
+            return true;
+        }
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/PluginInitiationUtils.java
@@ -1178,6 +1178,27 @@ public class PluginInitiationUtils {
             UltiTools.getInstance().getLogger().log(Level.FINE,
                 "Error stopping token refresh scheduler: " + e.getMessage());
         }
+
+        // 停掉还没走完的 magic-link 轮询。不停的话，一次「login 之后马上改主意 logout」
+        // 会在轮询下一周期拿到 completed 时把服务器悄悄登回去——那条分支自己会
+        // enableCloud() 加 initWebsocket()。
+        try {
+            CloudAuthManager.stopPolling();
+        } catch (Exception e) {
+            UltiTools.getInstance().getLogger().log(Level.FINE,
+                "Error stopping magic-link polling: " + e.getMessage());
+        }
+
+        // 最后推进凭证代际，让一切**已经在途**的凭证操作作废。
+        // 上面那些 stop* 用的都是 cancel(false)，只承诺不再调度新的执行，拦不住一个已经
+        // 进了 HTTP 请求的任务；而刷新与轮询都会在返回前写 currentToken 与 data.json。
+        // 没有这一步，logout 会被一个迟到几秒的刷新原地撤销，重启后自动重连。
+        try {
+            CloudAuthManager.invalidateCredentialOperations();
+        } catch (Exception e) {
+            UltiTools.getInstance().getLogger().log(Level.FINE,
+                "Error invalidating in-flight credential operations: " + e.getMessage());
+        }
     }
 
     /**

--- a/src/test/java/com/ultikits/ultitools/commands/CloudLogoutCommandTest.java
+++ b/src/test/java/com/ultikits/ultitools/commands/CloudLogoutCommandTest.java
@@ -94,6 +94,34 @@ class CloudLogoutCommandTest {
         }
 
         @Test
+        @DisplayName("凭证必须在拆线之后读：在途登录刚提交的 token 也要被清掉")
+        void tokenCommittedDuringTeardownIsStillCleared() throws Exception {
+            CommandSender sender = mock(CommandSender.class);
+
+            try (MockedStatic<CloudAuthManager> auth = mockStatic(CloudAuthManager.class);
+                 MockedStatic<PluginInitiationUtils> init = mockStatic(PluginInitiationUtils.class)) {
+
+                auth.when(CloudAuthManager::hasValidToken).thenReturn(false);
+
+                // 拆线之前没有凭证；拆线期间一次在途的 magic-link 轮询提交成功了。
+                // 若命令沿用拆线前的快照，就会走「未登录」分支而不清凭证，
+                // 于是 data.json 里留着一份可用 token，重启即自动重连。
+                java.util.concurrent.atomic.AtomicBoolean tornDown =
+                        new java.util.concurrent.atomic.AtomicBoolean(false);
+                init.when(PluginInitiationUtils::disableCloud).thenAnswer(invocation -> {
+                    tornDown.set(true);
+                    return null;
+                });
+                auth.when(CloudAuthManager::getCurrentToken)
+                        .thenAnswer(invocation -> tornDown.get() ? validToken() : null);
+
+                new CloudLoginCommand().logout(sender);
+
+                auth.verify(CloudAuthManager::clearToken, times(1));
+            }
+        }
+
+        @Test
         @DisplayName("从未登录过时不必清凭证，但拆线仍是无害且必要的")
         void neverLoggedInStillStopsAnythingLeftRunning() throws Exception {
             CommandSender sender = mock(CommandSender.class);

--- a/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
@@ -190,6 +190,21 @@ class CloudReconnectStateMachineTest {
         }
 
         @Test
+        @DisplayName("disableCloud 会让在途的凭证操作作废")
+        void disableCloudInvalidatesInFlightCredentialOperations() {
+            // 只停调度器是不够的：stop* 用的都是 cancel(false)，拦不住一个已经进了 HTTP
+            // 请求的刷新或轮询，而两者都会在返回前写 currentToken 与 data.json。
+            // 没有这一步，logout 会被一个迟到几秒的刷新原地撤销。
+            long before = CloudAuthManager.currentCredentialGeneration();
+
+            PluginInitiationUtils.disableCloud();
+
+            assertThat(CloudAuthManager.currentCredentialGeneration())
+                    .as("拆线必须推进凭证代际，否则迟到的结果仍会被提交")
+                    .isGreaterThan(before);
+        }
+
+        @Test
         @DisplayName("disableCloud 会停掉服务器监控")
         void disableCloudStopsServerMonitor() {
             // ServerMonitorManager 自带一个 ScheduledExecutorService 加两个主线程 Bukkit

--- a/src/test/java/com/ultikits/ultitools/utils/CredentialGenerationTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/CredentialGenerationTest.java
@@ -1,0 +1,128 @@
+package com.ultikits.ultitools.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.ultikits.ultitools.UltiTools;
+import com.ultikits.ultitools.entities.TokenEntity;
+
+/**
+ * 凭证代际：让在途的异步凭证操作在 logout 之后无法把凭证写回来。
+ *
+ * <p>问题的根子是「取消 ≠ 失效」。{@code stopTokenRefreshScheduler()} 用的是
+ * {@code cancel(false)} 加 {@code shutdown()}，两者都只承诺不再调度新的执行，对一个
+ * 已经进入 HTTP 请求的刷新任务毫无约束；而 {@code refreshToken()} 在返回**之前**就
+ * {@code saveToken()} 写盘。于是这样的时序完全成立：
+ *
+ * <pre>
+ *   1. 刷新任务发出 HTTP 请求（网络往返，秒级）
+ *   2. 管理员 /ulticloud logout → 停调度器 → clearToken() 清掉 data.json
+ *   3. HTTP 返回 → saveToken() 把新凭证写回 data.json
+ *   4. 重启服务器 → 读到有效凭证 → 自动登录
+ * </pre>
+ *
+ * <p>结果是 logout 这条命令没有效果，而它恰恰是一条安全语义的命令。magic-link
+ * 轮询有完全相同的形状，而且更彻底——它还会 {@code enableCloud()} 加
+ * {@code initWebsocket()}，直接把服务器登回去。
+ */
+@DisplayName("凭证代际（在途操作的失效判据）")
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+@SuppressWarnings("PMD.AvoidAccessibilityAlteration") // 需反射复位 UltiTools 单例（#250）
+class CredentialGenerationTest {
+
+    @TempDir
+    File dataFolder;
+
+    @BeforeEach
+    void setUp() {
+        Logger mockLogger = mock(Logger.class);
+        TestHelper.mockUltiToolsInstance(ultiTools -> {
+            lenient().when(ultiTools.getLogger()).thenReturn(mockLogger);
+            lenient().when(ultiTools.getDataFolder()).thenReturn(dataFolder);
+        });
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        Field instanceField = UltiTools.class.getDeclaredField("ultiTools");
+        instanceField.setAccessible(true);
+        instanceField.set(null, null);
+    }
+
+    private TokenEntity someToken() {
+        TokenEntity token = new TokenEntity();
+        token.setAccess_token("late-arriving-access-token");
+        token.setRefresh_token("late-arriving-refresh-token");
+        token.setExp((System.currentTimeMillis() / 1000) + 3600);
+        return token;
+    }
+
+    @Nested
+    @DisplayName("拆线之后到达的结果必须被丢弃")
+    class LateResultsAreDiscarded {
+
+        @Test
+        @DisplayName("代际未变时，提交成功")
+        void commitSucceedsWhenGenerationUnchanged() throws Exception {
+            long generation = CloudAuthManager.currentCredentialGeneration();
+
+            boolean committed = CloudAuthManager.commitTokenIfCurrent(someToken(), generation);
+
+            assertThat(committed).isTrue();
+            assertThat(CloudAuthManager.getCurrentToken()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("代际已被 invalidate 递增时，提交必须被拒绝且不落盘")
+        void commitIsRejectedAfterInvalidation() throws Exception {
+            // 在途操作出发时记下的代际
+            long generationAtStart = CloudAuthManager.currentCredentialGeneration();
+
+            // logout 期间：拆线路径让一切在途凭证操作作废
+            CloudAuthManager.invalidateCredentialOperations();
+            CloudAuthManager.clearToken();
+
+            // HTTP 请求这时才返回
+            boolean committed = CloudAuthManager.commitTokenIfCurrent(someToken(), generationAtStart);
+
+            assertThat(committed)
+                    .as("迟到的刷新结果不得把凭证写回来——否则 logout 等于没执行")
+                    .isFalse();
+            assertThat(CloudAuthManager.getCurrentToken())
+                    .as("内存中的凭证必须仍是空的")
+                    .isNull();
+            assertThat(new File(dataFolder, "data.json"))
+                    .as("磁盘上不该留下可用于重启后自动重连的凭证")
+                    .satisfiesAnyOf(
+                            f -> assertThat(f).doesNotExist(),
+                            f -> assertThat(f).content().doesNotContain("late-arriving-access-token"));
+        }
+
+        @Test
+        @DisplayName("每次 invalidate 都推进代际，多次 logout 不会让旧结果重新变得有效")
+        void generationIsMonotonic() {
+            long first = CloudAuthManager.currentCredentialGeneration();
+            CloudAuthManager.invalidateCredentialOperations();
+            long second = CloudAuthManager.currentCredentialGeneration();
+            CloudAuthManager.invalidateCredentialOperations();
+            long third = CloudAuthManager.currentCredentialGeneration();
+
+            assertThat(second).isGreaterThan(first);
+            assertThat(third).isGreaterThan(second);
+        }
+    }
+}


### PR DESCRIPTION
promote PR #287 上 Codex 第六轮复审的两条 P2。均核实属实，同一根因，一并修复。

## 根因：取消 ≠ 失效

`stopTokenRefreshScheduler()` 与 `stopPolling()` 用的都是 `cancel(false)` 加 `shutdown()`。两者都只承诺**不再调度新的执行**，对一个已经进入 HTTP 请求的任务毫无约束。而这两条路径都会在返回前写全局凭证状态。

### 路径 1 — token 刷新

`refreshToken()` 在返回**之前**就 `saveToken()` 写盘（`CloudAuthManager.java:136`）：

```
1. 刷新任务发出 HTTP 请求（网络往返，秒级）
2. 管理员 /ulticloud logout → 停调度器 → clearToken() 清掉 data.json
3. HTTP 返回 → saveToken() 把新凭证写回 data.json
4. 重启服务器 → 读到有效凭证 → 自动登录
```

**logout 成了一条没有效果的命令**，而它恰恰是安全语义的。

### 路径 2 — magic-link 轮询（更彻底）

`disableCloud()` 根本不调 `stopPolling()`——它此前只有 `onDisable` 一个生产调用方。而轮询的 `completed` 分支自己会做：

```java
saveToken(token);
PluginInitiationUtils.loginWithToken(token);
PluginInitiationUtils.enableCloud();      // ← 状态机重新打开
PluginInitiationUtils.initWebsocket();    // ← 重建连接
startTokenRefreshScheduler();             // ← 重启刷新调度
```

于是「`login` 之后马上改主意 `logout`」会在下一个轮询周期把服务器**悄悄登回去**，而 logout 刚刚才报告过云功能已停止。#295 让 logout 在无 token 时也执行并报告成功，这条路径因此更容易撞上。

## 修复：凭证代际

异步操作出发时记下当时的代际，提交结果前比对；拆线路径推进代际，迟到的结果一律作废。

```java
// 出发
final long generation = credentialGeneration.get();
// ... HTTP 往返 ...
// 提交
if (!commitTokenIfCurrent(newToken, generation)) {
    return null;   // logout 已发生，丢弃
}
```

`commitTokenIfCurrent` / `invalidateCredentialOperations` / `clearToken` **同步在类锁上**，因此「比对代际」与「写入」之间不存在窗口：拆线要么整个发生在提交之前（该次提交被拒），要么整个发生在提交之后（拆线把刚写的清掉）。两种都干净。

`doDisableCloud()` 另外补上了缺失的 `stopPolling()`。

## 测试

新增 `CredentialGenerationTest`：

- 代际未变 → 提交成功
- 代际已被 invalidate → **提交被拒，内存凭证为空，`data.json` 不含该 token**
- 代际单调递增（多次 logout 不会让旧结果重新有效）

并在 `CloudReconnectStateMachineTest` 钉住「`disableCloud` 必须推进代际」。

全量 **4332 tests, 0 failures**。