### PR TITLE
chore: 定版 6.2.5，去掉 SNAPSHOT 后缀

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <artifactId>UltiTools-API</artifactId>
     <groupId>com.ultikits</groupId>
-    <version>6.2.5-SNAPSHOT</version>
+    <version>6.2.5</version>
     <modelVersion>4.0.0</modelVersion>
     <name>UltiTools-API</name>
     <description>This project is the base of the Ultitools plugin development.</description>


### PR DESCRIPTION
6.2.5 发版流程第 2 步（共 3 步）。第 1 步 promote alpha → main 已完成（#287，`7e7ccd8`）。

## 改动

`pom.xml` 一行：`6.2.5-SNAPSHOT` → `6.2.5`

## 为什么现在改

`.github/scripts/release.sh` 会拒绝任何带 SNAPSHOT 的版本号，且那道校验刻意排在打 tag 之前——脚本自己的注释写明了理由：

> tag 一旦推上去，release 一旦建出来，`publish-packages.yml` 就会被触发并往 Maven Central 推——Central 不允许覆盖或删除已发布的坐标，那一步是不可撤销的。

而 `release.sh` 要求发布分支是 `main`，`main` 又只接受来自 `alpha` 的 PR（`pr-source-guard.yml`）。所以版本号必须经这条路进 main。

## 前置条件核对

| 项 | 状态 |
|---|---|
| 6.2.5 里程碑 | 37 closed / **0 open** |
| `PUBLISH_TO_CENTRAL` | `true` — 本次发布会推 Maven Central |
| GPG key expiry check | pass |
| main 上 promote 后的 post-merge CI | 4 个 workflow 全 success |
| tag `v6.2.5` | 未被占用 |

## 验证

- 全量 **4333 tests, 0 failures**
- `mvn help:evaluate -Dexpression=project.version` 读出 `6.2.5`
- pom.xml 的 CRLF 行尾保持不变（diff 为 1 增 1 删，非整文件重写）

## 之后

本 PR 合并后需要再开一个 alpha → main 的 PR 把版本号带进 main，然后才能跑 `release.sh`。发布动作不可撤销，会单独请求授权。