### PR TITLE
chore: 简化测试里已被 import 覆盖的全限定名

### DIFF
--- a/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/CloudReconnectStateMachineTest.java
@@ -347,8 +347,7 @@ class CloudReconnectStateMachineTest {
             // 这也正是真实场景的顺序——连着的时候日志积压，然后连接断掉，然后才 logout/关服。
             java.util.concurrent.atomic.AtomicBoolean connected =
                     new java.util.concurrent.atomic.AtomicBoolean(true);
-            com.ultikits.ultitools.websocket.UltiPanelWebSocketClient client =
-                    mock(com.ultikits.ultitools.websocket.UltiPanelWebSocketClient.class);
+            UltiPanelWebSocketClient client = mock(UltiPanelWebSocketClient.class);
             lenient().when(client.isConnected()).thenAnswer(invocation -> connected.get());
 
             com.ultikits.ultitools.manager.UltiPanelLogTransmitter transmitter =


### PR DESCRIPTION
## 背景

promote PR #287 的 Codacy 报出两条 `UnnecessaryFullyQualifiedName`（CodeStyle/minor），位置在 `CloudReconnectStateMachineTest` 的 `BoundedFlush` 用例。

## 原因

那两处全限定名是既有代码，原本没问题——当时文件并没有 import `UltiPanelWebSocketClient`。#297 为 `lateHandshakeDoesNotDereferenceClearedClient` 加了这个 import 之后，它们才变成"不必要的全限定名"。

```java
// 之前
com.ultikits.ultitools.websocket.UltiPanelWebSocketClient client =
        mock(com.ultikits.ultitools.websocket.UltiPanelWebSocketClient.class);
// 之后
UltiPanelWebSocketClient client = mock(UltiPanelWebSocketClient.class);
```

纯改名，无行为变更，测试通过。

修掉之后 promote PR 上 Codacy 只剩一条 —— `handleInboundMessage` 的 NPath 1514，已立项为技术债 #290，明确不在 6.2.5 发版前动刀。