### PR TITLE
chore: promote alpha → main（6.2.5 发版前置，第 2 步 / 共 3 步）

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <artifactId>UltiTools-API</artifactId>
     <groupId>com.ultikits</groupId>
-    <version>6.2.5-SNAPSHOT</version>
+    <version>6.2.5</version>
     <modelVersion>4.0.0</modelVersion>
     <name>UltiTools-API</name>
     <description>This project is the base of the Ultitools plugin development.</description>


### PR DESCRIPTION
6.2.5 发版流程第 2 步。把定版提交带进 `main`，`release.sh` 才能跑起来。

## 内容

相对第 1 步（#287，`7e7ccd8`）只多一个提交：

```
chore: 定版 6.2.5，去掉 SNAPSHOT 后缀 (#300)
```

`pom.xml` 一行：`6.2.5-SNAPSHOT` → `6.2.5`

## 为什么需要第二次 promote

`release.sh` 的三个硬性前提，缺一不可：

1. 当前分支必须是 `main`（`RELEASE_BRANCH` 默认值）
2. 本地 `main` 必须与 `origin/main` 一致
3. `pom.xml` 的版本号必须是正式版，带 SNAPSHOT 直接 die

而 `main` 只接受来自 `alpha` 的 PR（`pr-source-guard.yml`）。所以定版提交只能经这条路进 main。

## 前置条件

| 项 | 状态 |
|---|---|
| 6.2.5 里程碑 | 37 closed / 0 open |
| tag `v6.2.5` | 未被占用（本地 / 远端 / 草稿 release 三处均已查） |
| `PUBLISH_TO_CENTRAL` | `true` — 发布会推 Maven Central，**不可撤销** |
| 全量测试 | 4333 passed / 0 failed |
| 破坏性变更 | 无（`v6.2.4..main` 的 113 个提交中无 `feat!` / `BREAKING`） |

## 之后

本 PR 合并后即可在 `main` 上执行 `release.sh`。该动作会打 tag、建 release、触发 `publish-packages.yml` 推 GitHub Packages 与 Maven Central，**不可撤销**，会单独请求授权。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the project to version 6.2.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->