### PR TITLE
chore: bump alpha to 6.3.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <artifactId>UltiTools-API</artifactId>
     <groupId>com.ultikits</groupId>
-    <version>6.2.5</version>
+    <version>6.3.0-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
     <name>UltiTools-API</name>
     <description>This project is the base of the Ultitools plugin development.</description>


### PR DESCRIPTION
6.2.5 shipped and is tagged `v6.2.5`, but `alpha` was never moved to the next development
version. Three consequences had accumulated:

- **The repository contradicted itself.** #305 added `@since 6.3.0` and a 6.3.0 removal entry to
  `COMPATIBILITY.md` while `pom.xml` still read `6.2.5` — asserting it was a released version
  while carrying 6.3.0 plans.
- **`🔨 Build SNAPSHOT` was silently skipping.** That job is gated on the version carrying a
  `-SNAPSHOT` suffix. No check ever turned red; the artifacts simply stopped being produced. This
  surfaced while reviewing #305's CI run, where the job reported `skipping` on both workflows.
- **A release cut from `alpha` in that state would have overwritten the published 6.2.5.**

## Scope

One line. `plugin.yml` resolves `${project.version}` and needs no change. The `6.2.5` references
in `COMPATIBILITY.md` are historical removal announcements ("removal announced in 6.2.5") and are
deliberately left alone.

`mvn -o validate` passes and `project.version` resolves to `6.3.0-SNAPSHOT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzTkgBjRdaTcLrbvkoaFkp