### PR TITLE
feat(6.3.0): Phase 2 — persistence & transaction correctness

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -204,8 +204,9 @@ conclusion that nobody is using something.
 | `aop.CglibProxyFactory` | 6.3.0 | `aop.ProxyFactory` — same constructor shape (a list of interceptors); its `createProxy` methods have no direct replacement, see the next two rows | 0 |
 | `aop.ProxyFactory.createProxy(T)` and `createProxy(Class<T>, T)` | 6.3.0 | `aop.ProxyFactory.createProxyClass(Class<T>, Set<Method>)`, used through the container. Proxy creation moved to *before* the bean is constructed (issue #190: a `BeanPostProcessor` only ever sees an already-built instance, which is structurally too late) | 0 |
 | `aop.AopProxyBeanPostProcessor` | 6.3.0 | `aop.AopProxyResolver`, consulted by the container before construction instead of after | 0 |
+| `annotations.Propagation.NESTED` | 6.3.0 | No direct replacement — the six remaining constants (`REQUIRED`, `REQUIRES_NEW`, `SUPPORTS`, `NOT_SUPPORTED`, `MANDATORY`, `NEVER`) are exactly Jakarta Transactions 2.0's `TxType` set | 0 |
 
-All three entries above are removed in the same release that announces them, which the policy
+All four entries above are removed in the same release that announces them, which the policy
 above normally does not allow, and for two different reasons:
 
 - `aop.CglibProxyFactory` could not work on any supported server: it requires
@@ -222,6 +223,21 @@ above normally does not allow, and for two different reasons:
   the proxy class before the bean is constructed; a `BeanPostProcessor` cannot do that by interface
   contract, since both of its callbacks take an already-built instance. Neither had any downstream
   references. See issue #190.
+- `annotations.Propagation.NESTED` uses clause 2 for a reason distinct from the other three: all
+  seven original `Propagation` values, `NESTED` included, *are* implementable against the storage
+  layer — `NESTED` maps cleanly to `Connection.setSavepoint()`. It is dropped on
+  **controllability, not impossibility**: savepoint behaviour depends on whichever `sqlite-jdbc`
+  version the server's own Paper build happens to ship (`org.xerial:sqlite-jdbc` is not declared in
+  this project's `pom.xml` or `plugin.yml` — Paper supplies it — and versions `3.45.3.0`, `3.46.0.0`
+  and `3.47.0.0` have all been observed across local server caches), which this project can neither
+  pin nor test across. Clause 2's evidence, stated rather than argued: `@Transactional` has never
+  executed in any released version — the published 6.2.5 jar's `AopProxyBeanPostProcessor` is
+  referenced only by itself, and `PluginManager` has zero references to `AopAdvisor`, `addAdvisor`,
+  or `TransactionInterceptor` — so no released server ever evaluated `NESTED` regardless of this
+  reasoning. Across 17 in-house module/plugin repositories, `TransactionManager` /
+  `@Transactional` / `.transaction(` score **zero** hits, against a control of **94** hits for
+  `getDataOperator` (confirming the survey mechanism itself works). `NESTED` may be restored later
+  if savepoint behaviour ever becomes reliably pinnable across supported Paper builds.
 
 ## Migrating off `AbstractCommandExecutor`
 
@@ -450,76 +466,132 @@ exact-match requirement. Connector authors hitting this should use
 `api.UltiToolsAPI.connect(JavaPlugin)` instead, which does not go through reflective constructor
 resolution at all.
 
-### Recorded instance: `@Transactional` now refuses to load a module (6.3.0)
+### Recorded instance: `del()` with no conditions is now refused (6.3.0)
 
-Before 6.3.0, `@Transactional` was recognised by the framework's annotations but never wired to
-anything: there was no AOP container integration at all, so a bean carrying `@Transactional`
-loaded normally and ran completely untransacted, with no warning that the annotation had done
-nothing. 6.3.0 wires AOP into the container as part of issue #190, and `PluginManager.wireAop`
-declares `@Transactional` explicitly **unavailable** rather than leave it silently inert now that
-AOP itself works: `AopProxyResolver.rejectUnavailableAnnotations` throws a `ContainerException`
-for any container-created bean that carries it, which propagates through `createBean` →
-`refresh()` → `initializePlugin` → `register(...)`. `register` catches it, logs a WARNING, and
-returns `false` — **the module does not load at all.**
+Before 6.3.0, `AbstractRelationalDataOperator.del()` built its `DELETE FROM <table>` statement from
+whatever `WhereCondition`s it was given, with no check that there were any. Calling `del()` with a
+zero-length varargs array — a bare `dataOperator.del()`, no arguments at all — produced a
+WHERE-less `DELETE FROM <table>` and emptied the entire table in one statement. An explicit
+`del((WhereCondition[]) null)` reached the same code path.
 
-Method signatures are unchanged, so `japicmp` cannot detect this. It is recorded here because it
-is real, immediate breakage for a module that declares `@Transactional` today: before 6.3.0 the
-module loaded, just without the transaction it asked for; from 6.3.0 it does not load. The
-framework's own 17 in-house Modules were measured and use `@Transactional` zero times, but that
-measurement is about this organization's own code, not about third-party modules — exactly the
-audience this file exists to warn.
+6.3.0 refuses both shapes outright: `del()`'s zero-condition guard is the literal first statement
+of the method, ahead of building the SQL `StringBuilder` and ahead of touching the operator's
+`QueryRunner` at all — proven against a Mockito spy (zero interactions recorded after the throw),
+not merely the absence of a thrown exception. A `del(condition)` call carrying at least one real
+condition is unaffected.
 
-The reason is that the framework has no `TransactionManager` to give `@Transactional` real
-meaning: `DataStore` does not expose its `DataSource`, and the default SQLite backend opens one
-connection pool per entity class, so a single `.db` file would need several unrelated transaction
-managers before this could work correctly. Rather than continue running such beans untransacted —
-the exact silent-degradation failure mode this whole branch exists to close — 6.3.0 rejects them
-outright. Tracked in issues **#195** and **#196**; once the framework can supply a real
-`TransactionManager`, `@Transactional` will move from "unavailable" to "wired," which will be
-recorded here in its own right when it happens.
+**This takes the security-fix channel** ("Behavioral changes that need no migration period"
+above), not the two-step migration period the "silent degradation becoming failure" bucket would
+otherwise call for. The case-specific reason, not a generic "it's a bug fix" appeal: an
+unconditioned `del()` is an **unbounded data-loss primitive** reachable from any code that holds a
+`DataOperator` — one missing argument, or one `WhereCondition[]` built from a collection that
+happened to be empty at runtime, and the entire table is gone, with no transaction boundary on
+most call paths that could undo it. That is qualitatively different from a bug whose worst case is
+a wrong query result; here the worst case is unrecoverable data loss triggered by an easy-to-write
+mistake. Continuing to allow it for one more MINOR under a warning is not a safer default than
+refusing it now — the failure mode a warning would be protecting against is "I read the warning
+and kept shipping code that empties tables on typos," which a louder log line does not meaningfully
+improve.
 
-**How far the refusal reaches.** "Carries it" is wider than the annotation appearing in the file
-you are looking at, and it got wider still while 6.3.0 was being built. The refusal fires when
-either of these is true anywhere in the bean's superclass chain:
+A control-grouped survey (both a negative and a control query, per this project's own search-hazard
+rule) found no shipping caller relying on the old behaviour: `src/main` — 0 hits for a zero-argument
+`.del()`/null-array call, against 1 control hit (an unrelated `FileUtils.del(file)`); `src/test` —
+0 hits, against 11 control hits on `.del(` calls carrying real conditions; the 17 in-house
+`Modules/*` repositories — 0 hits, against 42 control hits on `.insert(` (confirming the grep
+mechanism itself works); the legacy, pre-6.2.0 `Plugins/` tree — 0 hits on both queries.
 
-- a method carries `@Transactional` — including a method your class inherits and never mentions,
-  and including one your class overrides without repeating the annotation;
-- a class carries `@Transactional` and declares at least one of the methods your bean ends up
-  with — including a base class your bean merely extends.
+### Recorded instance: `@Transactional` moves from refusing to load a module to being wired (6.3.0)
 
-So a module that never types the word `Transactional` still fails to load if it extends a class
-that does — from a shared internal base class, or from a library you depend on. Check your base
-classes, not only your own files.
+**Through the refusal described in earlier `6.3.0-SNAPSHOT` builds of this file, `@Transactional`
+was recognised by the framework's annotations but never wired to anything real.** No AOP container
+integration existed at all before this milestone, so a bean carrying `@Transactional` loaded
+normally and ran completely untransacted, with no warning that the annotation had done nothing.
+Rather than leave that silent no-op in place once AOP itself started working elsewhere in 6.3.0's
+development, `PluginManager.wireAop` declared `@Transactional` explicitly **unavailable**:
+`AopProxyResolver.rejectUnavailableAnnotations` refused to load any bean carrying it — including a
+method or class merely inherited or extended, not just one you wrote yourself — logging a WARNING
+and returning `false` from `register(...)` instead. That refusal is now withdrawn.
 
-Two edges are worth stating exactly, because both are easy to guess wrong:
+**6.3.0 ships `@Transactional` wired end to end, on all three storage backends:**
 
-- **Overriding does not hide the annotation.** Java does not inherit method annotations, but the
-  lookup falls back from a method to the declaration it overrides, the way Spring's transaction
-  attribute lookup does. So overriding an annotated superclass method still refuses — you do not
-  have to repeat the annotation on the override, and repeating it changes nothing.
-- **A class-level annotation on a class that declares no methods of its own governs nothing**,
-  because class-level scope reaches the declaring class and its subclasses, never its ancestors.
+- **SQLite and MySQL**, through `JdbcTransactionManager` — one manager instance per plugin
+  container, shared between the AOP interceptor and every `DataOperator` the store hands out
+  (`SQLiteDataStore.transactionManagerFor(DataScope)` / `MysqlDataStore.transactionManagerFor(DataScope)`,
+  each backed by a per-identity cache), so a `@Transactional` method that calls
+  `insertAll`/`updateAll` opens exactly one transaction, not two. SQLite is keyed by the plugin's
+  own backing `.db` file (one manager per file, mirroring the one-pool-per-file fix elsewhere in
+  this release); MySQL is keyed by requesting identity, since that backend has one global
+  `DataSource` shared by every plugin.
+- **JSON**, through `JsonTransactionManager` — a snapshot-based manager: on first touch inside a
+  transaction, an operator's cache is deep-copied; on rollback, the whole cache is restored from
+  that snapshot. **What this does not guarantee:** the restore replaces an operator's *entire*
+  cache, not individual entities. `REQUIRES_NEW`/`NOT_SUPPORTED`'s independence from an outer scope
+  is therefore only observable when the inner and outer scopes touch *different*
+  `SimpleJsonDataOperator` instances — if both write to the *same* operator, the outer scope's
+  eventual rollback restores that operator's cache to its pre-outer-write snapshot, discarding the
+  inner scope's already-committed write too. That is a property of whole-cache-granularity
+  rollback, not a defect in the suspend/resume mechanism.
 
-How far the annotation is *found* is shared with `@ExceptionCatch` by construction — one rule
-walks the override chain and the class hierarchy for both. What the two do with it differs, and
-deliberately so. `@ExceptionCatch` is wired, so it applies where the proxy can reach and is ignored
-with a warning where it cannot. `@Transactional` is unavailable in this release, so its presence
-alone refuses the load — including on a method no proxy could reach. Degrading `@ExceptionCatch`
-to "the exception propagates" is visible; degrading `@Transactional` to "no transaction" is not,
-and a body that writes several rows would run half-applied with nothing to show for it.
+`REQUIRES_NEW` and `NOT_SUPPORTED` now genuinely suspend the active transaction on every backend
+(JDBC via a sibling `ThreadLocal<Deque<TransactionContext>>`; JSON via the equivalent construction
+on `JsonTransactionManager`) instead of silently nesting into it. `Propagation.NESTED` is removed
+— see its entry under [AOP](#aop) above.
 
-If your module declares `@Transactional` anywhere, or extends anything that does, before upgrading
-to 6.3.0 you must either:
+**Worked before/after example.** `rollbackFor` is now **additive** to the unchecked
+`RuntimeException`/`Error` default, not a replacement for it — matching what the javadoc already
+said before this fix ("Specify **additional** exception types") but the code did not do. When both
+`rollbackFor` and `noRollbackFor` match the thrown exception, the rule whose listed class is the
+**shallower inheritance-depth match** wins (Spring's `RuleBasedTransactionAttribute` tiebreak); an
+exact-depth tie — including the same class listed in both arrays — favours rollback.
 
-- remove the annotation, or
-- call `DataOperator.transaction(Callable)` explicitly instead.
+```java
+class OrderException extends RuntimeException { }
+class ValidationException extends OrderException { }
 
-This falls under "moving from silent degradation to failure" in the table above, which normally
-asks for the two-step migration period described there. There is no safe intermediate step to walk
-through here: the "old behaviour" being phased out is a bean running without the transaction
-guarantee its own annotation promises, and continuing to allow that for one more release — even
-with a louder warning — is exactly the risk this document exists to flag, not something worth
-preserving a little longer.
+@Transactional(rollbackFor = ValidationException.class, noRollbackFor = OrderException.class)
+public void processOrder(Order order) throws ValidationException {
+    if (!order.hasShippingAddress()) {
+        throw new ValidationException("missing shipping address");
+    }
+}
+```
+
+`ValidationException` is an exact (depth-0) match for `rollbackFor`, and a depth-1 match for
+`noRollbackFor` (`ValidationException` → `OrderException`, one step up its own hierarchy).
+
+- **On 6.2.5** (`noRollbackFor` checked first, unconditionally): `noRollbackFor` matches, so the
+  method **commits** — the write that threw `ValidationException` is silently kept.
+- **After 6.3.0** (shallowest depth wins): `rollbackFor`'s depth-0 match beats `noRollbackFor`'s
+  depth-1 match, so the method **rolls back**.
+
+The plainer case this fix targets — an exception matching neither array:
+
+```java
+@Transactional(rollbackFor = BusinessException.class)
+public void chargeCard(Payment payment) throws BusinessException {
+    // ...
+    throw new NullPointerException(); // unrelated to BusinessException
+}
+```
+
+- **On 6.2.5**: a non-empty `rollbackFor` replaced the default rule entirely, so an exception not
+  on the list **committed** instead of rolling back — this exact annotation committed on an
+  unrelated `NullPointerException`.
+- **After 6.3.0**: neither array matches, so `shouldRollback` falls through to the unchanged
+  `RuntimeException`/`Error` default, and the method **rolls back** — exactly as it would with no
+  `rollbackFor` attribute at all.
+
+Both directions are proven through an external call and a self-invocation call on a real ByteBuddy
+proxy with a real JDBC connection, on both the JDBC and JSON backends.
+
+**If you removed `@Transactional` or switched to `DataOperator.transaction(Callable)` to work
+around the pre-6.3.0 refusal**, you can now re-add the annotation — but re-read the worked example
+above first if your method combines `rollbackFor` and `noRollbackFor`: the rollback direction may
+have changed under you.
+
+See the entry below, "Entity ownership is now enforced, and other 6.3.0 persistence
+deprecations," for `TransactionManager.getConnection()`/`setIsolationLevel(int)`/`setReadOnly(boolean)`,
+now `@Deprecated` `default` methods rather than abstract ones.
 
 ### Recorded instance: `@ExceptionCatch` can now stop a module from loading (6.3.0)
 
@@ -551,6 +623,90 @@ method, which is what Spring does for a method it cannot advise. The annotation 
 but the module loads.
 
 Method signatures are unchanged, so `japicmp` cannot detect any of this.
+
+### Recorded instance: entity ownership is now enforced, and other 6.3.0 persistence deprecations (SILENT-04)
+
+**Entity ownership.** Before 6.3.0, `getDataOperator(Class)` never asked *whose* entity you were
+asking for — a third-party module writing `getDataOperator(SomeoneElsesEntity.class)` received that
+other module's real `DataOperator` and could read and write its rows. Fixing this release's
+cache-keying isolation defect alone (see the pool-per-file/operator-per-scope work elsewhere in
+this milestone) would have made this *worse*, not better: with the cache keyed per requesting
+identity instead of entity class alone, the same call would instead return a **fresh, empty**
+operator over the caller's own storage, and every query on it would silently return nothing —
+"shouldn't work but does" becoming "looks like it works, always empty," exactly the defect class
+this milestone exists to remove.
+
+6.3.0 closes it with a real check instead. `DataStore.getOperator(DataScope, Class)` — the new,
+recommended entry point — refuses an entity outside the caller's own scope with
+`DataAccessException`/`ErrorCode.ENTITY_NOT_OWNED` (3010), naming the entity, the owning module
+(when known), and pointing at that module's own exposed service or the `EventBus` instead.
+`UltiToolsPlugin.getDataOperator(Class)` and `UltiToolsAPI.getDataOperator(JavaPlugin, Class)`
+apply the identical check before delegating to the legacy overloads, and — closing a gap disclosed
+mid-phase — `SQLiteDataStore`, `MysqlDataStore`, and `JsonStore` now run the same check as the
+*first statement* of their own `getOperator(UltiToolsPlugin, Class)`/`getOperator(File, Class)`
+overrides too, so reaching persistence through `UltiTools.getInstance().getDataStore()` directly
+(public in the published jar) no longer bypasses it. One caveat remains, stated in `DataStore.java`'s
+own javadoc rather than left implicit: nothing mechanically stops a *fourth*, hypothetical
+`DataStore` implementation from skipping the check inside its own override of the still-abstract
+`getOperator(UltiToolsPlugin, Class)` — the framework's own call-site checks
+(`UltiToolsPlugin.getDataOperator`/`UltiToolsAPI.getDataOperator`) are the backstop for that case.
+
+This takes **no migration period**, for the same reason the AOP proxy class naming and the
+superclass `@CmdMapping` registration entries above did: cross-module entity access was never a
+documented contract. No javadoc, guide page, or annotation ever stated that `getDataOperator`
+could reach another module's entity; the previous permissive behaviour was an accident of a shared
+cache key, not a promise. Measured, not assumed: 21 `@Table` classes across 17 in-house module
+repositories, **zero** naming collisions — and, per the maintainer's own framing of the risk, the
+realistic danger was never accidental collision but a third-party developer deliberately
+requesting an entity they already knew was not theirs.
+
+**The `"unknown"` plugin-name fallback is refused, not silently shared, at load.** Before 6.3.0, a
+module JAR whose `plugin.yml` carried no `name:` key resolved to the literal string `"unknown"`
+(`pluginConfig.getString("name", "unknown")`) and shared `sqliteDB/unknown.db` with every other
+name-less module ever deployed on that server. 6.3.0 refuses to load such a module at all —
+`PluginModuleException`, naming the JAR, thrown as the first statement of `UltiToolsPlugin`'s
+no-arg constructor, before any resource extraction or config initialisation runs. Like the
+entity-ownership case above, this takes **no migration period**: the `"unknown"` fallback was
+never a documented contract either — an internal default value with an accidental cross-module
+consequence, not a feature. A control-grouped survey of all 17 in-house module `plugin.yml` files
+found zero missing a `name:` key (17/17 control hits confirm the grep itself works), so no
+shipping module is refused at load by this change.
+
+*Fate of existing `sqliteDB/unknown.db` data.* This release does not migrate it. Measured on a live
+deployment: 96 KB, 10 tables belonging to 8 different modules, all zero rows except
+`world_settings` (3 rows — the same 3 rows already present in the module's own correctly-named
+`UltiWorlds.db`, so this measurement found no uniquely-held data there). If a name-less module's
+data existed *only* in `unknown.db` on your server, fixing its `plugin.yml` and reloading gives it
+a fresh, correctly-scoped `.db` file — it does not automatically recover the old shared file's
+rows. Inspect `sqliteDB/unknown.db` yourself before upgrading if you are unsure whether any of your
+modules were affected.
+
+**Newly deprecated, not yet removal-eligible.** Two more `@Deprecated(since = "6.3.0", forRemoval =
+true)` additions land in this release but do not appear in the "Removal list for 6.3.0" table above
+above, because condition 2 of [eligibility](#when-a-public-api-becomes-eligible-for-removal) — one
+MINOR since the *first* release carrying the annotation — is not yet satisfied by either: 6.3.0 is
+that first release, so neither is eligible for removal before 6.4.0 at the earliest.
+
+| Type / member | Replacement | Downstream references (informational) |
+|---|---|---|
+| `interfaces.TransactionManager.getConnection()` / `setIsolationLevel(int)` / `setReadOnly(boolean)` | `interfaces.JdbcTransactionManager`, which carries the same three as real abstract methods | 0 — `TransactionManager` appears in no published-jar signature of `DataStore`/`DataOperator`/`UltiToolsPlugin`/`UltiTools`; a module can only reach it today by downcasting `DataOperator` to `AbstractRelationalDataOperator` and supplying its own `DataSource` |
+| `interfaces.DataStore.getOperator(UltiToolsPlugin, Class)` and `getOperator(File, Class)` | `getOperator(DataScope, Class)` | Not separately measured — the documented, correct entry point for module authors is `getDataOperator(Class)` (94 downstream hits across 17 repositories, per the survey above), which still calls the deprecated overloads on your behalf and is unaffected by this deprecation |
+
+On `TransactionManager`, turning three previously-abstract methods into `@Deprecated` `default`
+methods that throw `UnsupportedOperationException` is, per `japicmp` 0.26.1's own
+`METHOD_ABSTRACT_NOW_DEFAULT` classification, reported as `binaryCompatible="false"`. Read
+literally in isolation that looks like a breaking change; in practice no compiled 6.2.x
+`TransactionManager` implementor breaks at link time from it. A previously-compiled **concrete**
+class was required to implement all nine of the interface's abstract methods to compile in the
+first place, so its own three overrides still resolve via ordinary virtual dispatch — the new
+`default` bodies are never reached for it. A previously-compiled **abstract** class that left the
+three JDBC-specific methods unimplemented (legal, since it was abstract) now has a working
+`default` fallback where none existed before, resolved via interface-method inheritance — exactly
+the case `default` methods exist to make safe. Neither case produces an `AbstractMethodError` or a
+`NoSuchMethodError`. `japicmp`'s conservative classification appears stricter than the JVM's actual
+binary-compatibility guarantee for this specific transformation (abstract → default, same
+signature, same return type) — recorded here so a reader trusting the raw `japicmp` report is not
+misled, without this document's own compatibility promise overstating it either.
 
 ## Binary incompatibilities the removal list cannot cover
 
@@ -1023,8 +1179,9 @@ Maven Central、只是没有对应的 git 标签，但它在仓库历史里有�
 | `aop.CglibProxyFactory` | 6.3.0 | `aop.ProxyFactory` —— 构造器形状相同（都接收拦截器列表）；其 `createProxy` 方法没有直接替代，见下两行 | 0 |
 | `aop.ProxyFactory.createProxy(T)` 与 `createProxy(Class<T>, T)` | 6.3.0 | `aop.ProxyFactory.createProxyClass(Class<T>, Set<Method>)`，经容器间接使用。代理创建时机提前到 bean 构造*之前*（issue #190：`BeanPostProcessor` 拿到的永远是已经造好的实例，结构上就晚了） | 0 |
 | `aop.AopProxyBeanPostProcessor` | 6.3.0 | `aop.AopProxyResolver`，由容器在构造前而非构造后咨询 | 0 |
+| `annotations.Propagation.NESTED` | 6.3.0 | 无直接替代——剩下的六个常量（`REQUIRED`、`REQUIRES_NEW`、`SUPPORTS`、`NOT_SUPPORTED`、`MANDATORY`、`NEVER`）恰好就是 Jakarta Transactions 2.0 的 `TxType` 取值集合 | 0 |
 
-以上三条都在宣布移除的同一个版本里被移除，这不符合上面的常规策略，理由分两类：
+以上四条都在宣布移除的同一个版本里被移除，这不符合上面的常规策略，理由分两类：
 
 - `aop.CglibProxyFactory` 在任何受支持的服务器上都无法工作：它需要
   `--add-opens java.base/java.lang=ALL-UNNAMED`，而 Paper 服务器不会设置这个参数，插件也无法
@@ -1038,6 +1195,18 @@ Maven Central、只是没有对应的 git 标签，但它在仓库历史里有�
   不会破坏任何真正在工作的集成。二者都在本周期内被 `AopProxyResolver` 取代：它在 bean 构造之前
   就解析出代理类，而 `BeanPostProcessor` 按接口约定拿到的两个回调都只能是已构造好的实例，结构上
   做不到这一点。两者都没有任何下游引用。详见 issue #190。
+- `annotations.Propagation.NESTED` 走第 2 条的理由和前三条不同：原本七个 `Propagation` 取值——
+  包括 `NESTED`——**在存储层上全都能实现**，`NESTED` 完全可以映射到 `Connection.setSavepoint()`。
+  它被砍掉是因为**可控性，不是不可实现**：保存点的实际行为取决于服务器所装 Paper 构建自带的
+  `sqlite-jdbc` 版本（`org.xerial:sqlite-jdbc` 既不在本项目 `pom.xml` 也不在 `plugin.yml` 里声明，
+  是 Paper 自带的——本机服务器缓存里就观测到过 `3.45.3.0`、`3.46.0.0`、`3.47.0.0` 三个不同版本），
+  这不是本项目能钉住或能跨版本测试的东西。第 2 条的证据，如实陈述而非论证：`@Transactional` 从未
+  在任何已发布版本上真正执行过——已发布的 6.2.5 jar 里 `AopProxyBeanPostProcessor` 只被自己引用，
+  `PluginManager` 对 `AopAdvisor`、`addAdvisor`、`TransactionInterceptor` 的引用为零——所以无论上面
+  这条理由是否成立，都没有任何已发布的服务器真正求值过 `NESTED`。对 UltiKits 组织内 17 个模块/
+  插件仓库的实测：`TransactionManager` / `@Transactional` / `.transaction(` 命中 **零次**，对照组
+  `getDataOperator` 命中 **94** 次（证明这次调查方法本身是有效的）。如果保存点行为将来能在受支持的
+  Paper 构建之间稳定钉住，`NESTED` 可以考虑恢复。
 
 ## `AbstractCommandExecutor` 的迁移
 
@@ -1235,63 +1404,115 @@ Constructor<? extends UltiToolsPlugin> constructor =
 六参数调用满足 `getDeclaredConstructor` 的精确匹配要求。命中这个问题的连接器作者应改用
 `api.UltiToolsAPI.connect(JavaPlugin)`，它完全不走反射构造器解析这条路。
 
-### 已记录的实例：`@Transactional` 现在会直接拒绝加载模块（6.3.0）
+### 已记录的实例：`del()` 不带任何条件时现在会被拒绝（6.3.0）
 
-6.3.0 之前，框架的注解体系认得 `@Transactional`，但它没有接到任何东西上——AOP 完全没有接入
-容器，所以带 `@Transactional` 的 bean 照常加载、完全不受事务保护地运行，也没有任何警告提示
-这个注解其实什么都没做。6.3.0 作为 issue #190 的一部分把 AOP 接入了容器，`PluginManager.wireAop`
-把 `@Transactional` 显式声明为**不可用**，而不是在 AOP 真正生效后仍然让它静默失效：
-`AopProxyResolver.rejectUnavailableAnnotations` 会为任何带有该注解的、由容器构造的 bean 抛出
-`ContainerException`，一路传播到 `createBean` → `refresh()` → `initializePlugin` →
-`register(...)`。`register` 捕获它、打一条 WARNING、返回 `false`——**模块完全不加载。**
+6.3.0 之前，`AbstractRelationalDataOperator.del()` 拿到什么 `WhereCondition` 就用什么拼
+`DELETE FROM <table>`，从不检查条件是否存在。不带任何参数直接调用 `del()`——一次裸调用，零参
+数——会生成一条没有 WHERE 子句的 `DELETE FROM <table>`，一条语句清空整张表。显式传入
+`del((WhereCondition[]) null)` 会走到同一条代码路径。
 
-方法签名没有变化，`japicmp` 抓不到这个变更。之所以记在这里，是因为它对今天声明了
-`@Transactional` 的模块是真实且立即的破坏：6.3.0 之前模块能加载（只是拿不到它要的事务保护），
-6.3.0 起直接不加载。本组织自己的 17 个 Modules 已核实 `@Transactional` 使用次数为零，但这只说明
-本组织自己的代码，说明不了第三方模块——而后者正是本文件要提醒的对象。
+6.3.0 把这两种形状都直接拒绝：`del()` 的零条件保护是方法的字面第一条语句，早于构建 SQL 用的
+`StringBuilder`，也早于碰操作器自己的 `QueryRunner`——用 Mockito spy 验证过（抛出之后
+`QueryRunner` 上零次交互记录），而不只是「没抛异常」这种弱证据。带至少一个真实条件的
+`del(condition)` 调用不受影响。
 
-原因是框架目前没有能让 `@Transactional` 真正生效的 TransactionManager：`DataStore` 不暴露自己的
-`DataSource`，默认的 SQLite 后端又是每个实体类开一个独立连接池，同一个 `.db` 文件底下会出现好几个
-互不相干的事务管理器，这个前提不解决就没法正确工作。与其让这样的 bean 继续静默地不受事务保护地
-运行——这正是本分支存在的目的所要消灭的那种静默失效——6.3.0 选择直接拒绝加载。跟踪于 issue
-**#195** 与 **#196**；等框架能提供真正的 TransactionManager，`@Transactional` 会从「不可用」变为
-「已接线」，届时会作为它自己的一条记录写在这里。
+**这走的是安全修复通道**（见上方「哪些行为变更可以在 MINOR 直接做」），而不是「从静默降级改成
+失败」那一类通常要求的两步迁移期。给出针对这个具体案例的理由，而不是笼统的「这是在修 bug」：
+一个不带条件的 `del()` 是任何持有 `DataOperator` 的代码都能触发的**无界数据丢失原语**——少传
+一个参数，或者一个运行时恰好为空集合构建出来的 `WhereCondition[]`，整张表就没了，而且大多数
+调用路径上没有事务边界能撤销它。这和「最坏情况是查询结果错了」这类 bug 有质的不同：这里的最坏
+情况是一个很容易写错就触发的、不可恢复的数据丢失。让它在警告下再多活一个 MINOR 并不比现在直接
+拒绝更安全——警告要防的失败模式是「我看到警告了，但照样继续发布会把表清空的代码」，这不是一条
+更响的日志能有效改善的。
 
-**这条拒绝的射程有多远。**「带有该注解」比「你正在看的这个文件里出现了这个注解」要宽，而且在
-6.3.0 的开发过程中又变得更宽了。只要 bean 的整条父类链上满足下面任意一条，拒绝就会触发：
+一次控制分组调查（按本项目自己的搜索陷阱规则，同时带负向查询和对照查询）没有找到任何依赖旧行为
+的现网调用方：`src/main`——零参数 `.del()`/null 数组调用 0 命中，对照组（一个无关的
+`FileUtils.del(file)`）1 命中；`src/test`——0 命中，对照组（带真实条件的 `.del(` 调用）11 命中；
+17 个内部 `Modules/*` 仓库——0 命中，对照组 `.insert(` 命中 42 次（证明 grep 机制本身有效）；
+6.2.0 之前的遗留 `Plugins/` 目录——两个查询都是 0 命中。
 
-- 某个方法带 `@Transactional`——包括你的类继承下来、自己从未提及的方法，也包括你的类覆写了、
-  但没有重复标注的方法；
-- 某个类带 `@Transactional`，且它自己声明了你的 bean 最终拥有的某个方法——包括你的 bean 只是
-  继承了它的某个基类。
+### 已记录的实例：`@Transactional` 从拒绝加载模块变为真正接线（6.3.0）
 
-也就是说，一个从头到尾没打过 `Transactional` 这个词的模块，只要它继承的类打了，就同样加载不了
-——可能来自你们内部共用的基类，也可能来自你依赖的某个库。请连基类一起检查，不要只看自己的文件。
+**在本文件早期 `6.3.0-SNAPSHOT` 版本所记录的那次拒绝期间，框架的注解体系认得 `@Transactional`，
+但它没有真正接到任何东西上。** 在本里程碑之前，AOP 完全没有接入容器，所以带 `@Transactional`
+的 bean 照常加载、完全不受事务保护地运行，也没有任何警告提示这个注解其实什么都没做。与其在
+6.3.0 开发过程中 AOP 本身已经在别处开始工作之后，继续放任这种静默空转，`PluginManager.wireAop`
+把 `@Transactional` 显式声明为**不可用**：`AopProxyResolver.rejectUnavailableAnnotations` 拒绝
+加载任何带有该注解的 bean——包括仅仅继承或扩展来的方法/类，不只是你自己写的那些——打一条
+WARNING，然后让 `register(...)` 返回 `false`。**这条拒绝现在被撤回了。**
 
-有两处边界值得写明，因为都容易猜错：
+**6.3.0 在全部三个存储后端上把 `@Transactional` 端到端接了线：**
 
-- **覆写不会遮住注解。** Java 确实不继承方法注解，但查找会从一个方法回退到它所覆写的那条声明，
-  与 Spring 的事务属性查找同理。所以覆写了父类上带注解的方法，同样会被拒绝——你不需要在覆写
-  方法上重复标注一次，重复标注也不改变结果。
-- **一个自己不声明任何方法的类，其类级注解什么都不管**，因为类级作用域只到「声明它的那个类
-  及其子类」，从不上溯到祖先。
+- **SQLite 与 MySQL**，通过 `JdbcTransactionManager`——每个插件容器一个管理器实例，
+  AOP 拦截器与该 store 分发出去的每一个 `DataOperator` 共用同一个实例
+  （`SQLiteDataStore.transactionManagerFor(DataScope)` / `MysqlDataStore.transactionManagerFor(DataScope)`，
+  各自由一个按身份缓存的 map 支撑），所以一个调用了 `insertAll`/`updateAll` 的 `@Transactional`
+  方法只会开出恰好一个事务，不是两个。SQLite 按插件自己的 `.db` 文件路径分 key（一个文件一个
+  管理器，与本版本其他地方「一个文件一个连接池」的修法呼应）；MySQL 按请求方身份分 key，因为
+  该后端所有插件共用同一个全局 `DataSource`。
+- **JSON**，通过 `JsonTransactionManager`——一个基于快照的管理器：事务内第一次触碰某个操作器时
+  深拷贝其缓存；回滚时从该快照整体恢复。**这不保证什么：** 恢复替换的是操作器**整个**缓存，
+  不是逐个实体的撤销。因此 `REQUIRES_NEW`/`NOT_SUPPORTED` 相对外层作用域的独立性，只有在内外
+  层触碰的是**不同的** `SimpleJsonDataOperator` 实例时才能被观察到——如果两者写的是**同一个**
+  操作器，外层作用域最终的回滚会把该操作器的缓存恢复到外层写入之前的快照，把内层作用域已经
+  提交的写入也一并丢弃。这是整体缓存粒度回滚的固有属性，不是 suspend/resume 机制本身的缺陷。
 
-注解被**找到**的射程与 `@ExceptionCatch` 是同一条规则算出来的——两者共用同一趟覆写链与类层级
-遍历。但两者拿它做的事不同，而且是有意为之。`@ExceptionCatch` 已接线，代理够得着就生效，够不着
-就忽略并打警告。`@Transactional` 在本版本不可用，因此它**只要存在**就拒绝加载——包括标在代理
-根本够不着的方法上。`@ExceptionCatch` 降级成「异常照常抛出」是看得见的；`@Transactional` 降级成
-「没有事务」看不见，一个要写好几行的方法体会半途而废，且不留任何痕迹。
+`REQUIRES_NEW` 与 `NOT_SUPPORTED` 现在在每个后端上都真正挂起当前活动事务（JDBC 侧靠一个
+sibling 的 `ThreadLocal<Deque<TransactionContext>>`；JSON 侧在 `JsonTransactionManager` 上有
+同等构造），而不是静默嵌套进去。`Propagation.NESTED` 已被移除——见上文 [AOP](#aop) 一节的条目。
 
-如果你的模块任何地方声明了 `@Transactional`，或者继承了任何声明了它的类，升级到 6.3.0 之前
-必须二选一：
+**前后对比的实例。** `rollbackFor` 现在是对未受检 `RuntimeException`/`Error` 默认规则的
+**叠加**，不是替换——这正是修复前 javadoc 已经写着的话（"指定**额外**的异常类型"），只是代码
+没有照做。当 `rollbackFor` 与 `noRollbackFor` 同时匹配抛出的异常时，胜出的是**继承深度更浅**
+的那条规则所列的类（Spring `RuleBasedTransactionAttribute` 的 tiebreak）；深度恰好相同——包括
+同一个类同时出现在两个数组里——时回滚胜出。
 
-- 移除该注解；或
-- 改为显式调用 `DataOperator.transaction(Callable)`。
+```java
+class OrderException extends RuntimeException { }
+class ValidationException extends OrderException { }
 
-按上面的分类，这属于「从静默降级改成失败」，通常需要走那里描述的两步迁移期。但这里没有安全的
-中间态可走：要逐步淘汰的「旧行为」本身就是一个 bean 在没有它自己注解承诺的事务保护下运行，哪怕
-只是多打一条更响的警告、再多放行一个版本，都正是本文件存在的目的要拦下的那种风险，不值得再多
-保留一会儿。
+@Transactional(rollbackFor = ValidationException.class, noRollbackFor = OrderException.class)
+public void processOrder(Order order) throws ValidationException {
+    if (!order.hasShippingAddress()) {
+        throw new ValidationException("missing shipping address");
+    }
+}
+```
+
+`ValidationException` 对 `rollbackFor` 是精确（深度 0）匹配，对 `noRollbackFor` 是深度 1 匹配
+（`ValidationException` → `OrderException`，往上一层）。
+
+- **在 6.2.5 上**（`noRollbackFor` 无条件优先检查）：`noRollbackFor` 匹配，方法**提交**——
+  抛出 `ValidationException` 的那次写入被静默保留。
+- **6.3.0 之后**（更浅深度胜出）：`rollbackFor` 的深度 0 匹配胜过 `noRollbackFor` 的深度 1
+  匹配，方法**回滚**。
+
+这个修法真正要解决的更朴素的情形——异常两个数组都不匹配：
+
+```java
+@Transactional(rollbackFor = BusinessException.class)
+public void chargeCard(Payment payment) throws BusinessException {
+    // ...
+    throw new NullPointerException(); // 与 BusinessException 无关
+}
+```
+
+- **在 6.2.5 上**：非空的 `rollbackFor` 会把默认规则整个替换掉，所以没列在其中的异常会
+  **提交**而不是回滚——这个注解就是会在一个无关的 `NullPointerException` 上提交。
+- **6.3.0 之后**：两个数组都不匹配，`shouldRollback` 落到未受检的 `RuntimeException`/`Error`
+  默认规则，方法**回滚**——和完全没写 `rollbackFor` 属性时一样。
+
+两个方向都在一个真实的 ByteBuddy 代理、真实 JDBC 连接上，通过外部调用和自调用两种路径证明过，
+JDBC 与 JSON 两个后端皆然。
+
+**如果你曾经因为 6.3.0 之前的那次拒绝而移除了 `@Transactional`，或改用了
+`DataOperator.transaction(Callable)`**，现在可以把注解加回来——但如果你的方法同时用了
+`rollbackFor` 和 `noRollbackFor`，先重读上面的对比实例：回滚方向可能已经在你没注意的情况下
+变了。
+
+`TransactionManager.getConnection()`/`setIsolationLevel(int)`/`setReadOnly(boolean)` 现在是
+`@Deprecated` 的 `default` 方法而不是抽象方法，见下文「实体归属现在会被强制检查，以及 6.3.0
+其他持久化层面的废弃」一条。
 
 ### 已记录的实例：`@ExceptionCatch` 现在可能让模块无法加载（6.3.0）
 
@@ -1319,6 +1540,73 @@ public final class MyService extends GuardedBase { }   // 6.2.5：能加载。6.
 一致。注解在那里不起作用，但模块照常加载。
 
 方法签名没有变化，`japicmp` 抓不到上述任何一条。
+
+### 已记录的实例：实体归属现在会被强制检查，以及 6.3.0 其他持久化层面的废弃（SILENT-04）
+
+**实体归属。** 6.3.0 之前，`getDataOperator(Class)` 从不问你在请求**谁的**实体——第三方模块
+写 `getDataOperator(SomeoneElsesEntity.class)` 会拿到另一个模块真实的 `DataOperator`，能读写
+它的数据行。单独修好本里程碑的缓存分 key 隔离缺陷（见本里程碑其他地方的「一个文件一个连接池 /
+一个作用域一个操作器」修法）反而会让这个问题**更糟而不是更好**：缓存改按请求方身份分 key 之后，
+同样的调用会返回一个针对调用者自己存储的**全新、空**操作器，其上的每一次查询都会静默返回空——
+「不该工作但确实工作」变成了「看起来在工作，但永远是空的」，这正是本里程碑要消灭的那一类缺陷。
+
+6.3.0 改用真正的检查来堵住它。`DataStore.getOperator(DataScope, Class)`——新的、推荐的入口——
+对超出调用者自身作用域的实体直接以 `DataAccessException`/`ErrorCode.ENTITY_NOT_OWNED`（3010）
+拒绝，点名该实体、（在已知的情况下）它所属的模块，并指向该模块自己暴露的服务或 `EventBus`。
+`UltiToolsPlugin.getDataOperator(Class)` 与 `UltiToolsAPI.getDataOperator(JavaPlugin, Class)`
+在委托给旧重载之前会执行同样的检查；本阶段中途披露过的一个缺口也已补上——`SQLiteDataStore`、
+`MysqlDataStore`、`JsonStore` 现在也会在各自 `getOperator(UltiToolsPlugin, Class)`/
+`getOperator(File, Class)` 重载的**第一条语句**里执行同样的检查，所以直接通过
+`UltiTools.getInstance().getDataStore()`（在已发布的 jar 里是 `public` 的）访问持久层
+也不再能绕过它。还留有一个未解决的边界，`DataStore.java` 自己的 javadoc 里明说了，没有藏着：
+没有任何机制能阻止一个**第四方**、假设性的 `DataStore` 实现在自己覆写仍然是抽象方法的
+`getOperator(UltiToolsPlugin, Class)` 时跳过这个检查——框架自己那两个入口点的检查
+（`UltiToolsPlugin.getDataOperator`/`UltiToolsAPI.getDataOperator`）是这种情况下唯一的兜底。
+
+这**不需要迁移期**，理由和上面 AOP 代理类命名、父类 `@CmdMapping` 注册这两条一样：跨模块访问
+实体从来都不是文档承诺的契约。没有任何 javadoc、指南页面或注解曾经说过 `getDataOperator` 可以
+拿到别的模块的实体；此前那种放任行为只是共享缓存 key 造成的意外，不是承诺。实测而非假设：
+17 个内部模块仓库里的 21 个 `@Table` 类，**零**命名冲突——按维护者自己的框定，现实中的风险从来
+不是意外撞名，而是第三方开发者明知某个实体不属于自己，仍然故意去请求它。
+
+**`"unknown"` 插件名回退现在会在加载期直接拒绝，而不是静默共享。** 6.3.0 之前，一个
+`plugin.yml` 没有 `name:` 键的模块 JAR 会解析成字面字符串 `"unknown"`
+（`pluginConfig.getString("name", "unknown")`），和这台服务器上曾经部署过的每一个同样没有
+名字的模块共享同一个 `sqliteDB/unknown.db`。6.3.0 直接拒绝加载这样的模块——`PluginModuleException`
+点名该 JAR，在 `UltiToolsPlugin` 无参构造器的第一条语句就抛出，早于任何资源释放或配置初始化。
+和上面的实体归属检查一样，这**不需要迁移期**：`"unknown"` 回退同样从来不是文档承诺的契约——
+它是一个带有意外跨模块后果的内部默认值，不是一项功能。对 17 个内部模块的 `plugin.yml` 做的
+控制分组调查一个都没找到缺失 `name:` 键的（17/17 命中确认 grep 本身有效），所以这一改动不会
+拒绝任何现网模块加载。
+
+*已有 `sqliteDB/unknown.db` 数据的去向。* 本版本不会迁移它。在一台真实部署机器上实测：96 KB，
+10 张表分属 8 个不同模块，全部零行，只有 `world_settings` 例外（3 行——同样的 3 行也存在于该
+模块自己正确命名的 `UltiWorlds.db` 里，所以这次测量没有在这里找到独占持有的数据）。如果你服务器
+上某个没有名字的模块的数据**只**存在于 `unknown.db`，修好它的 `plugin.yml` 并重载会让它拿到一个
+全新的、正确归属的 `.db` 文件——不会自动找回旧共享文件里的行。升级前如果拿不准哪些模块受影响，
+请自行检查 `sqliteDB/unknown.db`。
+
+**新增废弃、尚未到可移除的时候。** 本版本还带来两处新增的 `@Deprecated(since = "6.3.0",
+forRemoval = true)`，但都没有出现在上面「6.3.0 的移除清单」表里，因为二者都不满足
+[可移除性](#一个公开-api-何时可以被移除)的第 2 条——从**首个**带上该标注的发布起算已跨过一个
+MINOR：6.3.0 正是那个首个发布，所以最早也要到 6.4.0 才有资格被移除。
+
+| 类型 / 成员 | 替代方案 | 下游引用（参考） |
+|---|---|---|
+| `interfaces.TransactionManager.getConnection()` / `setIsolationLevel(int)` / `setReadOnly(boolean)` | `interfaces.JdbcTransactionManager`，把同样这三个方法作为真正的抽象方法保留 | 0——`TransactionManager` 不出现在已发布 jar 里 `DataStore`/`DataOperator`/`UltiToolsPlugin`/`UltiTools` 的任何签名中；今天一个模块只能通过把 `DataOperator` 强转成 `AbstractRelationalDataOperator` 并自带 `DataSource` 才能碰到它 |
+| `interfaces.DataStore.getOperator(UltiToolsPlugin, Class)` 与 `getOperator(File, Class)` | `getOperator(DataScope, Class)` | 未单独实测——模块作者应当使用、也是文档承诺的正确入口是 `getDataOperator(Class)`（按上面的调查，17 个仓库里下游命中 94 次），它仍然会替你调用这两个已废弃的重载，不受这次废弃影响 |
+
+在 `TransactionManager` 上，把三个原本抽象的方法改成会抛 `UnsupportedOperationException` 的
+`@Deprecated` `default` 方法，按 `japicmp` 0.26.1 自己的 `METHOD_ABSTRACT_NOW_DEFAULT` 分类，
+报告结果是 `binaryCompatible="false"`。单看这行字面意思像是破坏性变更；但实践中没有任何已编译的
+6.2.x `TransactionManager` 实现者会在链接期因此崩掉。一个此前已编译的**具体**类，为了能编译通过
+本来就必须实现该接口全部九个抽象方法，所以它自己那三个覆写方法仍然按普通虚方法分派解析——新的
+`default` 方法体对它而言从来不会被走到。一个此前已编译、把三个 JDBC 专属方法留空的**抽象**类
+（当时合法，因为它是抽象类）现在多了一个此前不存在的可用 `default` 兜底，通过接口方法继承解析——
+这正是 `default` 方法存在的意义所在，用来保证这种情况的安全。两种情况都不会产生
+`AbstractMethodError` 或 `NoSuchMethodError`。`japicmp` 这个保守的分类，对这个具体变换（抽象
+变默认、签名不变、返回类型不变）来说，看起来比 JVM 实际的二进制兼容保证更严格——记在这里是为了
+不让只看 `japicmp` 原始报告的读者被误导，同时也不让本文件自己的兼容性承诺说得比实际更满。
 
 ## 移除清单覆盖不到的二进制不兼容
 

--- a/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
@@ -25,6 +25,8 @@ import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
 import com.ultikits.ultitools.annotations.EnableAutoRegister;
 import com.ultikits.ultitools.context.SimpleContainer;
 import com.ultikits.ultitools.entities.Language;
+import com.ultikits.ultitools.exceptions.ErrorCode;
+import com.ultikits.ultitools.exceptions.PluginModuleException;
 import com.ultikits.ultitools.interfaces.Configurable;
 import com.ultikits.ultitools.interfaces.DataOperator;
 import com.ultikits.ultitools.interfaces.IPlugin;
@@ -81,9 +83,21 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
      */
     protected UltiToolsPlugin() {
         YamlConfiguration pluginConfig = loadPluginConfiguration();
-        
+
+        if (!pluginConfig.contains("name")) {
+            // D-16: a module with no `name:` key used to silently become "unknown" and share
+            // sqliteDB/unknown.db with every other name-less module (measured on-disk: 10 tables
+            // from 8 modules, one of them - world_settings - holding the same logical rows as a
+            // properly-named module's own .db file). Fail fast at load instead, naming the JAR, so
+            // the operator sees this at startup rather than discovering it as missing data later.
+            throw new PluginModuleException(ErrorCode.PLUGIN_LOAD_FAILED,
+                    "Module JAR '" + resolveJarFileNameForError() + "' has no 'name:' key in its "
+                            + "plugin.yml. Refusing to load rather than silently sharing "
+                            + "sqliteDB/unknown.db with other unnamed modules - add a 'name:' key.");
+        }
+
         version = pluginConfig.getString("version", "unknown");
-        pluginName = pluginConfig.getString("name", "unknown");
+        pluginName = pluginConfig.getString("name");
         authors = pluginConfig.getStringList("authors");
         loadAfter = pluginConfig.getStringList("loadAfter");
         minUltiToolsVersion = pluginConfig.getInt("api-version", 0);
@@ -308,6 +322,30 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
         } catch (java.net.URISyntaxException e) {
             throw new IOException("Invalid URL format", e);
         }
+    }
+
+    /**
+     * Best-effort resolution of this module's own JAR file name, for the {@code name:}-missing
+     * refusal message only. Never throws -- falls back to the class name if the code source is
+     * unavailable (e.g. when running from unpacked classes in a test).
+     * <p>
+     * 尽力解析本模块自身的 JAR 文件名，仅用于 {@code name:} 缺失时的拒绝加载信息。永不抛出异常——
+     * 当代码源不可用时（例如测试中从未打包的 class 运行）回退为类名。
+     *
+     * @return the JAR file name, or this class's name if it cannot be determined
+     */
+    private String resolveJarFileNameForError() {
+        try {
+            CodeSource src = this.getClass().getProtectionDomain().getCodeSource();
+            if (src != null && src.getLocation() != null) {
+                String path = src.getLocation().getPath();
+                int slash = path.lastIndexOf('/');
+                return slash >= 0 ? path.substring(slash + 1) : path;
+            }
+        } catch (Exception ignored) {
+            // Best effort only - fall through to the class-name fallback below.
+        }
+        return this.getClass().getName();
     }
 
     protected final String getConfigFolder() {

--- a/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
@@ -74,6 +74,7 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
     private String resourceFolderPath;
     @Getter
     private SimpleContainer context;
+    private com.ultikits.ultitools.manager.DataScope dataScope;
 
 
     /**
@@ -251,6 +252,33 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
     @ApiStatus.Internal
     public void setContext(SimpleContainer context) {
         this.context = context;
+    }
+
+    /**
+     * Injects the {@link com.ultikits.ultitools.manager.DataScope} credential {@code
+     * PluginManager} minted for this module (D-17). Called by {@code PluginManager} right after
+     * minting, before {@code wireAop} runs -- the same lifecycle point {@link #setContext}
+     * documents.
+     * <p>
+     * Deliberately still public, for the same reason {@link #setContext} is: {@code
+     * PluginManager} lives in another package and cannot be narrowed to package-private, and the
+     * compatibility policy forbids removing a public method in a PATCH release. The annotation is
+     * a signal to humans and IDEs; it enforces nothing at runtime.
+     * <p>
+     * 注入 {@code PluginManager} 为本模块铸造的 {@link com.ultikits.ultitools.manager.DataScope}
+     * 凭证（D-17）。由 {@code PluginManager} 在铸造后、{@code wireAop} 运行前调用——与
+     * {@link #setContext} 记录的是同一个生命周期节点。
+     * <p>
+     * 刻意保持 public，原因与 {@link #setContext} 相同：{@code PluginManager} 不在同一个包，
+     * 降不成 package-private；兼容性策略也不允许 PATCH 版本移除一个 public 方法。注解只是给人
+     * 和 IDE 看的信号，运行期不做任何强制。
+     *
+     * @param scope the scope minted for this plugin <br> 为本插件铸造的 scope
+     * @since 6.3.0
+     */
+    @ApiStatus.Internal
+    public void setDataScope(com.ultikits.ultitools.manager.DataScope scope) {
+        this.dataScope = scope;
     }
 
     /**
@@ -434,15 +462,27 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
     }
 
     /**
-     * Gets data operator.
+     * Gets data operator. Refuses outright if {@code dataClazz} is not registered to this module
+     * (D-14) -- checked against the same {@link com.ultikits.ultitools.manager.DataScope} minted
+     * for this module at load, via the same refusal {@code DataStore.getOperator(DataScope,
+     * Class)} builds, so the exception type, error code, and message shape are identical
+     * regardless of which entry point a caller reaches.
      * <p>
-     * 获取数据操作器。
+     * 获取数据操作器。若 {@code dataClazz} 未向本模块注册则直接拒绝（D-14）——校验依据是本模块
+     * 加载时铸造的同一个 {@link com.ultikits.ultitools.manager.DataScope}，构造拒绝信息的方式
+     * 与 {@code DataStore.getOperator(DataScope, Class)} 完全相同，因此无论调用方走到哪一个
+     * 入口，异常类型、错误码和消息形态都一致。
      *
      * @param dataClazz the class of the data entity <br> 数据实体的类
      * @param <T>       the type of the data entity <br> 数据实体的类型
      * @return the data operator <br> 数据操作器
+     * @throws com.ultikits.ultitools.exceptions.DataAccessException if {@code dataClazz} is not
+     *         registered to this module <br> 如果 {@code dataClazz} 未向本模块注册
      */
     public final <T extends BaseDataEntity<String>> DataOperator<T> getDataOperator(Class<T> dataClazz) {
+        if (dataScope != null && !dataScope.owns(dataClazz)) {
+            throw dataScope.refusalFor(dataClazz);
+        }
         return UltiTools.getInstance().getDataStore().getOperator(this, dataClazz);
     }
 

--- a/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
@@ -468,10 +468,30 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
      * Class)} builds, so the exception type, error code, and message shape are identical
      * regardless of which entry point a caller reaches.
      * <p>
+     * <strong>02-13 (CR-03):</strong> before this, {@code dataScope.owns(...)} was checked here
+     * inline and this method then delegated to the deprecated {@code getOperator(UltiToolsPlugin,
+     * Class)} overload directly -- so {@code DataStore.getOperator(DataScope, Class)}, the method
+     * D-17/02-07 built specifically as the credential-typed supported path, had zero real callers
+     * anywhere in the framework. This now routes through it, so production actually uses the path
+     * it was built for. {@code dataScope} is normally non-null by the time any module calls this
+     * (set by {@code PluginManager} right after minting, before {@code registerSelf()} runs); the
+     * {@code null} fallback below only covers a bare instance constructed outside the normal
+     * {@code PluginManager} load flow (e.g. a test), where the deprecated overload's own {@code
+     * checkOwnership(...)} call still refuses correctly on its own.
+     * <p>
      * 获取数据操作器。若 {@code dataClazz} 未向本模块注册则直接拒绝（D-14）——校验依据是本模块
      * 加载时铸造的同一个 {@link com.ultikits.ultitools.manager.DataScope}，构造拒绝信息的方式
      * 与 {@code DataStore.getOperator(DataScope, Class)} 完全相同，因此无论调用方走到哪一个
      * 入口，异常类型、错误码和消息形态都一致。
+     * <p>
+     * <strong>02-13（CR-03）：</strong>在此之前，这里内联检查 {@code dataScope.owns(...)}，
+     * 然后本方法直接委托给已废弃的 {@code getOperator(UltiToolsPlugin, Class)} 重载——于是
+     * {@code DataStore.getOperator(DataScope, Class)}，即 D-17/02-07 专门构建的、携带凭证的受支持
+     * 路径，在整个框架里没有任何真实调用方。现在改为通过它路由，生产环境真正用上了它当初构建的
+     * 目的。到任何模块调用本方法时 {@code dataScope} 通常已经非空（由 {@code PluginManager} 在铸造
+     * 之后、{@code registerSelf()} 运行之前立即设置）；下面的 {@code null} 回退分支只覆盖在正常
+     * {@code PluginManager} 加载流程之外直接构造出的裸实例（例如测试场景），此时已废弃重载自身的
+     * {@code checkOwnership(...)} 调用依然能正确拒绝。
      *
      * @param dataClazz the class of the data entity <br> 数据实体的类
      * @param <T>       the type of the data entity <br> 数据实体的类型
@@ -480,8 +500,8 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
      *         registered to this module <br> 如果 {@code dataClazz} 未向本模块注册
      */
     public final <T extends BaseDataEntity<String>> DataOperator<T> getDataOperator(Class<T> dataClazz) {
-        if (dataScope != null && !dataScope.owns(dataClazz)) {
-            throw dataScope.refusalFor(dataClazz);
+        if (dataScope != null) {
+            return UltiTools.getInstance().getDataStore().getOperator(dataScope, dataClazz);
         }
         return UltiTools.getInstance().getDataStore().getOperator(this, dataClazz);
     }

--- a/src/main/java/com/ultikits/ultitools/abstracts/command/BaseCommandExecutor.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/command/BaseCommandExecutor.java
@@ -30,6 +30,7 @@ import com.ultikits.ultitools.abstracts.command.validation.validators.CooldownVa
 import com.ultikits.ultitools.abstracts.command.validation.validators.PermissionValidator;
 import com.ultikits.ultitools.abstracts.command.validation.validators.SenderTypeValidator;
 import com.ultikits.ultitools.abstracts.command.validation.validators.UsageLockValidator;
+import com.ultikits.ultitools.abstracts.data.AuditableDataEntity;
 import com.ultikits.ultitools.annotations.command.AsyncCommand;
 import com.ultikits.ultitools.annotations.command.CmdExecutor;
 import com.ultikits.ultitools.annotations.command.CmdMapping;
@@ -242,27 +243,45 @@ public abstract class BaseCommandExecutor implements TabExecutor {
         BukkitRunnable runnable = new BukkitRunnable() {
             @Override
             public void run() {
-                lockValidator.acquireLock(context);
+                // T-02-REP-1/T-02-EOP-4 (02-08): the current-user context for
+                // AuditableDataEntity's audit columns is set and cleared HERE, inside the
+                // runnable that actually invokes the matched method -- not around the
+                // runTask()/runTaskAsynchronously() call below that schedules this runnable.
+                // Sync command bodies are deferred one tick and @AsyncCommand/@RunAsync bodies
+                // run on another thread entirely; a ThreadLocal write made on the scheduling
+                // thread would be invisible on whichever thread actually executes this run()
+                // (T-02-REP-4). clearCurrentUser() -- not setCurrentUser(null) -- runs in a
+                // finally around the whole body so a pooled Bukkit worker thread never carries
+                // one command's user into the next, whether this command's sender was a Player
+                // or not, and whether the handler returned normally or threw.
+                if (context.isPlayer()) {
+                    AuditableDataEntity.setCurrentUser(context.getPlayer().getUniqueId());
+                }
                 try {
-                    method.setAccessible(true);
-                    method.invoke(BaseCommandExecutor.this, params);
-                    cooldownValidator.applyCooldown(context);
-                } catch (Exception e) {
-                    context.getSender().sendMessage(ChatColor.RED + "命令执行出错: " + e.getMessage());
-                    Logger.getLogger(BaseCommandExecutor.class.getName())
-                            .log(Level.SEVERE, "Command execution failed: " + method.getName(), e);
-                    // Report to error collector
+                    lockValidator.acquireLock(context);
                     try {
-                        ErrorReportCollector erc = UltiTools.getInstance().getErrorReportCollector();
-                        if (erc != null) {
-                            Throwable cause = e.getCause() != null ? e.getCause() : e;
-                            erc.reportError(cause, extractModuleName(), triggerCtx);
+                        method.setAccessible(true);
+                        method.invoke(BaseCommandExecutor.this, params);
+                        cooldownValidator.applyCooldown(context);
+                    } catch (Exception e) {
+                        context.getSender().sendMessage(ChatColor.RED + "命令执行出错: " + e.getMessage());
+                        Logger.getLogger(BaseCommandExecutor.class.getName())
+                                .log(Level.SEVERE, "Command execution failed: " + method.getName(), e);
+                        // Report to error collector
+                        try {
+                            ErrorReportCollector erc = UltiTools.getInstance().getErrorReportCollector();
+                            if (erc != null) {
+                                Throwable cause = e.getCause() != null ? e.getCause() : e;
+                                erc.reportError(cause, extractModuleName(), triggerCtx);
+                            }
+                        } catch (Exception ignored) {
+                            // Never re-enter logging from error reporting
                         }
-                    } catch (Exception ignored) {
-                        // Never re-enter logging from error reporting
+                    } finally {
+                        lockValidator.releaseLock(context);
                     }
                 } finally {
-                    lockValidator.releaseLock(context);
+                    AuditableDataEntity.clearCurrentUser();
                 }
             }
         };

--- a/src/main/java/com/ultikits/ultitools/abstracts/data/AuditableDataEntity.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/data/AuditableDataEntity.java
@@ -55,7 +55,7 @@ public abstract class AuditableDataEntity<ID extends java.io.Serializable> exten
     public static void setCurrentUser(UUID userId) {
         CURRENT_USER.set(userId);
     }
-    
+
     /**
      * Clears the current user context.
      * Call this after completing data operations.
@@ -77,20 +77,56 @@ public abstract class AuditableDataEntity<ID extends java.io.Serializable> exten
         return CURRENT_USER.get();
     }
     
+    /**
+     * Sets {@code createdAt}/{@code updatedAt} to now and, if a {@link #setCurrentUser current
+     * user} is set, {@code createdBy}/{@code updatedBy} to it.
+     * <p>
+     * As of 6.3.0 (02-08), every relational and JSON data operator in this framework actually
+     * calls this before an entity is inserted -- previously it was reachable only by calling it
+     * directly, which nothing in the framework did, so {@code createdAt}/{@code createdBy} stayed
+     * {@code null} on every persisted row regardless of this method's own correctness. A later
+     * {@link #onUpdate()} does <strong>not</strong> touch {@code createdAt}/{@code createdBy}, so
+     * the values this method writes on insert persist unchanged through every subsequent update.
+     * <p>
+     * 将 {@code createdAt}/{@code updatedAt} 设为当前时间；若已设置{@link #setCurrentUser 当前用户}，
+     * 同时将 {@code createdBy}/{@code updatedBy} 设为该用户。
+     * <p>
+     * 自 6.3.0（02-08）起，框架内每个关系型和 JSON 数据操作器在插入实体前都会真正调用本方法——
+     * 此前只能被直接调用，而框架内没有任何地方会这样做，因此无论本方法自身是否正确，每一行
+     * 持久化数据的 {@code createdAt}/{@code createdBy} 都始终为 {@code null}。后续的
+     * {@link #onUpdate()} 不会改动 {@code createdAt}/{@code createdBy}，因此本方法在插入时
+     * 写入的值会在此后每一次更新中保持不变。
+     */
     @Override
     public void onCreate() {
         super.onCreate();
         LocalDateTime now = LocalDateTime.now();
         this.createdAt = now;
         this.updatedAt = now;
-        
+
         UUID currentUser = getCurrentUser();
         if (currentUser != null) {
             this.createdBy = currentUser;
             this.updatedBy = currentUser;
         }
     }
-    
+
+    /**
+     * Sets {@code updatedAt} to now and, if a {@link #setCurrentUser current user} is set,
+     * {@code updatedBy} to it. Deliberately does not touch {@code createdAt}/{@code createdBy} --
+     * see {@link #onCreate()}.
+     * <p>
+     * As of 6.3.0 (02-08), every relational and JSON data operator in this framework actually
+     * calls this before an entity is updated; see {@link #onCreate()}'s note on why that was not
+     * previously true.
+     * <p>
+     * 将 {@code updatedAt} 设为当前时间；若已设置{@link #setCurrentUser 当前用户}，同时将
+     * {@code updatedBy} 设为该用户。刻意不改动 {@code createdAt}/{@code createdBy}——见
+     * {@link #onCreate()}。
+     * <p>
+     * 自 6.3.0（02-08）起，框架内每个关系型和 JSON 数据操作器在更新实体前都会真正调用本方法；
+     * 此前为何并非如此，见 {@link #onCreate()} 中的说明。
+     */
     @Override
     public void onUpdate() {
         super.onUpdate();

--- a/src/main/java/com/ultikits/ultitools/abstracts/data/AuditableDataEntity.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/data/AuditableDataEntity.java
@@ -47,8 +47,23 @@ public abstract class AuditableDataEntity<ID extends java.io.Serializable> exten
      * Sets the current user for audit tracking.
      * Call this before performing data operations.
      * <p>
+     * {@code BaseCommandExecutor} (Phase 5's file; the current-user wrapper was added there in
+     * 02-08) calls this once, inside the runnable that actually invokes a command's matched
+     * method, when the resolved sender is a {@code Player} -- so a command handler's data
+     * operations record that player's UUID in {@code createdBy}/{@code updatedBy}. Nothing else
+     * in the framework calls this: a module performing data operations from outside a command
+     * handler (a scheduled task, a listener, an external plugin via the External Plugin API) is
+     * responsible for setting the context itself, or its writes record {@code null} actors.
+     * <p>
      * 设置用于审计跟踪的当前用户。
      * 在执行数据操作之前调用此方法。
+     * <p>
+     * {@code BaseCommandExecutor}（Phase 5 的文件；当前用户包装器由 02-08 加入）在实际调用
+     * 命令匹配方法的那个 runnable 内部调用一次本方法——仅当解析出的发送者是 {@code Player}
+     * 时才会调用，因此命令处理器中的数据操作会把该玩家的 UUID 记入
+     * {@code createdBy}/{@code updatedBy}。框架中没有其他地方会调用它：模块如果在命令处理器
+     * 之外执行数据操作（定时任务、监听器、通过 External Plugin API 接入的外部插件），
+     * 需要自行设置该上下文，否则写入的审计字段记录的行为者会是 {@code null}。
      *
      * @param userId the current user's UUID
      */
@@ -60,8 +75,21 @@ public abstract class AuditableDataEntity<ID extends java.io.Serializable> exten
      * Clears the current user context.
      * Call this after completing data operations.
      * <p>
+     * {@code BaseCommandExecutor} calls this in a {@code finally} around the same invocation it
+     * wraps with {@link #setCurrentUser(UUID)}, so it runs whether the handler returns normally
+     * or throws. It calls this method -- not {@code setCurrentUser(null)} -- specifically because
+     * this removes the {@link ThreadLocal} entry entirely rather than leaving a {@code null}
+     * mapping behind, which matters on a pooled Bukkit worker thread that gets reused for a later,
+     * unrelated command.
+     * <p>
      * 清除当前用户上下文。
      * 在完成数据操作后调用此方法。
+     * <p>
+     * {@code BaseCommandExecutor} 在包裹同一次调用的 {@code finally} 块中调用本方法（与
+     * {@link #setCurrentUser(UUID)} 成对），因此无论处理器正常返回还是抛出异常都会执行。
+     * 它调用的是本方法而不是 {@code setCurrentUser(null)}，原因是本方法会把
+     * {@link ThreadLocal} 条目彻底移除，而不是留下一个值为 {@code null} 的映射——这对
+     * 之后被复用来处理另一条无关命令的 Bukkit 工作线程池线程很重要。
      */
     public static void clearCurrentUser() {
         CURRENT_USER.remove();

--- a/src/main/java/com/ultikits/ultitools/annotations/Propagation.java
+++ b/src/main/java/com/ultikits/ultitools/annotations/Propagation.java
@@ -5,6 +5,14 @@ package com.ultikits.ultitools.annotations;
  * <p>
  * Propagation determines how a transaction behaves when it encounters
  * an existing transaction context.
+ * <p>
+ * This is exactly Jakarta Transactions 2.0's {@code TxType} set - six constants, no {@code NESTED}.
+ * A {@code NESTED} propagation (a savepoint within the existing transaction) was removed in 6.3.0
+ * (D-09): it is implementable on JDBC via {@code Connection.setSavepoint()}, but savepoint
+ * behaviour depends on whichever sqlite-jdbc version the server's Paper build happens to ship, and
+ * this project cannot pin or test across that. The removal used the {@code COMPATIBILITY.md}
+ * clause-2 same-release exception - {@code Propagation} shipped in 6.2.5 but no released version
+ * ever executed it.
  *
  * @author wisdomme
  * @since 6.2.0
@@ -54,13 +62,5 @@ public enum Propagation {
      * <p>
      * Cannot execute within a transaction. If one exists, an exception is thrown.
      */
-    NEVER,
-
-    /**
-     * Execute within a nested transaction if a current transaction exists.
-     * <p>
-     * Creates a savepoint within the existing transaction. If no transaction
-     * exists, behaves like REQUIRED.
-     */
-    NESTED
+    NEVER
 }

--- a/src/main/java/com/ultikits/ultitools/annotations/Transactional.java
+++ b/src/main/java/com/ultikits/ultitools/annotations/Transactional.java
@@ -88,7 +88,26 @@ public @interface Transactional {
     /**
      * The transaction timeout in seconds.
      * <p>
-     * Defaults to -1 (no timeout / use database default).
+     * Defaults to -1 (no timeout / use database default). Only a value greater than 0 is ever
+     * acted on at all -- the interceptor skips calling {@code TransactionManager.setTimeout(int)}
+     * entirely for -1 or 0, so both mean exactly "no timeout requested."
+     * <p>
+     * <b>Not currently enforced as a bound on the method body, and not currently enforced at
+     * all on two of the three backends.</b> This attribute is <em>not</em>, and will never be,
+     * a wall-clock limit on how long the annotated method may run -- that would require
+     * cancelling or interrupting work already in flight, which plain JDBC does not support
+     * (see {@code REQUIREMENTS.md}'s "out of scope" section). Per backend, today:
+     * <ul>
+     *   <li>SQLite, MySQL (JDBC-backed): a positive value is accepted but currently has no
+     *       effect. {@code DataSourceTransactionManager.setTimeout(int)} only logs it; no
+     *       statement issued inside the transaction carries any query timeout as a result.</li>
+     *   <li>JSON-backed: a positive value makes the transaction fail outright.
+     *       {@code JsonTransactionManager.setTimeout(int)} throws
+     *       {@link UnsupportedOperationException} unconditionally, since a snapshot-based
+     *       rollback has no query or connection to bound.</li>
+     * </ul>
+     * A method that leaves this attribute at its default is unaffected on every backend, since
+     * the interceptor never calls {@code setTimeout} for it.
      *
      * @return the timeout in seconds
      */

--- a/src/main/java/com/ultikits/ultitools/annotations/Transactional.java
+++ b/src/main/java/com/ultikits/ultitools/annotations/Transactional.java
@@ -90,17 +90,24 @@ public @interface Transactional {
      * <p>
      * Defaults to -1 (no timeout / use database default). Only a value greater than 0 is ever
      * acted on at all -- the interceptor skips calling {@code TransactionManager.setTimeout(int)}
-     * entirely for -1 or 0, so both mean exactly "no timeout requested."
+     * entirely for -1 or 0, so both mean exactly "no timeout requested," on every backend.
      * <p>
-     * <b>Not currently enforced as a bound on the method body, and not currently enforced at
-     * all on two of the three backends.</b> This attribute is <em>not</em>, and will never be,
-     * a wall-clock limit on how long the annotated method may run -- that would require
-     * cancelling or interrupting work already in flight, which plain JDBC does not support
-     * (see {@code REQUIREMENTS.md}'s "out of scope" section). Per backend, today:
+     * <b>The bound is per statement against a shared, shrinking budget -- not a wall-clock
+     * limit on the method body.</b> (D-10, Spring's approach.) When a value greater than 0 is
+     * set, the transaction gets a deadline {@code N} seconds out from when it began. Every
+     * individual JDBC statement issued afterward -- through the ORM's normal read/write methods,
+     * and through the direct batch paths in {@code insertAll}/{@code updateAll} -- is given a
+     * query timeout equal to whatever time is <em>left</em> in that budget when the statement is
+     * prepared, floored at 1 second so an exhausted budget still fails fast rather than becoming
+     * unlimited ({@code setQueryTimeout(0)} means "no limit" in the JDBC contract). This is
+     * deliberately <em>not</em> a wall-clock bound on the method as a whole: non-database work
+     * inside the method (a slow computation, a network call to something else) is never
+     * interrupted, because plain JDBC has no mechanism to cancel work already in flight, and
+     * this framework does not add one (see {@code REQUIREMENTS.md}'s "out of scope" section).
+     * <p>
+     * Per backend:
      * <ul>
-     *   <li>SQLite, MySQL (JDBC-backed): a positive value is accepted but currently has no
-     *       effect. {@code DataSourceTransactionManager.setTimeout(int)} only logs it; no
-     *       statement issued inside the transaction carries any query timeout as a result.</li>
+     *   <li>SQLite, MySQL (JDBC-backed): enforced exactly as described above.</li>
      *   <li>JSON-backed: a positive value makes the transaction fail outright.
      *       {@code JsonTransactionManager.setTimeout(int)} throws
      *       {@link UnsupportedOperationException} unconditionally, since a snapshot-based

--- a/src/main/java/com/ultikits/ultitools/annotations/Transactional.java
+++ b/src/main/java/com/ultikits/ultitools/annotations/Transactional.java
@@ -98,20 +98,29 @@ public @interface Transactional {
     boolean readOnly() default false;
 
     /**
-     * Exception types that should trigger a rollback.
+     * Exception types that should trigger a rollback, in addition to the {@code RuntimeException}/
+     * {@code Error} default.
      * <p>
-     * By default, transactions are rolled back for RuntimeException and Error.
-     * Specify additional exception types here if needed.
+     * This is additive, not a replacement: an exception that matches neither {@code rollbackFor}
+     * nor {@code noRollbackFor} still falls through to the unchecked default, exactly as if
+     * neither attribute were set. When an exception matches both this and {@link #noRollbackFor()},
+     * the rule whose listed class is the <b>shallower</b> inheritance-depth match to the thrown
+     * exception wins (Spring's {@code RuleBasedTransactionAttribute} tiebreak); on an exact-depth
+     * tie - including the same class appearing in both arrays - the transaction rolls back.
      *
-     * @return exception types to rollback for
+     * @return exception types to additionally rollback for
+     * @since 6.3.0 additive combination with {@link #noRollbackFor()} and the depth tiebreak
+     *        (D-06, D-07); before 6.3.0 a non-empty, unmatched {@code rollbackFor} silently
+     *        committed instead of falling through to the default.
      */
     Class<? extends Throwable>[] rollbackFor() default {};
 
     /**
-     * Exception types that should NOT trigger a rollback.
+     * Exception types that should NOT trigger a rollback, overriding the {@code RuntimeException}/
+     * {@code Error} default for those types.
      * <p>
-     * Use this to prevent rollback for specific exceptions that would
-     * normally cause a rollback.
+     * Combines with {@link #rollbackFor()} by shallowest-inheritance-depth match, described there;
+     * on an exact-depth tie the transaction still rolls back.
      *
      * @return exception types to not rollback for
      */

--- a/src/main/java/com/ultikits/ultitools/annotations/Transactional.java
+++ b/src/main/java/com/ultikits/ultitools/annotations/Transactional.java
@@ -43,8 +43,15 @@ import java.lang.annotation.Target;
  *
  * <p><b>Important:</b>
  * <ul>
- *   <li>Self-invocation (calling a @Transactional method from within the same class) bypasses the proxy</li>
- *   <li>Only public methods can be transactional</li>
+ *   <li>Self-invocation (calling a {@code @Transactional} method on {@code this} from within the
+ *       same class) <b>is</b> intercepted: the framework's generated proxy is a subclass of the
+ *       bean itself, not a delegate wrapping a separate target, so a call to
+ *       {@code this.method()} dispatches virtually onto the proxy's override. Re-verified against
+ *       three pre-existing {@code shouldInterceptSelfInvocation} test classes (2026-08-27)</li>
+ *   <li>Private, static, and final methods cannot be transactional - each is dispatched in a way
+ *       that bypasses the proxy (respectively: {@code invokespecial}, {@code invokestatic}, and
+ *       no override is possible); a package-private method is also ineligible when it is declared
+ *       in a different package than the bean class</li>
  *   <li>The class must not be final (subclass proxy limitation)</li>
  * </ul>
  *

--- a/src/main/java/com/ultikits/ultitools/annotations/UltiToolsModule.java
+++ b/src/main/java/com/ultikits/ultitools/annotations/UltiToolsModule.java
@@ -63,9 +63,22 @@ public @interface UltiToolsModule {
      * that scan, not a replacement for it. Equivalent to JPA's {@code <jar-file>} persistence-unit
      * element.
      * <p>
+     * <b>Validated, not trusted (02-14).</b> Each class must live on this module's own classpath --
+     * either its own JAR, or a jar/module not already known to belong to a different,
+     * already-discovered module. A class that structurally belongs to a DIFFERENT module (its own
+     * JAR, or one already recorded as owned by another module) fails plugin registration with a
+     * {@code com.ultikits.ultitools.exceptions.PluginModuleException} instead of silently granting
+     * this module a working {@code DataOperator} for another module's entity.
+     * <p>
      * 本模块拥有、但存放在自身 JAR 之外的实体类——共享库 JAR、多模块构建的公共产物，或插件套件的
      * 共享 JAR。模块自身 JAR 中的 {@code @Table} 类始终会被自动扫描；本属性是对该扫描结果的补充，
      * 而非替代。等价于 JPA 持久化单元中的 {@code <jar-file>} 元素。
+     * <p>
+     * <b>会被校验，而非被信任（02-14）。</b>其中每一个类都必须存放在本模块自身的 classpath
+     * 上——要么是它自己的 JAR，要么是一个尚未被记录为归属于另一个已发现模块的 jar/模块。若某个
+     * 类在结构上被确认属于另一个不同的模块（它自身的 JAR，或已记录归属于另一个模块），插件注册
+     * 会失败并抛出 {@code com.ultikits.ultitools.exceptions.PluginModuleException}，而不是静默地
+     * 让本模块获得另一个模块实体的可用 {@code DataOperator}。
      *
      * @return additional entity classes <br> 额外的实体类
      * @since 6.3.0

--- a/src/main/java/com/ultikits/ultitools/annotations/UltiToolsModule.java
+++ b/src/main/java/com/ultikits/ultitools/annotations/UltiToolsModule.java
@@ -55,4 +55,20 @@ public @interface UltiToolsModule {
      */
     @AliasFor(annotation = I18n.class, attribute = "value")
     String[] i18n() default {};
+
+    /**
+     * Entity classes this module owns that live outside its own JAR -- a shared library JAR, a
+     * multi-module build's common artifact, or a plugin suite's shared JAR. The module's own JAR
+     * is always scanned for {@code @Table} classes automatically; this attribute is additive to
+     * that scan, not a replacement for it. Equivalent to JPA's {@code <jar-file>} persistence-unit
+     * element.
+     * <p>
+     * 本模块拥有、但存放在自身 JAR 之外的实体类——共享库 JAR、多模块构建的公共产物，或插件套件的
+     * 共享 JAR。模块自身 JAR 中的 {@code @Table} 类始终会被自动扫描；本属性是对该扫描结果的补充，
+     * 而非替代。等价于 JPA 持久化单元中的 {@code <jar-file>} 元素。
+     *
+     * @return additional entity classes <br> 额外的实体类
+     * @since 6.3.0
+     */
+    Class<?>[] additionalEntities() default {};
 }

--- a/src/main/java/com/ultikits/ultitools/aop/TransactionInterceptor.java
+++ b/src/main/java/com/ultikits/ultitools/aop/TransactionInterceptor.java
@@ -80,10 +80,17 @@ public class TransactionInterceptor implements MethodInterceptor {
                 }
                 return invocation.proceed();
 
-            case REQUIRES_NEW:
-                // Always create a new transaction
-                // Note: In a full implementation, we would suspend the existing transaction
-                return executeInNewTransaction(invocation, tx);
+            case REQUIRES_NEW: {
+                // D-09: always suspend whatever is active (a no-op returning null if nothing is),
+                // begin a genuinely new and independent transaction, and resume the suspended
+                // frame in a finally so a failure on the inner path cannot strand it.
+                Object suspended = transactionManager.suspend();
+                try {
+                    return executeInNewTransaction(invocation, tx);
+                } finally {
+                    transactionManager.resume(suspended);
+                }
+            }
 
             case SUPPORTS:
                 // Execute with or without transaction
@@ -97,23 +104,22 @@ public class TransactionInterceptor implements MethodInterceptor {
                 }
                 return invocation.proceed();
 
-            case NOT_SUPPORTED:
-                // Execute without transaction (in a full impl, would suspend existing)
-                return invocation.proceed();
+            case NOT_SUPPORTED: {
+                // D-09: same suspend/resume shape as REQUIRES_NEW, minus the inner begin() - the
+                // body runs with no active transaction at all.
+                Object suspended = transactionManager.suspend();
+                try {
+                    return invocation.proceed();
+                } finally {
+                    transactionManager.resume(suspended);
+                }
+            }
 
             case NEVER:
                 if (existingTx) {
                     throw new IllegalStateException(
                             "Existing transaction found for NEVER propagation on method: " +
                                     invocation.getMethod().getName());
-                }
-                return invocation.proceed();
-
-            case NESTED:
-                // For NESTED, we would create a savepoint in a full implementation
-                // For now, treat it like REQUIRED
-                if (!existingTx) {
-                    return executeInNewTransaction(invocation, tx);
                 }
                 return invocation.proceed();
 

--- a/src/main/java/com/ultikits/ultitools/aop/TransactionInterceptor.java
+++ b/src/main/java/com/ultikits/ultitools/aop/TransactionInterceptor.java
@@ -166,28 +166,68 @@ public class TransactionInterceptor implements MethodInterceptor {
 
     /**
      * Determines if the transaction should be rolled back for the given exception.
+     * <p>
+     * Additive, depth-ordered combination of {@code rollbackFor} and {@code noRollbackFor}
+     * (D-06/D-07 - confirmed by the maintainer during 02-06's checkpoint, matching Spring's
+     * {@code RuleBasedTransactionAttribute}): each array is checked for its shallowest matching
+     * inheritance depth via {@link #shallowestMatchDepth(Throwable, Class[])}. When both arrays
+     * match, the shallower depth wins; an exact-depth tie - including the same exception class
+     * listed in both arrays - favours rollback. When only one array matches, that one decides.
+     * When neither matches (including when both arrays are empty), this falls through to the
+     * unchanged {@code RuntimeException}/{@code Error} default - a non-empty {@code rollbackFor}
+     * with no match no longer short-circuits to "commit" the way it did before this fix.
      */
     private boolean shouldRollback(Throwable e, Transactional tx) {
-        // Check noRollbackFor first
-        for (Class<? extends Throwable> noRollback : tx.noRollbackFor()) {
-            if (noRollback.isInstance(e)) {
-                return false;
-            }
-        }
+        Integer rollbackDepth = shallowestMatchDepth(e, tx.rollbackFor());
+        Integer noRollbackDepth = shallowestMatchDepth(e, tx.noRollbackFor());
 
-        // Check rollbackFor
-        Class<? extends Throwable>[] rollbackFor = tx.rollbackFor();
-        if (rollbackFor.length > 0) {
-            for (Class<? extends Throwable> rollback : rollbackFor) {
-                if (rollback.isInstance(e)) {
-                    return true;
-                }
-            }
-            // rollbackFor specified but exception doesn't match - don't rollback
+        if (rollbackDepth != null && noRollbackDepth != null) {
+            // Tie favours rollback: this is the "should have rolled back" failure direction,
+            // chosen deliberately over silently committing.
+            return rollbackDepth <= noRollbackDepth;
+        }
+        if (rollbackDepth != null) {
+            return true;
+        }
+        if (noRollbackDepth != null) {
             return false;
         }
 
-        // Default: rollback for RuntimeException and Error
+        // Neither rule matched (or both arrays are empty) - fall through to the default.
         return e instanceof RuntimeException || e instanceof Error;
+    }
+
+    /**
+     * Returns the shallowest inheritance depth at which {@code thrown}'s runtime class matches any
+     * rule in {@code rules}, or {@code null} if none match. Depth 0 is an exact class match; each
+     * step up {@code thrown}'s superclass chain toward a matching rule adds 1.
+     */
+    private Integer shallowestMatchDepth(Throwable thrown, Class<? extends Throwable>[] rules) {
+        Integer shallowest = null;
+        for (Class<? extends Throwable> rule : rules) {
+            if (rule.isInstance(thrown)) {
+                int depth = inheritanceDepth(thrown.getClass(), rule);
+                if (shallowest == null || depth < shallowest) {
+                    shallowest = depth;
+                }
+            }
+        }
+        return shallowest;
+    }
+
+    /**
+     * Walks {@code thrownClass}'s superclass chain to find the depth at which it matches {@code
+     * ruleClass}. Callers only reach this after confirming {@code ruleClass.isInstance(...)} of an
+     * instance of {@code thrownClass} already holds, so the walk is guaranteed to terminate at
+     * {@code ruleClass} rather than at {@code null}.
+     */
+    private int inheritanceDepth(Class<?> thrownClass, Class<?> ruleClass) {
+        int depth = 0;
+        Class<?> current = thrownClass;
+        while (current != null && !current.equals(ruleClass)) {
+            current = current.getSuperclass();
+            depth++;
+        }
+        return depth;
     }
 }

--- a/src/main/java/com/ultikits/ultitools/api/ExternalPluginAdapter.java
+++ b/src/main/java/com/ultikits/ultitools/api/ExternalPluginAdapter.java
@@ -7,6 +7,7 @@ import java.util.logging.Logger;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import com.ultikits.ultitools.context.SimpleContainer;
+import com.ultikits.ultitools.manager.DataScope;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -40,6 +41,19 @@ public class ExternalPluginAdapter {
     @Getter
     @Setter
     private boolean connected;
+    /**
+     * The credential {@code PluginManager.registerExternal} mints for this adapter (D-17), set
+     * immediately after minting and before {@code wireAop} runs. {@code null} only in the brief
+     * window between adapter construction and that assignment.
+     * <p>
+     * {@code PluginManager.registerExternal} 为该适配器铸造的凭证（D-17），铸造后、
+     * {@code wireAop} 运行前立即设置。仅在适配器构造完成到该赋值之间的短暂窗口内为 {@code null}。
+     *
+     * @since 6.3.0
+     */
+    @Getter
+    @Setter
+    private DataScope dataScope;
 
     public ExternalPluginAdapter(JavaPlugin javaPlugin) {
         this.javaPlugin = javaPlugin;

--- a/src/main/java/com/ultikits/ultitools/api/UltiToolsAPI.java
+++ b/src/main/java/com/ultikits/ultitools/api/UltiToolsAPI.java
@@ -122,19 +122,34 @@ public final class UltiToolsAPI {
 
     /**
      * Get a DataOperator for an external plugin's data entity.
-     * Data is stored in the plugin's own data folder.
+     * Data is stored in the plugin's own data folder. Refuses outright if {@code dataEntity} is
+     * not registered to {@code plugin} (D-14) -- checked against the same {@link
+     * com.ultikits.ultitools.manager.DataScope} minted for this plugin at {@code connect(...)}
+     * time, via the same refusal {@code DataStore.getOperator(DataScope, Class)} builds, so the
+     * exception type, error code, and message shape are identical regardless of which entry point
+     * a caller reaches.
      * <p>
-     * 获取外部插件的数据操作器。数据存储在插件自己的数据文件夹中。
+     * 获取外部插件的数据操作器。数据存储在插件自己的数据文件夹中。若 {@code dataEntity} 未向
+     * {@code plugin} 注册则直接拒绝（D-14）——校验依据是该插件 {@code connect(...)} 时铸造的同一个
+     * {@link com.ultikits.ultitools.manager.DataScope}，构造拒绝信息的方式与
+     * {@code DataStore.getOperator(DataScope, Class)} 完全相同，因此无论调用方走到哪一个入口，
+     * 异常类型、错误码和消息形态都一致。
      *
      * @param plugin the external JavaPlugin
      * @param dataEntity the data entity class (must have @Table annotation)
      * @param <T> entity type
      * @return data operator
+     * @throws com.ultikits.ultitools.exceptions.DataAccessException if {@code dataEntity} is not
+     *         registered to {@code plugin}
      */
     public static <T extends BaseDataEntity<String>> DataOperator<T> getDataOperator(JavaPlugin plugin, Class<T> dataEntity) {
         ExternalPluginAdapter adapter = adapters.get(plugin);
         if (adapter == null) {
             throw new IllegalStateException("Plugin " + plugin.getName() + " is not connected to UltiTools");
+        }
+        com.ultikits.ultitools.manager.DataScope scope = adapter.getDataScope();
+        if (scope != null && !scope.owns(dataEntity)) {
+            throw scope.refusalFor(dataEntity);
         }
         return UltiTools.getInstance().getDataStore().getOperator(adapter.getDataFolder(), dataEntity);
     }

--- a/src/main/java/com/ultikits/ultitools/api/UltiToolsAPI.java
+++ b/src/main/java/com/ultikits/ultitools/api/UltiToolsAPI.java
@@ -47,6 +47,29 @@ public final class UltiToolsAPI {
      * @throws IllegalStateException if UltiTools is not loaded
      */
     public static void connect(JavaPlugin plugin) {
+        connect(plugin, new Class<?>[0]);
+    }
+
+    /**
+     * Connect an external Bukkit plugin to UltiTools framework, declaring entity classes that
+     * legitimately live outside the plugin's own JAR (D-19) -- a shared library JAR, or a
+     * multi-module build's common artifact. The plugin's own JAR is always scanned for
+     * {@code @Table} classes automatically; {@code additionalEntities} is additive to that scan,
+     * not a replacement for it. The single-argument {@link #connect(JavaPlugin)} overload is
+     * unchanged and delegates here with an empty array.
+     * <p>
+     * 将外部 Bukkit 插件连接到 UltiTools 框架，并声明合法存放在插件自身 JAR 之外的实体类
+     * （D-19）——共享库 JAR，或多模块构建的公共产物。插件自身 JAR 中的 {@code @Table} 类始终会
+     * 被自动扫描；{@code additionalEntities} 是对该扫描结果的补充，而非替代。单参数的
+     * {@link #connect(JavaPlugin)} 重载保持不变，以空数组委托到本方法。
+     *
+     * @param plugin            the external JavaPlugin to connect <br> 待连接的外部 JavaPlugin
+     * @param additionalEntities entity classes owned by this plugin that live outside its own JAR
+     *                            <br> 该插件拥有、但存放在自身 JAR 之外的实体类
+     * @throws IllegalStateException if UltiTools is not loaded
+     * @since 6.3.0
+     */
+    public static void connect(JavaPlugin plugin, Class<?>... additionalEntities) {
         if (UltiTools.getInstance() == null) {
             throw new IllegalStateException("UltiTools is not loaded! Add 'depend: [UltiTools]' to your plugin.yml");
         }
@@ -60,7 +83,7 @@ public final class UltiToolsAPI {
         adapters.put(plugin, adapter);
 
         try {
-            UltiTools.getInstance().getPluginManager().registerExternal(adapter);
+            UltiTools.getInstance().getPluginManager().registerExternal(adapter, additionalEntities);
             adapter.setConnected(true);
             Bukkit.getLogger().log(Level.INFO,
                     "[UltiTools-API] External plugin connected: " + plugin.getName() + " v" + adapter.getVersion());

--- a/src/main/java/com/ultikits/ultitools/api/UltiToolsAPI.java
+++ b/src/main/java/com/ultikits/ultitools/api/UltiToolsAPI.java
@@ -58,15 +58,36 @@ public final class UltiToolsAPI {
      * not a replacement for it. The single-argument {@link #connect(JavaPlugin)} overload is
      * unchanged and delegates here with an empty array.
      * <p>
+     * <b>{@code additionalEntities} is validated, not trusted (02-14).</b> Each class must live on
+     * {@code plugin}'s own classpath -- either its own JAR, or a jar/module not already known to
+     * belong to a different, currently-loaded plugin. A class that structurally belongs to a
+     * DIFFERENT plugin (its own JAR, or one already recorded as owned by another plugin) is
+     * refused with an {@link IllegalStateException} wrapping a
+     * {@code com.ultikits.ultitools.exceptions.PluginModuleException}, and no partial registration
+     * is left behind -- {@code additionalEntities} cannot be used to obtain a working
+     * {@link DataOperator} for another plugin's entity, only to declare entities this plugin
+     * genuinely owns but does not package.
+     * <p>
      * 将外部 Bukkit 插件连接到 UltiTools 框架，并声明合法存放在插件自身 JAR 之外的实体类
      * （D-19）——共享库 JAR，或多模块构建的公共产物。插件自身 JAR 中的 {@code @Table} 类始终会
      * 被自动扫描；{@code additionalEntities} 是对该扫描结果的补充，而非替代。单参数的
      * {@link #connect(JavaPlugin)} 重载保持不变，以空数组委托到本方法。
+     * <p>
+     * <b>{@code additionalEntities} 会被校验，而非被信任（02-14）。</b>其中每一个类都必须存放在
+     * {@code plugin} 自身的 classpath 上——要么是它自己的 JAR，要么是一个尚未被记录为归属于
+     * 另一个当前已加载插件的 jar/模块。若某个类在结构上被确认属于另一个不同的插件（它自身的
+     * JAR，或已记录归属于另一个插件），则会被拒绝，抛出包裹了
+     * {@code com.ultikits.ultitools.exceptions.PluginModuleException} 的
+     * {@link IllegalStateException}，且不会留下任何部分注册的状态——{@code additionalEntities}
+     * 无法被用来获得另一个插件实体的可用 {@link DataOperator}，只能用来声明本插件确实拥有、
+     * 但未打包在自身 JAR 中的实体。
      *
      * @param plugin            the external JavaPlugin to connect <br> 待连接的外部 JavaPlugin
      * @param additionalEntities entity classes owned by this plugin that live outside its own JAR
      *                            <br> 该插件拥有、但存放在自身 JAR 之外的实体类
-     * @throws IllegalStateException if UltiTools is not loaded
+     * @throws IllegalStateException if UltiTools is not loaded, or if an entity in
+     *                                {@code additionalEntities} does not live on {@code plugin}'s
+     *                                own classpath (02-14)
      * @since 6.3.0
      */
     public static void connect(JavaPlugin plugin, Class<?>... additionalEntities) {

--- a/src/main/java/com/ultikits/ultitools/api/UltiToolsAPI.java
+++ b/src/main/java/com/ultikits/ultitools/api/UltiToolsAPI.java
@@ -129,11 +129,30 @@ public final class UltiToolsAPI {
      * exception type, error code, and message shape are identical regardless of which entry point
      * a caller reaches.
      * <p>
+     * <strong>02-13 (CR-03):</strong> before this, {@code scope.owns(...)} was checked here inline
+     * and this method then delegated to the deprecated {@code getOperator(File, Class)} overload
+     * directly -- so {@code DataStore.getOperator(DataScope, Class)}, the method D-17/02-07 built
+     * specifically as the credential-typed supported path, had zero real callers anywhere in the
+     * framework. This now routes through it, so production actually uses the path it was built
+     * for. {@code scope} is normally non-null by the time a connected plugin calls this (set by
+     * {@code PluginManager.registerExternal} right after minting); the {@code null} fallback below
+     * only covers an adapter that predates that wiring, where the deprecated overload's own {@code
+     * checkOwnership(...)} call still refuses correctly on its own.
+     * <p>
      * 获取外部插件的数据操作器。数据存储在插件自己的数据文件夹中。若 {@code dataEntity} 未向
      * {@code plugin} 注册则直接拒绝（D-14）——校验依据是该插件 {@code connect(...)} 时铸造的同一个
      * {@link com.ultikits.ultitools.manager.DataScope}，构造拒绝信息的方式与
      * {@code DataStore.getOperator(DataScope, Class)} 完全相同，因此无论调用方走到哪一个入口，
      * 异常类型、错误码和消息形态都一致。
+     * <p>
+     * <strong>02-13（CR-03）：</strong>在此之前，这里内联检查 {@code scope.owns(...)}，然后本方法
+     * 直接委托给已废弃的 {@code getOperator(File, Class)} 重载——于是
+     * {@code DataStore.getOperator(DataScope, Class)}，即 D-17/02-07 专门构建的、携带凭证的受支持
+     * 路径，在整个框架里没有任何真实调用方。现在改为通过它路由，生产环境真正用上了它当初构建的
+     * 目的。到已连接插件调用本方法时 {@code scope} 通常已经非空（由
+     * {@code PluginManager.registerExternal} 在铸造之后立即设置）；下面的 {@code null} 回退分支只
+     * 覆盖早于该接入逻辑的 adapter，此时已废弃重载自身的 {@code checkOwnership(...)} 调用依然能
+     * 正确拒绝。
      *
      * @param plugin the external JavaPlugin
      * @param dataEntity the data entity class (must have @Table annotation)
@@ -148,8 +167,8 @@ public final class UltiToolsAPI {
             throw new IllegalStateException("Plugin " + plugin.getName() + " is not connected to UltiTools");
         }
         com.ultikits.ultitools.manager.DataScope scope = adapter.getDataScope();
-        if (scope != null && !scope.owns(dataEntity)) {
-            throw scope.refusalFor(dataEntity);
+        if (scope != null) {
+            return UltiTools.getInstance().getDataStore().getOperator(scope, dataEntity);
         }
         return UltiTools.getInstance().getDataStore().getOperator(adapter.getDataFolder(), dataEntity);
     }

--- a/src/main/java/com/ultikits/ultitools/entities/WhereCondition.java
+++ b/src/main/java/com/ultikits/ultitools/entities/WhereCondition.java
@@ -28,6 +28,10 @@ public class WhereCondition {
     private Object value;
     /**
      * 查询的运算符
+     * <p>
+     * Always non-null: {@code @Builder.Default} guarantees {@link Comparison#EQUAL} when the
+     * builder does not set it explicitly, so no relational WHERE builder has to null-check this
+     * field before mapping it to a SQL operator.
      */
     @Builder.Default
     private Comparison comparison = Comparison.EQUAL;

--- a/src/main/java/com/ultikits/ultitools/exceptions/ErrorCode.java
+++ b/src/main/java/com/ultikits/ultitools/exceptions/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     DATA_ENTITY_INVALID(3007, "Data entity invalid"),
     DATA_OPERATION_FAILED(3008, "Data operation failed"),
     TRANSACTION_ROLLBACK_ONLY(3009, "Transaction was marked rollback-only by a nested scope"),
+    ENTITY_NOT_OWNED(3010, "Entity is not owned by the requesting plugin"),
 
     // ===== Command Errors (4000-4999) =====
     COMMAND_ERROR(4000, "Command error"),

--- a/src/main/java/com/ultikits/ultitools/exceptions/ErrorCode.java
+++ b/src/main/java/com/ultikits/ultitools/exceptions/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     TRANSACTION_FAILED(3006, "Transaction failed"),
     DATA_ENTITY_INVALID(3007, "Data entity invalid"),
     DATA_OPERATION_FAILED(3008, "Data operation failed"),
+    TRANSACTION_ROLLBACK_ONLY(3009, "Transaction was marked rollback-only by a nested scope"),
 
     // ===== Command Errors (4000-4999) =====
     COMMAND_ERROR(4000, "Command error"),

--- a/src/main/java/com/ultikits/ultitools/exceptions/UnexpectedRollbackException.java
+++ b/src/main/java/com/ultikits/ultitools/exceptions/UnexpectedRollbackException.java
@@ -1,0 +1,78 @@
+package com.ultikits.ultitools.exceptions;
+
+/**
+ * Signals that a transaction's outer {@code commit()} found the transaction already marked
+ * rollback-only by a nested scope, and performed a real rollback instead of committing.
+ * <p>
+ * This is the analogue of the signal a Spring-family container raises
+ * ({@code org.springframework.transaction.UnexpectedRollbackException}) when an outer commit
+ * discovers an inner scope already decided the whole transaction cannot succeed. Before D-08, the
+ * inner scope's decision was discarded silently - the outer {@code commit()} logged a WARNING and
+ * returned normally, leaving the caller believing its work was persisted when it was not. Throwing
+ * this instead makes that outcome observable.
+ * <p>
+ * 标记外层 {@code commit()} 发现事务已被内层作用域标记为「只能回滚」，因而执行了真正的回滚
+ * 而非提交。这是 Spring 系容器中同类信号
+ * （{@code org.springframework.transaction.UnexpectedRollbackException}）在本框架里的对应物：
+ * 外层提交发现内层作用域已经判定整个事务无法成功。D-08 之前，内层的这一判定会被静默丢弃——
+ * 外层 {@code commit()} 只记一条 WARNING 便正常返回，调用方会误以为自己的工作已经持久化，
+ * 实际并未发生。改为抛出该异常后，这一结果不再是静默的。
+ *
+ * @author wisdomme
+ * @since 6.3.0
+ */
+public class UnexpectedRollbackException extends UltiToolsException {
+
+    /**
+     * Creates a new unexpected-rollback exception with a generic error code.
+     *
+     * @param message the error message
+     */
+    public UnexpectedRollbackException(String message) {
+        super(ErrorCode.TRANSACTION_ROLLBACK_ONLY, message);
+    }
+
+    /**
+     * Creates a new unexpected-rollback exception with a specific error code.
+     *
+     * @param errorCode the error code
+     * @param message   the error message
+     */
+    public UnexpectedRollbackException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    /**
+     * Creates a new unexpected-rollback exception with message and cause.
+     *
+     * @param message the error message
+     * @param cause   the underlying cause
+     */
+    public UnexpectedRollbackException(String message, Throwable cause) {
+        super(ErrorCode.TRANSACTION_ROLLBACK_ONLY, message, cause);
+    }
+
+    /**
+     * Creates a new unexpected-rollback exception with error code, message, and cause.
+     *
+     * @param errorCode the error code
+     * @param message   the error message
+     * @param cause     the underlying cause
+     */
+    public UnexpectedRollbackException(ErrorCode errorCode, String message, Throwable cause) {
+        super(errorCode, message, cause);
+    }
+
+    /**
+     * Creates an exception naming the nested scope that marked the transaction rollback-only.
+     *
+     * @param origin a description of the nested scope that set the marker (e.g. a method name or
+     *               transaction depth) - included verbatim in the message
+     * @return a new UnexpectedRollbackException
+     */
+    public static UnexpectedRollbackException markedBy(String origin) {
+        return new UnexpectedRollbackException(ErrorCode.TRANSACTION_ROLLBACK_ONLY,
+                "Transaction was marked rollback-only by " + origin
+                        + "; the outer commit() performed a real rollback instead of committing.");
+    }
+}

--- a/src/main/java/com/ultikits/ultitools/interfaces/DataOperator.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/DataOperator.java
@@ -105,7 +105,16 @@ public interface DataOperator<T extends BaseDataEntity<String>> {
     /**
      * Delete data record by conditions.
      * <p>
+     * Since 6.3.0, a call with no conditions (a {@code null} or zero-length
+     * {@code whereConditions}) is rejected with a {@code DataAccessException} instead of
+     * deleting every row of the table — this is a behavioral change with no migration period
+     * (COMPATIBILITY.md's security-fix channel); see 02-CONTEXT.md D-12.
+     * <p>
      * 按照条件删除记录
+     * <br>
+     * 自 6.3.0 起，不带任何条件调用（{@code whereConditions} 为 {@code null} 或空数组）会直接
+     * 抛出 {@code DataAccessException}，而不是清空整张表——这是一项没有迁移期的行为变更
+     * （COMPATIBILITY.md 的安全修复通道），详见 02-CONTEXT.md D-12。
      *
      * @param whereConditions Conditions <br> 条件参数
      */

--- a/src/main/java/com/ultikits/ultitools/interfaces/DataStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/DataStore.java
@@ -2,6 +2,7 @@ package com.ultikits.ultitools.interfaces;
 
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
+import com.ultikits.ultitools.manager.DataScope;
 
 /**
  * Data storage interface.
@@ -43,6 +44,21 @@ public interface DataStore {
      */
     default <T extends BaseDataEntity<String>> DataOperator<T> getOperator(java.io.File dataFolder, Class<T> dataEntity) {
         throw new UnsupportedOperationException("This DataStore does not support external plugin data storage");
+    }
+
+    /**
+     * Get the JDBC {@link javax.sql.DataSource} backing this store for the given scope, needing
+     * no entity class up front (a connection pool needs only a JDBC URL).
+     * <p>
+     * 获取该存储针对给定 scope 的底层 JDBC {@link javax.sql.DataSource}，无需预先给出实体类
+     * （连接池只需要 JDBC URL）。非 JDBC 存储（如 JSON 后端）预期保留此默认实现。
+     *
+     * @param scope the requesting scope <br> 请求方的 scope
+     * @return the JDBC data source for that scope <br> 该 scope 对应的 JDBC 数据源
+     * @since 6.3.0
+     */
+    default javax.sql.DataSource getDataSource(DataScope scope) {
+        throw new UnsupportedOperationException("This DataStore (" + getStoreType() + ") does not expose a JDBC DataSource");
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/interfaces/DataStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/DataStore.java
@@ -28,21 +28,80 @@ public interface DataStore {
      * @param dataEntity Data entity class <br> 数据实体类
      * @param <T>        Must inherit {@link BaseDataEntity}
      * @return Data operation entity <br> 数据操作实体
+     * @deprecated Carries no ownership check of its own (D-14/D-18) -- a {@code DataStore}
+     *             implementation that overrides this method directly, rather than reaching an
+     *             operator through {@link #getOperator(DataScope, Class)}, does not get the
+     *             refusal. Framework-internal callers ({@code UltiToolsPlugin.getDataOperator})
+     *             already check ownership themselves before calling this. Use {@link
+     *             #getOperator(DataScope, Class)}.
+     *             <p>
+     *             自身不带所有权校验（D-14/D-18）——直接覆写这个方法的 {@code DataStore}
+     *             实现，而不是通过 {@link #getOperator(DataScope, Class)} 获取操作器，
+     *             不会得到拒绝校验。框架内部调用方（{@code UltiToolsPlugin.getDataOperator}）
+     *             在调用它之前已经自行做过所有权校验。请改用
+     *             {@link #getOperator(DataScope, Class)}。
      */
+    @Deprecated(since = "6.3.0", forRemoval = true)
     <T extends BaseDataEntity<String>> DataOperator<T> getOperator(UltiToolsPlugin plugin, Class<T> dataEntity);
 
     /**
-     * Get data operator for an external plugin, scoped to the plugin's own data folder.
+     * Get data operator for an external plugin, scoped to the plugin's own data folder. Refuses
+     * outright (D-18) when {@code dataFolder} resolves to a registered external plugin's scope
+     * that does not own {@code dataEntity}, or when {@code dataFolder} matches no registered
+     * scope at all -- an unresolvable folder fails closed rather than proceeding unchecked (D-15).
+     * A {@code DataStore} that overrides this method directly (as every backend shipped by this
+     * framework does) does not inherit this check; see the {@code @deprecated} note.
      * <p>
-     * 获取外部插件的数据操作器，数据范围限定在插件自己的数据文件夹中。
+     * 获取外部插件的数据操作器，数据范围限定在插件自己的数据文件夹中。当 {@code dataFolder}
+     * 解析到的已注册外部插件 scope 并不拥有 {@code dataEntity} 时，或 {@code dataFolder}
+     * 完全不匹配任何已注册 scope 时，直接拒绝（D-18）——无法解析的文件夹按 fail-closed 处理，
+     * 而不是不加校验地放行（D-15）。直接覆写这个方法的 {@code DataStore}（本框架自带的每个
+     * 后端都是如此）不会继承这项校验；见 {@code @deprecated} 说明。
      *
      * @param dataFolder the external plugin's data folder (e.g., plugins/MyPlugin/)
      * @param dataEntity data entity class
      * @param <T> entity type
      * @return data operator
+     * @throws com.ultikits.ultitools.exceptions.DataAccessException if {@code dataFolder} matches
+     *         no registered scope, or matches one that does not own {@code dataEntity}
      * @since 6.2.2
+     * @deprecated Only enforces D-18's ownership check in its own {@code default} body -- a
+     *             {@code DataStore} implementation that overrides this method directly, rather
+     *             than reaching an operator through {@link #getOperator(DataScope, Class)}, does
+     *             not get the refusal. Framework-internal callers
+     *             ({@code UltiToolsAPI.getDataOperator}) already check ownership themselves before
+     *             calling this. Use {@link #getOperator(DataScope, Class)}.
+     *             <p>
+     *             只在自己的 {@code default} 方法体内强制执行 D-18 的所有权校验——直接覆写这个
+     *             方法的 {@code DataStore} 实现，而不是通过 {@link #getOperator(DataScope, Class)}
+     *             获取操作器，不会得到拒绝校验。框架内部调用方
+     *             （{@code UltiToolsAPI.getDataOperator}）在调用它之前已经自行做过所有权校验。
+     *             请改用 {@link #getOperator(DataScope, Class)}。
      */
+    @Deprecated(since = "6.3.0", forRemoval = true)
     default <T extends BaseDataEntity<String>> DataOperator<T> getOperator(java.io.File dataFolder, Class<T> dataEntity) {
+        com.ultikits.ultitools.UltiTools ultiTools = com.ultikits.ultitools.UltiTools.getInstance();
+        // The reverse lookup only ever registers EXTERNAL scopes (D-18) -- every internal plugin
+        // shares the framework's own data folder (DataScope.forPlugin), so that one folder can
+        // never be attributed to a single owner by folder alone. Skip the check for exactly that
+        // sentinel folder rather than let it always refuse a folder no external scope could ever
+        // register (same disambiguation JsonStore.identityOf(DataScope) already uses, 02-05).
+        boolean isFrameworkCoreFolder = ultiTools != null && ultiTools.getDataFolder() != null
+                && ultiTools.getDataFolder().equals(dataFolder);
+        if (!isFrameworkCoreFolder) {
+            DataScope scope = ultiTools != null && ultiTools.getPluginManager() != null
+                    ? ultiTools.getPluginManager().findScopeForDataFolder(dataFolder)
+                    : null;
+            if (scope == null) {
+                throw new com.ultikits.ultitools.exceptions.DataAccessException(
+                        com.ultikits.ultitools.exceptions.ErrorCode.ENTITY_NOT_OWNED,
+                        "Data folder is not a registered external plugin -- call UltiToolsAPI.connect(...) "
+                                + "before requesting a data operator.");
+            }
+            if (!scope.owns(dataEntity)) {
+                throw scope.refusalFor(dataEntity);
+            }
+        }
         throw new UnsupportedOperationException("This DataStore does not support external plugin data storage");
     }
 

--- a/src/main/java/com/ultikits/ultitools/interfaces/DataStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/DataStore.java
@@ -90,24 +90,46 @@ public interface DataStore {
      * (D-14/D-18/02-12). Called both by this interface's own {@code default} body above and, as
      * the first statement (before any path resolution, cache lookup, or connection-pool creation),
      * by the {@code getOperator(File, Class)} override of every backend this framework ships --
-     * so a refused call has not created a pool, a file, or a cache entry as a side effect. The
-     * reverse lookup only ever registers EXTERNAL scopes (D-18) -- every internal plugin shares
-     * the framework's own data folder ({@code DataScope.forPlugin}), so that one folder can never
-     * be attributed to a single owner by folder alone. The framework's own core data folder is
-     * exempt from the reverse-lookup refusal for exactly that reason (same disambiguation
-     * {@code JsonStore.identityOf(DataScope)} already uses, 02-05) -- it is also what lets {@link
-     * #getOperator(DataScope, Class)}'s delegation reach an INTERNAL scope's own {@code
-     * getOperator(File, Class)} without being refused a second time.
+     * so a refused call has not created a pool, a file, or a cache entry as a side effect.
+     * <p>
+     * The reverse lookup only ever registers EXTERNAL scopes (D-18) -- every internal plugin
+     * shares the framework's own data folder ({@code DataScope.forPlugin}), so that one folder can
+     * never be attributed to a single owner by folder alone, and any call reaching here with the
+     * framework's own core data folder is refused exactly like any other unregistered folder.
+     * <strong>Before 02-13 this method exempted the framework's own core data folder from the
+     * reverse-lookup refusal</strong>, on the reasoning that {@link #getOperator(DataScope, Class)}
+     * needed to reach an INTERNAL scope's own {@code getOperator(File, Class)} without being
+     * refused a second time. CR-01 (02-REVIEW.md) found that exemption was keyed purely on the
+     * <em>value</em> of {@code dataFolder} -- and {@code UltiTools#getDataFolder()} is {@code
+     * public} in the published jar, the exact fact D-17's own javadoc names as the reason {@link
+     * DataScope} had to be unforgeable -- not on any credential or caller identity, so any code
+     * sharing the JVM could reach it. On {@code MysqlDataStore} this was a genuine,
+     * unauthenticated read/write bypass onto another module's real table (there is exactly one
+     * global {@code DataSource} for the whole server). 02-13's fix: {@link
+     * #getOperator(DataScope, Class)} no longer routes an INTERNAL scope through this method at
+     * all -- it resolves directly via an internal, unchecked construction path (see {@code
+     * getOperatorUnchecked} on the framework's three shipped backends) that never touches this
+     * check, so no exemption is needed here anymore.
      * <p>
      * {@link #getOperator(java.io.File, Class)} 旧重载的共享所有权校验（D-14/D-18/02-12）。既被
      * 本接口上面的 {@code default} 方法体调用，也被本框架自带的每一个后端在其
      * {@code getOperator(File, Class)} 覆写方法体的第一条语句（先于任何路径解析、缓存查找或连接池
-     * 创建）调用——因此被拒绝的调用不会产生连接池、文件或缓存条目这类副作用。反向查找只会登记
-     * EXTERNAL scope（D-18）——每个内部插件共享的都是框架自己的数据文件夹（{@code
-     * DataScope.forPlugin}），单靠文件夹本身永远无法把它归属到某一个所有者。框架自己的核心数据
-     * 文件夹正因如此被排除在反向查找拒绝之外（与 {@code JsonStore.identityOf(DataScope)}
-     * 已经使用的判别方式相同，02-05）——这也是 {@link #getOperator(DataScope, Class)} 的委托能够
-     * 到达 INTERNAL scope 自己的 {@code getOperator(File, Class)} 而不被二次拒绝的原因。
+     * 创建）调用——因此被拒绝的调用不会产生连接池、文件或缓存条目这类副作用。
+     * <p>
+     * 反向查找只会登记 EXTERNAL scope（D-18）——每个内部插件共享的都是框架自己的数据文件夹
+     * （{@code DataScope.forPlugin}），单靠文件夹本身永远无法把它归属到某一个所有者，因此任何
+     * 携带框架自身核心数据文件夹到达这里的调用，都会像任何其他未注册文件夹一样被拒绝。
+     * <strong>02-13 之前，本方法把框架自己的核心数据文件夹排除在反向查找拒绝之外</strong>，理由是
+     * {@link #getOperator(DataScope, Class)} 需要让 INTERNAL scope 到达自己的
+     * {@code getOperator(File, Class)} 而不被二次拒绝。CR-01（02-REVIEW.md）发现那个豁免仅仅依据
+     * {@code dataFolder} 的「值」来判断——而 {@code UltiTools#getDataFolder()} 在已发布 jar 中是
+     * {@code public} 的，正是 D-17 自己 javadoc 里点名的、{@link DataScope} 之所以必须无法伪造的
+     * 那个事实——而不是依据任何凭证或调用方身份，因此共享同一 JVM 的任何代码都能触达它。在
+     * {@code MysqlDataStore} 上这是一个真实的、未经身份验证的读写绕过，直接触及另一个模块的真实表
+     * （整个服务器只有一个全局 {@code DataSource}）。02-13 的修复：{@link
+     * #getOperator(DataScope, Class)} 不再让 INTERNAL scope 经过本方法——它改为通过一条内部的、
+     * 不带校验的构造路径直接解析（见本框架三个自带后端各自的 {@code getOperatorUnchecked}），
+     * 这条路径完全不会触及本检查，因此这里也就不再需要任何豁免了。
      *
      * @param dataFolder the external plugin's data folder <br> 外部插件的数据文件夹
      * @param dataEntity data entity class <br> 数据实体类
@@ -119,11 +141,6 @@ public interface DataStore {
      */
     default void checkOwnership(java.io.File dataFolder, Class<?> dataEntity) {
         com.ultikits.ultitools.UltiTools ultiTools = com.ultikits.ultitools.UltiTools.getInstance();
-        boolean isFrameworkCoreFolder = ultiTools != null && ultiTools.getDataFolder() != null
-                && ultiTools.getDataFolder().equals(dataFolder);
-        if (isFrameworkCoreFolder) {
-            return;
-        }
         DataScope scope = ultiTools != null && ultiTools.getPluginManager() != null
                 ? ultiTools.getPluginManager().findScopeForDataFolder(dataFolder)
                 : null;
@@ -232,6 +249,15 @@ public interface DataStore {
      * this method: there is no credential to skip checking, because there is no way to obtain one
      * that was not already checked at minting time.
      * <p>
+     * <strong>02-13 (CR-01):</strong> the check above used to delegate to {@link
+     * #getOperator(java.io.File, Class)} for every scope, internal or external -- which for an
+     * INTERNAL scope meant reaching {@link #checkOwnership(java.io.File, Class)}'s now-removed
+     * core-folder exemption. It now delegates to {@link #getOperatorUnchecked(DataScope, Class)}
+     * instead, an internal construction path with no ownership check of its own, reachable only
+     * after this method's own {@code scope.owns(...)} check has already passed -- so the
+     * unforgeability guarantee above is no longer contingent on a second method's exemption logic
+     * agreeing with it.
+     * <p>
      * 获取 {@code scope} 拥有的实体的数据操作器，不拥有时直接拒绝（D-14）。该凭证由框架签发且
      * 无法伪造（{@code DataScope} 的构造器和静态工厂方法对 {@code manager} 包之外均为包私有），
      * 因此这是受支持的路径：与 {@link #getOperator(UltiToolsPlugin, Class)} 和
@@ -248,6 +274,13 @@ public interface DataStore {
      * {@link #checkOwnership(UltiToolsPlugin, Class)}，就会为那一个重载重新打开绕过的口子——
      * 除了约定（以及这段 javadoc）之外，没有任何机制能拦住它。本方法不存在这种缺口：没有凭证可以
      * 跳过校验，因为根本不存在一种获取凭证的方式，而这种方式在铸造时没有被校验过。
+     * <p>
+     * <strong>02-13（CR-01）：</strong>上面这个检查过去会把每一个 scope（无论内部还是外部）都
+     * 委托给 {@link #getOperator(java.io.File, Class)} 处理——对 INTERNAL scope 而言，这意味着
+     * 会走到 {@link #checkOwnership(java.io.File, Class)} 现已删除的核心文件夹豁免逻辑。现在它改为
+     * 委托给 {@link #getOperatorUnchecked(DataScope, Class)}——一条自身不带所有权校验的内部构造
+     * 路径，只有在本方法自己的 {@code scope.owns(...)} 检查已经通过之后才能到达——因此上面说的
+     * 「无法伪造」这个保证，不再依赖另一个方法的豁免逻辑是否与它保持一致。
      *
      * @param scope      the requesting scope <br> 请求方的 scope
      * @param dataEntity data entity class <br> 数据实体类
@@ -261,7 +294,53 @@ public interface DataStore {
         if (!scope.owns(dataEntity)) {
             throw scope.refusalFor(dataEntity);
         }
-        return getOperator(scope.getDataFolder(), dataEntity);
+        return getOperatorUnchecked(scope, dataEntity);
+    }
+
+    /**
+     * Internal, unchecked construction path used ONLY by {@link #getOperator(DataScope, Class)},
+     * called after its own {@code scope.owns(...)} check has already passed (CR-01, 02-13).
+     * Building the actual operator -- path/identity resolution, connection-pool cache, operator
+     * cache, {@code transactionManagerFor(...)} wiring -- is exactly what the legacy overloads
+     * have always done for the internal/external shape {@code scope} resolves to; what changed is
+     * that {@link #getOperator(DataScope, Class)} no longer reaches that construction logic via
+     * the public, previously ownership-exempt {@link #getOperator(java.io.File, Class)} overload.
+     * <p>
+     * This member is technically {@code public} -- Java gives interface members no narrower
+     * visibility -- but it is not reachable as a bypass: nothing outside the {@code manager}
+     * package can construct a {@link DataScope} to pass to it (the same unforgeability {@link
+     * #getOperator(DataScope, Class)} itself relies on), so a caller able to invoke this method at
+     * all already holds a scope it could just as validly pass to the checked entry point instead.
+     * It is not part of the officially-extensible {@link DataStore} contract in the same sense the
+     * other members are; the default throws, matching the same "backend does not support this by
+     * default" posture {@link #getDataSource(DataScope)} already uses. The three backends this
+     * framework ships each override it.
+     * <p>
+     * 仅供 {@link #getOperator(DataScope, Class)} 内部使用的、不带校验的构造路径，只有在它自己的
+     * {@code scope.owns(...)} 检查已经通过之后才会被调用（CR-01，02-13）。构造操作器本身——路径/
+     * 身份解析、连接池缓存、操作器缓存、{@code transactionManagerFor(...)} 装配——与旧重载对
+     * {@code scope} 所解析出的内部/外部两种形态一直以来的做法完全相同；变化的只是
+     * {@link #getOperator(DataScope, Class)} 不再通过公开的、曾经对所有权豁免的
+     * {@link #getOperator(java.io.File, Class)} 重载来到达这段构造逻辑。
+     * <p>
+     * 这个成员在技术上是 {@code public} 的——Java 不允许接口成员拥有更窄的可见性——但它并不构成
+     * 绕过口子：{@code manager} 包之外没有任何代码能够构造出一个 {@link DataScope} 传给它（与
+     * {@link #getOperator(DataScope, Class)} 自身依赖的不可伪造性完全相同），因此任何能够调用这个
+     * 方法的调用方，手上本就已经握着一个同样能合法传给受校验入口的 scope。它不属于
+     * {@link DataStore} 正式对外开放的扩展契约那一部分；默认实现直接抛出，与
+     * {@link #getDataSource(DataScope)} 已经使用的「后端默认不支持」姿态一致。本框架自带的三个
+     * 后端各自都覆写了它。
+     *
+     * @param scope      the requesting scope, already verified to own {@code dataEntity} <br>
+     *                   请求方的 scope，已确认拥有 {@code dataEntity}
+     * @param dataEntity data entity class <br> 数据实体类
+     * @param <T>        Must inherit {@link BaseDataEntity}
+     * @return data operator for that entity <br> 该实体的数据操作器
+     * @since 6.3.0
+     */
+    default <T extends BaseDataEntity<String>> DataOperator<T> getOperatorUnchecked(DataScope scope, Class<T> dataEntity) {
+        throw new UnsupportedOperationException(
+                "This DataStore (" + getStoreType() + ") does not support DataScope-based operator resolution");
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/interfaces/DataStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/DataStore.java
@@ -218,12 +218,36 @@ public interface DataStore {
      * reaching {@code UltiTools#getDataStore()} directly -- {@code public} in the published jar --
      * still cannot obtain an operator for an entity it does not own.
      * <p>
+     * As of 02-12, the two legacy overloads also refuse an unowned entity -- {@link
+     * #checkOwnership(UltiToolsPlugin, Class)} and {@link #checkOwnership(java.io.File, Class)} run
+     * as the first statement of every backend this framework ships. The distinction this
+     * paragraph draws is narrower than it once was, but still real: this method's credential is
+     * unforgeable by construction, so calling it correctly is impossible to get wrong. The legacy
+     * overloads instead resolve the caller after the fact -- a reverse folder lookup, or an
+     * entity-ownership registry consult -- which only protects a caller when the {@code DataStore}
+     * implementation it reaches has actually wired that resolution in; a hypothetical fourth
+     * implementation that overrides {@link #getOperator(UltiToolsPlugin, Class)} directly without
+     * calling {@link #checkOwnership(UltiToolsPlugin, Class)} would reopen the bypass for that one
+     * overload, with nothing but convention (and this javadoc) stopping it. No such gap exists for
+     * this method: there is no credential to skip checking, because there is no way to obtain one
+     * that was not already checked at minting time.
+     * <p>
      * 获取 {@code scope} 拥有的实体的数据操作器，不拥有时直接拒绝（D-14）。该凭证由框架签发且
      * 无法伪造（{@code DataScope} 的构造器和静态工厂方法对 {@code manager} 包之外均为包私有），
      * 因此这是受支持的路径：与 {@link #getOperator(UltiToolsPlugin, Class)} 和
      * {@link #getOperator(java.io.File, Class)} 不同，没有只有框架才能签发的 scope 就无法到达
      * 这里——即便调用方直接拿到已发布 jar 中 {@code public} 的 {@code UltiTools#getDataStore()}，
      * 也无法获得一个它不拥有的实体的操作器。
+     * <p>
+     * 从 02-12 起，两个旧重载也会拒绝未拥有的实体——{@link #checkOwnership(UltiToolsPlugin, Class)}
+     * 和 {@link #checkOwnership(java.io.File, Class)} 会作为本框架自带每个后端方法体的第一条语句
+     * 运行。本段落划出的界线比过去窄了，但依然真实：本方法的凭证从构造上就无法伪造，因此正确调用
+     * 它不可能出错。旧重载则是事后解析调用方——反向文件夹查找，或查询实体所有权登记表——这只在
+     * 到达的 {@code DataStore} 实现真的接入了这套解析逻辑时才起保护作用；一个假想的第四个实现，
+     * 如果直接覆写 {@link #getOperator(UltiToolsPlugin, Class)} 却不调用
+     * {@link #checkOwnership(UltiToolsPlugin, Class)}，就会为那一个重载重新打开绕过的口子——
+     * 除了约定（以及这段 javadoc）之外，没有任何机制能拦住它。本方法不存在这种缺口：没有凭证可以
+     * 跳过校验，因为根本不存在一种获取凭证的方式，而这种方式在铸造时没有被校验过。
      *
      * @param scope      the requesting scope <br> 请求方的 scope
      * @param dataEntity data entity class <br> 数据实体类

--- a/src/main/java/com/ultikits/ultitools/interfaces/DataStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/DataStore.java
@@ -62,6 +62,37 @@ public interface DataStore {
     }
 
     /**
+     * Get a data operator for the entity {@code scope} owns, refusing outright when it does not
+     * (D-14). The credential is framework-minted and unforgeable ({@code DataScope}'s constructor
+     * and static factories are package-private to {@code manager}), so this is the supported path:
+     * unlike {@link #getOperator(UltiToolsPlugin, Class)} and {@link #getOperator(java.io.File,
+     * Class)}, it cannot be reached without a scope only the framework can issue, so a caller
+     * reaching {@code UltiTools#getDataStore()} directly -- {@code public} in the published jar --
+     * still cannot obtain an operator for an entity it does not own.
+     * <p>
+     * 获取 {@code scope} 拥有的实体的数据操作器，不拥有时直接拒绝（D-14）。该凭证由框架签发且
+     * 无法伪造（{@code DataScope} 的构造器和静态工厂方法对 {@code manager} 包之外均为包私有），
+     * 因此这是受支持的路径：与 {@link #getOperator(UltiToolsPlugin, Class)} 和
+     * {@link #getOperator(java.io.File, Class)} 不同，没有只有框架才能签发的 scope 就无法到达
+     * 这里——即便调用方直接拿到已发布 jar 中 {@code public} 的 {@code UltiTools#getDataStore()}，
+     * 也无法获得一个它不拥有的实体的操作器。
+     *
+     * @param scope      the requesting scope <br> 请求方的 scope
+     * @param dataEntity data entity class <br> 数据实体类
+     * @param <T>        Must inherit {@link BaseDataEntity}
+     * @return data operator for that entity <br> 该实体的数据操作器
+     * @throws com.ultikits.ultitools.exceptions.DataAccessException if {@code scope} does not own
+     *         {@code dataEntity} <br> 如果 {@code scope} 不拥有 {@code dataEntity}
+     * @since 6.3.0
+     */
+    default <T extends BaseDataEntity<String>> DataOperator<T> getOperator(DataScope scope, Class<T> dataEntity) {
+        if (!scope.owns(dataEntity)) {
+            throw scope.refusalFor(dataEntity);
+        }
+        return getOperator(scope.getDataFolder(), dataEntity);
+    }
+
+    /**
      * Save all possible caches and destroy all data operation classes.
      * <p>
      * 保存所有可能的缓存并销毁所有的数据操作类

--- a/src/main/java/com/ultikits/ultitools/interfaces/DataStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/DataStore.java
@@ -29,17 +29,18 @@ public interface DataStore {
      * @param <T>        Must inherit {@link BaseDataEntity}
      * @return Data operation entity <br> 数据操作实体
      * @deprecated Carries no ownership check of its own (D-14/D-18) -- a {@code DataStore}
-     *             implementation that overrides this method directly, rather than reaching an
-     *             operator through {@link #getOperator(DataScope, Class)}, does not get the
-     *             refusal. Framework-internal callers ({@code UltiToolsPlugin.getDataOperator})
-     *             already check ownership themselves before calling this. Use {@link
-     *             #getOperator(DataScope, Class)}.
+     *             implementation that overrides this method directly must call {@link
+     *             #checkOwnership(UltiToolsPlugin, Class)} as its own first statement to get the
+     *             refusal; the three backends shipped by this framework all do (02-12). Framework-
+     *             internal callers ({@code UltiToolsPlugin.getDataOperator}) already check
+     *             ownership themselves before calling this. Use {@link #getOperator(DataScope,
+     *             Class)}.
      *             <p>
      *             自身不带所有权校验（D-14/D-18）——直接覆写这个方法的 {@code DataStore}
-     *             实现，而不是通过 {@link #getOperator(DataScope, Class)} 获取操作器，
-     *             不会得到拒绝校验。框架内部调用方（{@code UltiToolsPlugin.getDataOperator}）
-     *             在调用它之前已经自行做过所有权校验。请改用
-     *             {@link #getOperator(DataScope, Class)}。
+     *             实现必须自己把 {@link #checkOwnership(UltiToolsPlugin, Class)} 作为方法体的
+     *             第一条语句调用，才能得到拒绝校验；本框架自带的三个后端都是如此（02-12）。
+     *             框架内部调用方（{@code UltiToolsPlugin.getDataOperator}）在调用它之前已经
+     *             自行做过所有权校验。请改用 {@link #getOperator(DataScope, Class)}。
      */
     @Deprecated(since = "6.3.0", forRemoval = true)
     <T extends BaseDataEntity<String>> DataOperator<T> getOperator(UltiToolsPlugin plugin, Class<T> dataEntity);
@@ -65,44 +66,132 @@ public interface DataStore {
      * @throws com.ultikits.ultitools.exceptions.DataAccessException if {@code dataFolder} matches
      *         no registered scope, or matches one that does not own {@code dataEntity}
      * @since 6.2.2
-     * @deprecated Only enforces D-18's ownership check in its own {@code default} body -- a
-     *             {@code DataStore} implementation that overrides this method directly, rather
-     *             than reaching an operator through {@link #getOperator(DataScope, Class)}, does
-     *             not get the refusal. Framework-internal callers
+     * @deprecated Enforces D-18's ownership check via {@link #checkOwnership(java.io.File, Class)}
+     *             as its own first statement -- a {@code DataStore} implementation that overrides
+     *             this method directly must call the same helper to get the refusal; the three
+     *             backends shipped by this framework all do (02-12). Framework-internal callers
      *             ({@code UltiToolsAPI.getDataOperator}) already check ownership themselves before
      *             calling this. Use {@link #getOperator(DataScope, Class)}.
      *             <p>
-     *             只在自己的 {@code default} 方法体内强制执行 D-18 的所有权校验——直接覆写这个
-     *             方法的 {@code DataStore} 实现，而不是通过 {@link #getOperator(DataScope, Class)}
-     *             获取操作器，不会得到拒绝校验。框架内部调用方
+     *             通过在方法体第一条语句调用 {@link #checkOwnership(java.io.File, Class)} 强制执行
+     *             D-18 的所有权校验——直接覆写这个方法的 {@code DataStore} 实现必须调用同一个
+     *             辅助方法才能得到拒绝校验；本框架自带的三个后端都是如此（02-12）。框架内部调用方
      *             （{@code UltiToolsAPI.getDataOperator}）在调用它之前已经自行做过所有权校验。
      *             请改用 {@link #getOperator(DataScope, Class)}。
      */
     @Deprecated(since = "6.3.0", forRemoval = true)
     default <T extends BaseDataEntity<String>> DataOperator<T> getOperator(java.io.File dataFolder, Class<T> dataEntity) {
+        checkOwnership(dataFolder, dataEntity);
+        throw new UnsupportedOperationException("This DataStore does not support external plugin data storage");
+    }
+
+    /**
+     * Shared ownership check for the {@link #getOperator(java.io.File, Class)} legacy overload
+     * (D-14/D-18/02-12). Called both by this interface's own {@code default} body above and, as
+     * the first statement (before any path resolution, cache lookup, or connection-pool creation),
+     * by the {@code getOperator(File, Class)} override of every backend this framework ships --
+     * so a refused call has not created a pool, a file, or a cache entry as a side effect. The
+     * reverse lookup only ever registers EXTERNAL scopes (D-18) -- every internal plugin shares
+     * the framework's own data folder ({@code DataScope.forPlugin}), so that one folder can never
+     * be attributed to a single owner by folder alone. The framework's own core data folder is
+     * exempt from the reverse-lookup refusal for exactly that reason (same disambiguation
+     * {@code JsonStore.identityOf(DataScope)} already uses, 02-05) -- it is also what lets {@link
+     * #getOperator(DataScope, Class)}'s delegation reach an INTERNAL scope's own {@code
+     * getOperator(File, Class)} without being refused a second time.
+     * <p>
+     * {@link #getOperator(java.io.File, Class)} 旧重载的共享所有权校验（D-14/D-18/02-12）。既被
+     * 本接口上面的 {@code default} 方法体调用，也被本框架自带的每一个后端在其
+     * {@code getOperator(File, Class)} 覆写方法体的第一条语句（先于任何路径解析、缓存查找或连接池
+     * 创建）调用——因此被拒绝的调用不会产生连接池、文件或缓存条目这类副作用。反向查找只会登记
+     * EXTERNAL scope（D-18）——每个内部插件共享的都是框架自己的数据文件夹（{@code
+     * DataScope.forPlugin}），单靠文件夹本身永远无法把它归属到某一个所有者。框架自己的核心数据
+     * 文件夹正因如此被排除在反向查找拒绝之外（与 {@code JsonStore.identityOf(DataScope)}
+     * 已经使用的判别方式相同，02-05）——这也是 {@link #getOperator(DataScope, Class)} 的委托能够
+     * 到达 INTERNAL scope 自己的 {@code getOperator(File, Class)} 而不被二次拒绝的原因。
+     *
+     * @param dataFolder the external plugin's data folder <br> 外部插件的数据文件夹
+     * @param dataEntity data entity class <br> 数据实体类
+     * @throws com.ultikits.ultitools.exceptions.DataAccessException if {@code dataFolder} matches
+     *         no registered scope, or matches one that does not own {@code dataEntity} <br>
+     *         如果 {@code dataFolder} 匹配不到任何已注册 scope，或匹配到的 scope 并不拥有
+     *         {@code dataEntity}
+     * @since 6.3.0
+     */
+    default void checkOwnership(java.io.File dataFolder, Class<?> dataEntity) {
         com.ultikits.ultitools.UltiTools ultiTools = com.ultikits.ultitools.UltiTools.getInstance();
-        // The reverse lookup only ever registers EXTERNAL scopes (D-18) -- every internal plugin
-        // shares the framework's own data folder (DataScope.forPlugin), so that one folder can
-        // never be attributed to a single owner by folder alone. Skip the check for exactly that
-        // sentinel folder rather than let it always refuse a folder no external scope could ever
-        // register (same disambiguation JsonStore.identityOf(DataScope) already uses, 02-05).
         boolean isFrameworkCoreFolder = ultiTools != null && ultiTools.getDataFolder() != null
                 && ultiTools.getDataFolder().equals(dataFolder);
-        if (!isFrameworkCoreFolder) {
-            DataScope scope = ultiTools != null && ultiTools.getPluginManager() != null
-                    ? ultiTools.getPluginManager().findScopeForDataFolder(dataFolder)
-                    : null;
-            if (scope == null) {
-                throw new com.ultikits.ultitools.exceptions.DataAccessException(
-                        com.ultikits.ultitools.exceptions.ErrorCode.ENTITY_NOT_OWNED,
-                        "Data folder is not a registered external plugin -- call UltiToolsAPI.connect(...) "
-                                + "before requesting a data operator.");
-            }
-            if (!scope.owns(dataEntity)) {
-                throw scope.refusalFor(dataEntity);
-            }
+        if (isFrameworkCoreFolder) {
+            return;
         }
-        throw new UnsupportedOperationException("This DataStore does not support external plugin data storage");
+        DataScope scope = ultiTools != null && ultiTools.getPluginManager() != null
+                ? ultiTools.getPluginManager().findScopeForDataFolder(dataFolder)
+                : null;
+        if (scope == null) {
+            throw new com.ultikits.ultitools.exceptions.DataAccessException(
+                    com.ultikits.ultitools.exceptions.ErrorCode.ENTITY_NOT_OWNED,
+                    "Data folder is not a registered external plugin -- call UltiToolsAPI.connect(...) "
+                            + "before requesting a data operator.");
+        }
+        if (!scope.owns(dataEntity)) {
+            throw scope.refusalFor(dataEntity);
+        }
+    }
+
+    /**
+     * Shared ownership check for the {@link #getOperator(UltiToolsPlugin, Class)} legacy overload
+     * (D-14/D-18/02-12), the counterpart to {@link #checkOwnership(java.io.File, Class)} above for
+     * the overload that already carries a {@link UltiToolsPlugin} identity directly rather than a
+     * {@link java.io.File} to reverse-resolve. Called by every backend this framework ships as the
+     * first statement of their own {@code getOperator(UltiToolsPlugin, Class)} override, before
+     * any path resolution, cache lookup, or connection-pool creation.
+     * <p>
+     * {@code UltiToolsPlugin} exposes no accessor for the {@link DataScope} {@code PluginManager}
+     * mints for it -- only {@link UltiToolsPlugin#setDataScope}, the injection point, is public --
+     * so this cannot call {@code plugin}'s own {@code DataScope#owns(Class)} directly. It instead
+     * consults the same {@code PluginManager#findOwningPlugin(Class)} registry {@link
+     * DataScope#refusalFor(Class)} itself already treats as authoritative for message-building:
+     * every scope's owned-entity set is recorded there at minting time (D-19), first-registration-
+     * wins on a collision. This project's measured, zero-collision entity population across 21
+     * {@code @Table} classes / 17 repositories (02-CONTEXT.md) means "the registry's recorded
+     * owner equals the requester's own name" and "the requester's own scope owns the entity" agree
+     * in every case this codebase has ever produced; a genuine collision would need {@link
+     * UltiToolsPlugin} to expose its own {@link DataScope} to close fully, which is out of this
+     * change's scope (02-12-PLAN.md's file boundary excludes {@code UltiToolsPlugin.java}).
+     * <p>
+     * {@code UltiToolsPlugin} 没有暴露 {@code PluginManager} 为它铸造的 {@link DataScope} 的
+     * 访问器——只有注入点 {@link UltiToolsPlugin#setDataScope} 是 public 的——所以这里无法直接
+     * 调用 {@code plugin} 自己的 {@code DataScope#owns(Class)}。转而查询与 {@link
+     * DataScope#refusalFor(Class)} 自身构造拒绝信息时依赖的同一个
+     * {@code PluginManager#findOwningPlugin(Class)} 登记表：每个 scope 拥有的实体集合都会在
+     * 铸造时（D-19）记录进这张表，发生冲突时先注册者优先。本项目实测到的、跨 21 个 {@code @Table}
+     * 类 / 17 个仓库的零冲突实体分布（见 02-CONTEXT.md）意味着「登记表记录的归属方与请求方自己的
+     * 名字一致」和「请求方自己的 scope 拥有该实体」在本代码库迄今产生的每一种情况下都是等价的；
+     * 真正发生冲突时需要 {@code UltiToolsPlugin} 自己暴露 {@link DataScope} 才能彻底解决，这超出了
+     * 本次改动的范围（02-12-PLAN.md 的文件边界不包含 {@code UltiToolsPlugin.java}）。
+     *
+     * @param plugin     the requesting plugin <br> 请求方插件
+     * @param dataEntity data entity class <br> 数据实体类
+     * @throws com.ultikits.ultitools.exceptions.DataAccessException if {@code plugin} does not own
+     *         {@code dataEntity} per the registry above <br> 如果按上述登记表 {@code plugin}
+     *         并不拥有 {@code dataEntity}
+     * @since 6.3.0
+     */
+    default void checkOwnership(UltiToolsPlugin plugin, Class<?> dataEntity) {
+        com.ultikits.ultitools.UltiTools ultiTools = com.ultikits.ultitools.UltiTools.getInstance();
+        String owner = ultiTools != null && ultiTools.getPluginManager() != null
+                ? ultiTools.getPluginManager().findOwningPlugin(dataEntity)
+                : null;
+        String requester = plugin.getPluginName();
+        if (!java.util.Objects.equals(requester, owner)) {
+            String message = owner != null
+                    ? "Entity " + dataEntity.getName() + " belongs to module '" + owner + "', not '"
+                            + requester + "' -- use " + owner + "'s exposed service or the EventBus instead."
+                    : "Entity " + dataEntity.getName() + " is not registered to '" + requester
+                            + "' -- use the owning module's exposed service or the EventBus instead.";
+            throw new com.ultikits.ultitools.exceptions.DataAccessException(
+                    com.ultikits.ultitools.exceptions.ErrorCode.ENTITY_NOT_OWNED, message);
+        }
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/interfaces/JdbcTransactionManager.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/JdbcTransactionManager.java
@@ -1,0 +1,53 @@
+package com.ultikits.ultitools.interfaces;
+
+import java.sql.Connection;
+
+/**
+ * JDBC-specific extension of {@link TransactionManager}.
+ * <p>
+ * Carries the three members that only make sense against a JDBC {@link javax.sql.DataSource} -
+ * raw {@link Connection} access and the two connection-level knobs a transaction can tune before
+ * any statement runs. A non-JDBC backend (a JSON snapshot manager, for instance) implements
+ * {@link TransactionManager} directly and never has to answer these three, instead of inheriting
+ * abstract methods it can only lie about (D-04).
+ * <p>
+ * Framework internals that genuinely need a {@link Connection} - {@code TransactionAwareDataSource},
+ * {@code AbstractRelationalDataOperator} - should program against this sub-interface, not against
+ * {@link TransactionManager} directly.
+ * <p>
+ * {@code TransactionManager} 的 JDBC 专属扩展，携带只对 JDBC {@link javax.sql.DataSource}
+ * 有意义的三个成员——裸 {@link Connection} 访问，以及事务开始后、任何语句执行前可调的两个
+ * 连接级开关。非 JDBC 后端（例如 JSON 快照管理器）直接实现 {@link TransactionManager}，
+ * 永远不必回答这三个问题，而不是被迫继承只能撒谎的抽象方法（D-04）。
+ *
+ * @author wisdomme
+ * @since 6.3.0
+ */
+public interface JdbcTransactionManager extends TransactionManager {
+
+    /**
+     * Gets the current connection, creating a new one if necessary.
+     * <p>
+     * If a transaction is active, returns the connection associated with it.
+     * Otherwise, returns a new connection from the data source.
+     *
+     * @return the current connection
+     */
+    Connection getConnection();
+
+    /**
+     * Sets the isolation level for the current transaction.
+     * <p>
+     * Must be called after begin() and before any statements are executed.
+     *
+     * @param level the JDBC isolation level constant
+     */
+    void setIsolationLevel(int level);
+
+    /**
+     * Sets read-only mode for the current transaction.
+     *
+     * @param readOnly true for read-only mode
+     */
+    void setReadOnly(boolean readOnly);
+}

--- a/src/main/java/com/ultikits/ultitools/interfaces/TransactionManager.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/TransactionManager.java
@@ -20,8 +20,20 @@ public interface TransactionManager {
      * Otherwise, returns a new connection from the data source.
      *
      * @return the current connection
+     * @deprecated JDBC-specific; not every {@code TransactionManager} backs a
+     *             {@link javax.sql.DataSource}. Program against
+     *             {@link JdbcTransactionManager#getConnection()} instead. This default throws
+     *             {@link UnsupportedOperationException} for any backend that only implements the
+     *             base interface.
+     * @since 6.3.0 demoted from an abstract method to a {@code default} one (D-04); zero binary
+     *        removal.
      */
-    Connection getConnection();
+    @Deprecated(since = "6.3.0", forRemoval = true)
+    default Connection getConnection() {
+        throw new UnsupportedOperationException(
+                "getConnection() is JDBC-specific and not supported by this TransactionManager. "
+                        + "Implement " + JdbcTransactionManager.class.getName() + " to provide it.");
+    }
 
     /**
      * Begins a new transaction.
@@ -62,15 +74,39 @@ public interface TransactionManager {
      * Must be called after begin() and before any statements are executed.
      *
      * @param level the JDBC isolation level constant
+     * @deprecated JDBC-specific; program against
+     *             {@link JdbcTransactionManager#setIsolationLevel(int)} instead. This default
+     *             throws {@link UnsupportedOperationException} for any backend that only
+     *             implements the base interface.
+     * @since 6.3.0 demoted from an abstract method to a {@code default} one (D-04); zero binary
+     *        removal.
      */
-    void setIsolationLevel(int level);
+    @Deprecated(since = "6.3.0", forRemoval = true)
+    default void setIsolationLevel(int level) {
+        throw new UnsupportedOperationException(
+                "setIsolationLevel(int) is JDBC-specific and not supported by this "
+                        + "TransactionManager. Implement " + JdbcTransactionManager.class.getName()
+                        + " to provide it.");
+    }
 
     /**
      * Sets read-only mode for the current transaction.
      *
      * @param readOnly true for read-only mode
+     * @deprecated JDBC-specific; program against
+     *             {@link JdbcTransactionManager#setReadOnly(boolean)} instead. This default
+     *             throws {@link UnsupportedOperationException} for any backend that only
+     *             implements the base interface.
+     * @since 6.3.0 demoted from an abstract method to a {@code default} one (D-04); zero binary
+     *        removal.
      */
-    void setReadOnly(boolean readOnly);
+    @Deprecated(since = "6.3.0", forRemoval = true)
+    default void setReadOnly(boolean readOnly) {
+        throw new UnsupportedOperationException(
+                "setReadOnly(boolean) is JDBC-specific and not supported by this "
+                        + "TransactionManager. Implement " + JdbcTransactionManager.class.getName()
+                        + " to provide it.");
+    }
 
     /**
      * Sets the timeout for the current transaction.

--- a/src/main/java/com/ultikits/ultitools/interfaces/TransactionManager.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/TransactionManager.java
@@ -123,4 +123,44 @@ public interface TransactionManager {
      * @return the transaction depth (0 if no transaction)
      */
     int getTransactionDepth();
+
+    /**
+     * Suspends the current transaction, if any, detaching it from this thread so an independent
+     * transaction can begin in its place. Backs {@code Propagation.REQUIRES_NEW} and
+     * {@code Propagation.NOT_SUPPORTED} (D-09).
+     * <p>
+     * Deliberately typed to return an opaque {@code Object} rather than a backend-specific
+     * context type: a JDBC-backed manager suspends a {@link Connection}-holding context, a JSON
+     * snapshot manager (02-05) suspends a set of operator snapshots (D-03) - neither shape belongs
+     * on this base interface. Pass whatever this returns to {@link #resume(Object)} to restore it;
+     * the caller must not otherwise inspect or reuse the returned value.
+     * <p>
+     * The default implementation does not support suspension: it always returns {@code null},
+     * meaning nothing was suspended. A backend that maintains thread-bound transaction state
+     * (JDBC, JSON) must override this together with {@link #resume(Object)} - overriding only one
+     * of the pair breaks the contract silently.
+     *
+     * @return an opaque handle to resume later, or {@code null} if no transaction was active
+     * @since 6.3.0
+     */
+    default Object suspend() {
+        return null;
+    }
+
+    /**
+     * Restores a transaction previously detached by {@link #suspend()}.
+     * <p>
+     * {@code null} is a no-op - it means {@link #suspend()} found nothing active in the first
+     * place, so there is nothing to restore. Passing a handle this {@code TransactionManager} did
+     * not itself produce is a programming error.
+     * <p>
+     * The default implementation is a no-op, pairing with {@link #suspend()}'s default of always
+     * returning {@code null}.
+     *
+     * @param suspended the handle returned by a prior {@link #suspend()} call, or {@code null}
+     * @since 6.3.0
+     */
+    default void resume(Object suspended) {
+        // No-op: the default suspend() never produces a non-null handle.
+    }
 }

--- a/src/main/java/com/ultikits/ultitools/interfaces/TransactionManager.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/TransactionManager.java
@@ -118,6 +118,31 @@ public interface TransactionManager {
     void setTimeout(int seconds);
 
     /**
+     * Returns the {@link System#nanoTime()} value at which the active transaction's timeout
+     * budget expires, or {@code null} when no timeout is configured for the active transaction
+     * -- no active transaction at all, or {@code @Transactional(timeout=0)} (the default).
+     * <p>
+     * D-10: consulted per statement (by {@code TimeoutAwareQueryRunner} and the two direct
+     * {@code PreparedStatement} call sites {@code AbstractRelationalDataOperator.insertAll}/
+     * {@code updateAll} build themselves) to compute the time <em>remaining</em> in the budget,
+     * not a value captured once -- the caller re-reads this on every statement.
+     * <p>
+     * The default implementation always returns {@code null}, meaning "never enforced" -- the
+     * same posture a backend whose {@code setTimeout(int)} refuses any positive value outright
+     * (rather than ever recording a deadline) naturally has, since it never has anything to
+     * report here either. A backend that wants per-statement enforcement overrides this together
+     * with {@link #setTimeout(int)} -- overriding only one half of the pair leaves the other
+     * silently inert, the same caution {@link #suspend()}'s javadoc gives for its pair.
+     *
+     * @return the deadline, as a {@link System#nanoTime()} value, or {@code null} if none is
+     *         active
+     * @since 6.3.0
+     */
+    default Long getTimeoutDeadlineNanos() {
+        return null;
+    }
+
+    /**
      * Gets the current transaction depth (for nested transactions).
      *
      * @return the transaction depth (0 if no transaction)

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/AbstractRelationalDataOperator.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/AbstractRelationalDataOperator.java
@@ -5,6 +5,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -23,6 +24,11 @@ import org.apache.commons.dbutils.ResultSetHandler;
 import org.apache.commons.dbutils.handlers.ScalarHandler;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializer;
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
 import com.ultikits.ultitools.annotations.Column;
 import com.ultikits.ultitools.annotations.Table;
@@ -49,7 +55,23 @@ import com.ultikits.ultitools.utils.ReflectionUtil;
 public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<String>> implements DataOperator<T> {
 
     private static final Logger LOGGER = Logger.getLogger(AbstractRelationalDataOperator.class.getName());
-    private static final Gson GSON = new Gson();
+    /**
+     * Default Gson has no bundled adapter for {@code java.time.LocalDateTime}: its reflective
+     * fallback tries to reach {@code LocalDateTime}'s private fields, which JDK 9+'s module
+     * system refuses without {@code --add-opens java.base/java.time}, throwing
+     * {@code JsonIOException} at the first non-null {@code @Column}-mapped {@code LocalDateTime}
+     * value (02-08 -- {@code AuditableDataEntity#createdAt}/{@code updatedAt} were always
+     * {@code null} before this plan, so the per-field {@link #insert} / {@link #update} JSON
+     * fallback below never reached this type until the lifecycle hooks started populating it).
+     * Serializes to/from {@link LocalDateTime#toString()}'s ISO-8601 form, which
+     * {@link LocalDateTime#parse(CharSequence)} reads back exactly.
+     */
+    private static final Gson GSON = new GsonBuilder()
+            .registerTypeAdapter(LocalDateTime.class, (JsonSerializer<LocalDateTime>) (src, type, context) ->
+                    src == null ? JsonNull.INSTANCE : new JsonPrimitive(src.toString()))
+            .registerTypeAdapter(LocalDateTime.class, (JsonDeserializer<LocalDateTime>) (json, type, context) ->
+                    json.isJsonNull() ? null : LocalDateTime.parse(json.getAsString()))
+            .create();
 
     protected final Class<T> type;
     protected final DataSource dataSource;
@@ -144,7 +166,31 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
         }
     }
 
+    /**
+     * The read handler used by {@link #getAll(WhereCondition...)}, {@link #getLike}, and
+     * {@link #page}: fires {@code onLoad()} once per row it materializes. {@link #getById} and
+     * {@link #delById} deliberately do *not* go through this handler -- see
+     * {@link #getRawListHandler()}.
+     */
     protected ResultSetHandler<List<T>> getListHandler() {
+        ResultSetHandler<List<T>> raw = getRawListHandler();
+        return rs -> {
+            List<T> list = raw.handle(rs);
+            for (T entity : list) {
+                entity.onLoad();
+            }
+            return list;
+        };
+    }
+
+    /**
+     * The same row-materialization logic as {@link #getListHandler()}, without firing
+     * {@code onLoad()}. Used internally by {@link #getById} (which fires {@code onLoad()} itself,
+     * exactly once, on the single entity it returns) and {@link #delById} (which needs the
+     * entity to fire {@code onDelete()} on, but deleting is not loading -- see 02-08-PLAN.md's
+     * delete-hook-path split).
+     */
+    private ResultSetHandler<List<T>> getRawListHandler() {
         // Build mappings from SQL column names to Java field names and boolean detection.
         // Gson matches JSON keys to Java field names, so we must use field names (camelCase)
         // as map keys, not SQL column names (snake_case).
@@ -185,6 +231,22 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
             }
             return list;
         };
+    }
+
+    /**
+     * Fetches a single row by id without firing {@code onLoad()}. Shared by {@link #getById}
+     * (which fires {@code onLoad()} on the result) and {@link #delById} (which fires
+     * {@code onDelete()} instead -- deleting is not loading).
+     */
+    private T fetchRawById(Object id) {
+        String sql = "SELECT * FROM " + tableName + " WHERE id = ?";
+        try {
+            List<T> list = queryRunner.query(sql, getRawListHandler(), id);
+            return list.isEmpty() ? null : list.get(0);
+        } catch (SQLException e) {
+            throw new DataAccessException(ErrorCode.DATA_OPERATION_FAILED,
+                    "Failed to get entity by id: " + id, e);
+        }
     }
 
     /**
@@ -301,14 +363,11 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
 
     @Override
     public T getById(Object id) {
-        String sql = "SELECT * FROM " + tableName + " WHERE id = ?";
-        try {
-            List<T> list = queryRunner.query(sql, getListHandler(), id);
-            return list.isEmpty() ? null : list.get(0);
-        } catch (SQLException e) {
-            throw new DataAccessException(ErrorCode.DATA_OPERATION_FAILED,
-                    "Failed to get entity by id: " + id, e);
+        T entity = fetchRawById(id);
+        if (entity != null) {
+            entity.onLoad();
         }
+        return entity;
     }
 
     @Override
@@ -378,6 +437,9 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
         if (obj.getId() == null) {
             obj.setId(java.util.UUID.randomUUID().toString());
         }
+        // Fires before the fields below are read for the SQL parameters, so whatever onCreate()
+        // writes (e.g. AuditableDataEntity's createdAt/createdBy) is what actually gets persisted.
+        obj.onCreate();
         StringBuilder sql = new StringBuilder("INSERT INTO ").append(tableName).append(" (");
         StringBuilder values = new StringBuilder(") VALUES (");
         List<Object> params = new ArrayList<>();
@@ -419,6 +481,13 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
         }
     }
 
+    /**
+     * Deletes by predicate, without loading matched rows into entities first. Consequently this
+     * overload does <strong>not</strong> fire {@code onDelete()} -- there is no entity to fire it
+     * on without fabricating one, and this class does not fabricate entities to satisfy a hook.
+     * {@link #delById(Object)} fetches the entity first and does fire {@code onDelete()} on it
+     * (02-08-PLAN.md's delete-hook-path split).
+     */
     @Override
     public void del(WhereCondition... whereConditions) {
         // T-02-TAM-1 / SILENT-01 / D-12: refuse before any SQL text is built and before any
@@ -442,8 +511,18 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
         }
     }
 
+    /**
+     * Deletes by id, fetching the entity first so {@code onDelete()} can fire on it -- unlike
+     * {@link #del(WhereCondition...)}, which deletes by predicate without materializing rows and
+     * therefore does not fire the hook. If no row matches {@code id}, nothing is fetched and
+     * {@code onDelete()} does not fire.
+     */
     @Override
     public void delById(Object id) {
+        T entity = fetchRawById(id);
+        if (entity != null) {
+            entity.onDelete();
+        }
         String sql = "DELETE FROM " + tableName + " WHERE id = ?";
         try {
             queryRunner.update(sql, id);
@@ -469,6 +548,11 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
 
     @Override
     public void update(T obj) throws IllegalAccessException {
+        // Fires before the fields below are read for the SQL parameters, so whatever onUpdate()
+        // writes (e.g. AuditableDataEntity's updatedAt/updatedBy) is what actually gets
+        // persisted. onUpdate() does not touch createdAt/createdBy, so an entity carrying its
+        // original creation values in memory persists them unchanged here.
+        obj.onUpdate();
         StringBuilder sql = new StringBuilder("UPDATE ").append(tableName).append(" SET ");
         List<Object> params = new ArrayList<>();
         Field[] fields = ReflectionUtil.getFields(obj.getClass());
@@ -544,11 +628,16 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
             return;
         }
         transaction(() -> {
-            // Auto-generate UUID for entities without id
+            // Auto-generate UUID for entities without id, then fire onCreate() once per entity
+            // in list order -- before the second loop below reads fields for the batch
+            // PreparedStatement, exactly mirroring insert()'s single-entity ordering. This loop
+            // builds its own statement rather than delegating to insert(), so a hook wired only
+            // into insert() would silently skip this path.
             for (T entity : entities) {
                 if (entity.getId() == null) {
                     entity.setId(java.util.UUID.randomUUID().toString());
                 }
+                entity.onCreate();
             }
             List<ColumnMapping> columns = getColumnMappings();
             StringBuilder sql = new StringBuilder("INSERT INTO ").append(tableName).append(" (");
@@ -612,6 +701,11 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
                 try (Connection conn = dataSource.getConnection();
                      PreparedStatement pstmt = conn.prepareStatement(sql.toString())) {
                     for (T entity : entities) {
+                        // Fires once per entity, in list order, before this entity's fields are
+                        // read below -- this loop builds its own statement rather than
+                        // delegating to update(T), so a hook wired only into update(T) would
+                        // silently skip this path.
+                        entity.onUpdate();
                         int idx = 1;
                         for (ColumnMapping col : columns) {
                             Object value = col.field.get(entity);

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/AbstractRelationalDataOperator.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/AbstractRelationalDataOperator.java
@@ -23,6 +23,7 @@ import com.google.gson.Gson;
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
 import com.ultikits.ultitools.annotations.Column;
 import com.ultikits.ultitools.annotations.Table;
+import com.ultikits.ultitools.entities.Comparison;
 import com.ultikits.ultitools.entities.WhereCondition;
 import com.ultikits.ultitools.exceptions.DataAccessException;
 import com.ultikits.ultitools.exceptions.ErrorCode;
@@ -140,6 +141,96 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
         };
     }
 
+    /**
+     * Maps a {@link Comparison} to its SQL operator fragment (including the placeholder).
+     * <p>
+     * Shared by all four relational WHERE builders ({@link #exist(WhereCondition...)},
+     * {@link #getAll(WhereCondition...)}, {@link #page(int, int, WhereCondition...)},
+     * {@link #del(WhereCondition...)}) so a given {@code Comparison} means the same thing on
+     * every one of them, and on {@code SimpleJsonDataOperator}'s JSON backend. There is no
+     * silent fallback to equality: an unhandled constant throws rather than being misread as
+     * {@code EQUAL}, since a silent default is exactly how this defect stayed invisible before.
+     *
+     * @param comparison the comparison operator
+     * @return the SQL fragment, e.g. {@code " > ?"}
+     */
+    private String sqlOperatorFor(Comparison comparison) {
+        switch (comparison) {
+            case EQUAL:
+                return " = ?";
+            case GREATER:
+                return " > ?";
+            case LESS:
+                return " < ?";
+            case INCLUDE:
+            case STARTSWITH:
+            case ENDSWITH:
+                return " LIKE ?";
+            default:
+                throw new IllegalArgumentException("Unhandled comparison: " + comparison);
+        }
+    }
+
+    /**
+     * Wraps a condition's value with the {@code %} wildcards its {@link Comparison} implies,
+     * matching {@code SimpleJsonDataOperator#conditionCal}'s existing placement exactly:
+     * {@code INCLUDE} wraps both sides, {@code STARTSWITH} appends a trailing wildcard,
+     * {@code ENDSWITH} prepends a leading wildcard. {@code EQUAL}/{@code GREATER}/{@code LESS}
+     * pass the value through unchanged.
+     *
+     * @param condition the condition supplying the comparison and the raw value
+     * @return the value to bind as the SQL parameter
+     */
+    private Object likeWrappedValue(WhereCondition condition) {
+        Object value = condition.getValue();
+        switch (condition.getComparison()) {
+            case INCLUDE:
+                return "%" + value + "%";
+            case STARTSWITH:
+                return value + "%";
+            case ENDSWITH:
+                return "%" + value;
+            default:
+                return value;
+        }
+    }
+
+    /**
+     * Appends a {@code WHERE} clause built from {@code conditions} to {@code sql} and their
+     * bound values to {@code params}, routing every column through {@link #sqlOperatorFor} so
+     * the four relational builders cannot diverge in how they honor a {@link Comparison} again.
+     * <p>
+     * When {@code skipEmpty} is {@code true}, conditions whose {@link WhereCondition#isEmpty()}
+     * is {@code true} are skipped — {@link #getAll(WhereCondition...)}'s pre-existing behavior,
+     * preserved here rather than changed. {@link #exist(WhereCondition...)},
+     * {@link #page(int, int, WhereCondition...)}, and {@link #del(WhereCondition...)} do not
+     * skip empty conditions; that asymmetry already existed before this method and is not
+     * resolved by this change (see 02-03-SUMMARY.md).
+     *
+     * @param sql        the SQL being built; must already hold the statement up to (not
+     *                   including) the WHERE clause
+     * @param params     the parameter list to append bound values to, in SQL order
+     * @param conditions the conditions to render; must be non-null and non-empty
+     * @param skipEmpty  whether to skip conditions whose {@code isEmpty()} is true
+     */
+    private void appendConditions(StringBuilder sql, List<Object> params, WhereCondition[] conditions,
+                                   boolean skipEmpty) {
+        boolean first = true;
+        for (WhereCondition condition : conditions) {
+            if (skipEmpty && condition.isEmpty()) {
+                continue;
+            }
+            if (first) {
+                sql.append(" WHERE ");
+                first = false;
+            } else {
+                sql.append(" AND ");
+            }
+            sql.append(condition.getColumn()).append(sqlOperatorFor(condition.getComparison()));
+            params.add(likeWrappedValue(condition));
+        }
+    }
+
     @Override
     public boolean exist(T object) {
         return exist(WhereCondition.builder().column("id").value(object.getId()).build());
@@ -150,15 +241,7 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
         StringBuilder sql = new StringBuilder("SELECT COUNT(*) FROM ").append(tableName);
         List<Object> params = new ArrayList<>();
         if (whereConditions != null && whereConditions.length > 0) {
-            sql.append(" WHERE ");
-            for (int i = 0; i < whereConditions.length; i++) {
-                WhereCondition condition = whereConditions[i];
-                sql.append(condition.getColumn()).append(" = ?");
-                params.add(condition.getValue());
-                if (i < whereConditions.length - 1) {
-                    sql.append(" AND ");
-                }
-            }
+            appendConditions(sql, params, whereConditions, false);
         }
         try {
             Long count = queryRunner.query(sql.toString(), new ScalarHandler<>(), params.toArray());
@@ -191,21 +274,7 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
         StringBuilder sql = new StringBuilder("SELECT * FROM ").append(tableName);
         List<Object> params = new ArrayList<>();
         if (whereConditions != null && whereConditions.length > 0) {
-            // Filter out empty conditions
-            boolean first = true;
-            for (WhereCondition condition : whereConditions) {
-                if (condition.isEmpty()) {
-                    continue;
-                }
-                if (first) {
-                    sql.append(" WHERE ");
-                    first = false;
-                } else {
-                    sql.append(" AND ");
-                }
-                sql.append(condition.getColumn()).append(" = ?");
-                params.add(condition.getValue());
-            }
+            appendConditions(sql, params, whereConditions, true);
         }
         try {
             return queryRunner.query(sql.toString(), getListHandler(), params.toArray());
@@ -243,15 +312,7 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
         StringBuilder sql = new StringBuilder("SELECT * FROM ").append(tableName);
         List<Object> params = new ArrayList<>();
         if (whereConditions != null && whereConditions.length > 0) {
-            sql.append(" WHERE ");
-            for (int i = 0; i < whereConditions.length; i++) {
-                WhereCondition condition = whereConditions[i];
-                sql.append(condition.getColumn()).append(" = ?");
-                params.add(condition.getValue());
-                if (i < whereConditions.length - 1) {
-                    sql.append(" AND ");
-                }
-            }
+            appendConditions(sql, params, whereConditions, false);
         }
         sql.append(" LIMIT ? OFFSET ?");
         params.add(size);
@@ -316,15 +377,7 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
         StringBuilder sql = new StringBuilder("DELETE FROM ").append(tableName);
         List<Object> params = new ArrayList<>();
         if (whereConditions != null && whereConditions.length > 0) {
-            sql.append(" WHERE ");
-            for (int i = 0; i < whereConditions.length; i++) {
-                WhereCondition condition = whereConditions[i];
-                sql.append(condition.getColumn()).append(" = ?");
-                params.add(condition.getValue());
-                if (i < whereConditions.length - 1) {
-                    sql.append(" AND ");
-                }
-            }
+            appendConditions(sql, params, whereConditions, false);
         }
         try {
             queryRunner.update(sql.toString(), params.toArray());

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/AbstractRelationalDataOperator.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/AbstractRelationalDataOperator.java
@@ -97,7 +97,10 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
         // transaction, getConnection() returns the transaction's connection instead
         // of a fresh auto-commit one.
         this.dataSource = new TransactionAwareDataSource(dataSource, () -> this.transactionManager);
-        this.queryRunner = new QueryRunner(this.dataSource);
+        // D-10: TimeoutAwareQueryRunner reads the active transaction's remaining-time budget
+        // fresh on every statement via currentTimeoutDeadlineNanos() -- this operator outlives
+        // any single transaction, and transactionManager itself can be swapped out.
+        this.queryRunner = new TimeoutAwareQueryRunner(this.dataSource, this::currentTimeoutDeadlineNanos);
         Table tableAnnotation = ReflectionUtil.getAnnotation(type, Table.class);
         if (tableAnnotation == null) {
             throw new DataAccessException(ErrorCode.DATA_ENTITY_INVALID,
@@ -151,6 +154,37 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
      */
     public void setTransactionManager(TransactionManager transactionManager) {
         this.transactionManager = transactionManager;
+    }
+
+    /**
+     * Supplies {@link #queryRunner}'s per-statement query timeout deadline (D-10): the active
+     * transaction's remaining-time budget, or {@code null} when none is configured (no active
+     * transaction, or {@code @Transactional(timeout=0)}, the default). Also used directly by
+     * {@link #applyStatementTimeout} for the two {@code PreparedStatement} call sites that
+     * bypass {@link #queryRunner} entirely. A method reference rather than a field capture, so
+     * every call reads {@link #transactionManager}'s *current* value -- this operator outlives
+     * any single transaction, and {@link #setTransactionManager} can swap the manager out.
+     */
+    private Long currentTimeoutDeadlineNanos() {
+        return transactionManager != null ? transactionManager.getTimeoutDeadlineNanos() : null;
+    }
+
+    /**
+     * Applies the same per-statement query timeout {@link #queryRunner} (a {@link
+     * TimeoutAwareQueryRunner}) would, to a {@link PreparedStatement} built directly against
+     * {@link #dataSource} -- the two call sites in {@link #insertAll} and {@link #updateAll}
+     * that bypass {@code QueryRunner} entirely. A timeout wired only into {@link #queryRunner}'s
+     * path would leave these two batch operations silently ignoring
+     * {@code @Transactional(timeout=)}, exactly the gap 02-RESEARCH.md warns about.
+     *
+     * @param statement the statement to apply the timeout to, already prepared
+     * @throws SQLException if the driver rejects the timeout value
+     */
+    private void applyStatementTimeout(PreparedStatement statement) throws SQLException {
+        Long deadlineNanos = currentTimeoutDeadlineNanos();
+        if (deadlineNanos != null) {
+            statement.setQueryTimeout(TimeoutAwareQueryRunner.remainingSecondsFloored(deadlineNanos));
+        }
     }
 
     /**
@@ -656,6 +690,9 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
 
             try (Connection conn = dataSource.getConnection();
                  PreparedStatement pstmt = conn.prepareStatement(sql.toString())) {
+                // D-10: this statement bypasses queryRunner entirely, so it needs the same
+                // per-statement timeout applied explicitly -- see applyStatementTimeout's javadoc.
+                applyStatementTimeout(pstmt);
                 for (T entity : entities) {
                     int idx = 1;
                     for (ColumnMapping col : columns) {
@@ -700,6 +737,9 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
 
                 try (Connection conn = dataSource.getConnection();
                      PreparedStatement pstmt = conn.prepareStatement(sql.toString())) {
+                    // D-10: this statement bypasses queryRunner entirely -- same reasoning as
+                    // insertAll's identical call above.
+                    applyStatementTimeout(pstmt);
                     for (T entity : entities) {
                         // Fires once per entity, in list order, before this entity's fields are
                         // read below -- this loop builds its own statement rather than

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/AbstractRelationalDataOperator.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/AbstractRelationalDataOperator.java
@@ -246,7 +246,7 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
      * bound values to {@code params}, routing every column through {@link #sqlOperatorFor} so
      * the four relational builders cannot diverge in how they honor a {@link Comparison} again.
      * <p>
-     * When {@code skipEmpty} is {@code true}, conditions whose {@link WhereCondition#isEmpty()}
+     * When {@code skipEmpty} is {@code true}, conditions whose {@code WhereCondition#isEmpty()}
      * is {@code true} are skipped — {@link #getAll(WhereCondition...)}'s pre-existing behavior,
      * preserved here rather than changed. {@link #exist(WhereCondition...)},
      * {@link #page(int, int, WhereCondition...)}, and {@link #del(WhereCondition...)} do not

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/AbstractRelationalDataOperator.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/AbstractRelationalDataOperator.java
@@ -164,6 +164,8 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
      * bypass {@link #queryRunner} entirely. A method reference rather than a field capture, so
      * every call reads {@link #transactionManager}'s *current* value -- this operator outlives
      * any single transaction, and {@link #setTransactionManager} can swap the manager out.
+     *
+     * @return the active transaction's timeout deadline, or {@code null} if none is configured
      */
     private Long currentTimeoutDeadlineNanos() {
         return transactionManager != null ? transactionManager.getTimeoutDeadlineNanos() : null;

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/AbstractRelationalDataOperator.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/AbstractRelationalDataOperator.java
@@ -6,10 +6,13 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.logging.Logger;
 
@@ -53,6 +56,12 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
     protected final String tableName;
     protected final QueryRunner queryRunner;
     protected TransactionManager transactionManager;
+    /**
+     * The entity's own {@code @Column} names, reflected once at construction. The allow-list
+     * {@link #validateColumn(String)} checks every WHERE-clause column identifier against
+     * before it is concatenated into SQL text (T-02-SQLI-1).
+     */
+    private final Set<String> knownColumns;
 
     /**
      * Creates a new data operator.
@@ -73,7 +82,44 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
                     "Entity class " + type.getName() + " must have @Table annotation");
         }
         this.tableName = tableAnnotation.value();
+        this.knownColumns = buildKnownColumns(type);
         initializeTable();
+    }
+
+    /**
+     * Reflects the entity's {@code @Column} mappings once, for {@link #validateColumn(String)}'s
+     * allow-list. This mirrors the same reflected metadata {@link #buildColumnDefinitions(Class)}
+     * and {@link #getColumnMappings()} already read from the entity class — a dedicated pass over
+     * it, not a second scan of anything already cached.
+     *
+     * @param entityType the entity class
+     * @return an unmodifiable set of every {@code @Column} SQL name declared on {@code entityType}
+     *         (including inherited fields, e.g. {@code AbstractDataEntity}'s {@code id})
+     */
+    private static Set<String> buildKnownColumns(Class<?> entityType) {
+        Set<String> columns = new HashSet<>();
+        for (Field field : ReflectionUtil.getFields(entityType)) {
+            if (field.isAnnotationPresent(Column.class)) {
+                columns.add(field.getAnnotation(Column.class).value());
+            }
+        }
+        return Collections.unmodifiableSet(columns);
+    }
+
+    /**
+     * Refuses a column identifier that is not among the entity's own reflected {@code @Column}
+     * mappings, before it can be concatenated into SQL text (T-02-SQLI-1). Called from
+     * {@link #appendConditions} on behalf of all four relational WHERE builders.
+     *
+     * @param column the column name from a caller-supplied {@link WhereCondition}
+     * @throws DataAccessException if {@code column} is not a known column of {@link #type}
+     */
+    private void validateColumn(String column) {
+        if (!knownColumns.contains(column)) {
+            throw new DataAccessException(ErrorCode.DATA_ENTITY_INVALID,
+                    "Unknown column '" + column + "' for entity " + type.getName()
+                            + " -- it is not among the entity's @Column mappings.");
+        }
     }
 
     /**
@@ -220,6 +266,7 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
             if (skipEmpty && condition.isEmpty()) {
                 continue;
             }
+            validateColumn(condition.getColumn());
             if (first) {
                 sql.append(" WHERE ");
                 first = false;
@@ -374,11 +421,19 @@ public abstract class AbstractRelationalDataOperator<T extends BaseDataEntity<St
 
     @Override
     public void del(WhereCondition... whereConditions) {
+        // T-02-TAM-1 / SILENT-01 / D-12: refuse before any SQL text is built and before any
+        // QueryRunner interaction. The varargs no-arg call produces a zero-length array, not
+        // null -- both shapes are refused here. Stateless: every call re-checks, so this is
+        // not a one-shot latch and cannot partially execute on a retry.
+        if (whereConditions == null || whereConditions.length == 0) {
+            throw new DataAccessException(ErrorCode.DATA_ENTITY_INVALID,
+                    "Refusing to delete every row of table '" + tableName + "' with no WhereCondition. "
+                            + "Pass an explicit condition, or use a dedicated full-table operation "
+                            + "if one genuinely exists.");
+        }
         StringBuilder sql = new StringBuilder("DELETE FROM ").append(tableName);
         List<Object> params = new ArrayList<>();
-        if (whereConditions != null && whereConditions.length > 0) {
-            appendConditions(sql, params, whereConditions, false);
-        }
+        appendConditions(sql, params, whereConditions, false);
         try {
             queryRunner.update(sql.toString(), params.toArray());
         } catch (SQLException e) {

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/TimeoutAwareQueryRunner.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/TimeoutAwareQueryRunner.java
@@ -76,9 +76,12 @@ public class TimeoutAwareQueryRunner extends QueryRunner {
 
     @Override
     protected PreparedStatement prepareStatement(Connection conn, String sql) throws SQLException {
-        // RED stub (02-09 Task 1): does not yet apply setQueryTimeout -- see
-        // TimeoutAwareQueryRunnerTest for the failing assertions this leaves red.
-        return super.prepareStatement(conn, sql);
+        PreparedStatement statement = super.prepareStatement(conn, sql);
+        Long deadlineNanos = deadlineSupplier.get();
+        if (deadlineNanos != null) {
+            statement.setQueryTimeout(remainingSecondsFloored(deadlineNanos));
+        }
+        return statement;
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/TimeoutAwareQueryRunner.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/TimeoutAwareQueryRunner.java
@@ -89,11 +89,16 @@ public class TimeoutAwareQueryRunner extends QueryRunner {
      * {@link #MIN_QUERY_TIMEOUT_SECONDS} so an exhausted or already-passed deadline still
      * produces a real, enforced limit rather than {@code 0} ("no limit") or a negative value
      * (which the JDBC driver rejects).
+     * <p>
+     * Package-visible (not {@code private}) so {@link AbstractRelationalDataOperator}'s two
+     * direct {@code PreparedStatement} call sites -- {@code insertAll}/{@code updateAll}, which
+     * bypass {@code QueryRunner} entirely -- apply the identical floor this class does, rather
+     * than a second, potentially-diverging copy of the same arithmetic.
      *
      * @param deadlineNanos the deadline, as a {@link System#nanoTime()} value
      * @return the query timeout to apply, in seconds, always {@code >= MIN_QUERY_TIMEOUT_SECONDS}
      */
-    private static int remainingSecondsFloored(long deadlineNanos) {
+    static int remainingSecondsFloored(long deadlineNanos) {
         long remainingNanos = deadlineNanos - System.nanoTime();
         long remainingSeconds = TimeUnit.NANOSECONDS.toSeconds(remainingNanos);
         return (int) Math.max(MIN_QUERY_TIMEOUT_SECONDS, Math.min(Integer.MAX_VALUE, remainingSeconds));

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/TimeoutAwareQueryRunner.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/TimeoutAwareQueryRunner.java
@@ -1,0 +1,98 @@
+package com.ultikits.ultitools.interfaces.impl.data;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import javax.sql.DataSource;
+
+import org.apache.commons.dbutils.QueryRunner;
+
+/**
+ * A {@link QueryRunner} that applies a per-statement JDBC query timeout, computed against a
+ * shared transaction deadline rather than a fixed value (D-10 -- Spring's approach: each
+ * statement gets the time <em>remaining</em> in the transaction's budget, not a fresh full
+ * allowance).
+ * <p>
+ * Overrides {@link org.apache.commons.dbutils.AbstractQueryRunner#prepareStatement(Connection,
+ * String)} -- the one override point {@code AbstractQueryRunner}'s own javadoc documents for
+ * exactly this purpose ("Subclasses can override this method to provide special
+ * PreparedStatement configuration if needed"), confirmed by reading
+ * {@code commons-dbutils-1.8.1-sources.jar}. Every other {@code QueryRunner} behavior --
+ * parameter binding, result-set handling, resource cleanup -- is untouched.
+ * <p>
+ * {@link #deadlineSupplier} is read fresh on every statement, not captured once: the operator
+ * holding this runner outlives any single transaction, so the deadline it should honor changes
+ * across calls. A {@code null} result means "no timeout configured" -- no active transaction, or
+ * {@code @Transactional(timeout = 0)} (the default) -- and {@link PreparedStatement#setQueryTimeout}
+ * is not called at all, leaving the statement at the driver's own default.
+ * <p>
+ * <b>The floor.</b> An already-exhausted budget produces {@link #MIN_QUERY_TIMEOUT_SECONDS}
+ * (currently 1), never 0 and never a negative number. In the JDBC contract,
+ * {@code setQueryTimeout(0)} means "no limit" -- silently handing an exhausted budget an
+ * unlimited timeout would be the opposite of what a timeout is for. A negative value is rejected
+ * by the driver outright. Flooring at the smallest real limit is the only choice that fails fast
+ * instead of either of those.
+ * <p>
+ * Deliberately does not attempt to cancel or interrupt a statement already in flight when its
+ * budget expires -- that would be a wall-clock bound on the surrounding method body, which
+ * REQUIREMENTS.md rules out as not implementable on plain JDBC (WIRE-14). The bound here is
+ * per-statement, by construction, applied before the statement is ever executed.
+ *
+ * @author wisdomme
+ * @since 6.3.0
+ */
+public class TimeoutAwareQueryRunner extends QueryRunner {
+
+    /**
+     * The smallest query timeout, in seconds, this runner will ever apply. {@code
+     * setQueryTimeout(0)} means "no limit" in the JDBC contract, so an exhausted deadline must
+     * never round down to it -- 1 is the smallest value that still means "a real, enforced
+     * limit."
+     */
+    static final int MIN_QUERY_TIMEOUT_SECONDS = 1;
+
+    /**
+     * Supplies the active transaction's deadline as a {@link System#nanoTime()} value, or {@code
+     * null} when no timeout is configured for the current statement (no active transaction, or a
+     * zero/negative {@code @Transactional(timeout=)}). Read fresh per statement -- see the class
+     * javadoc.
+     */
+    private final Supplier<Long> deadlineSupplier;
+
+    /**
+     * Creates a new timeout-aware query runner.
+     *
+     * @param dataSource       the data source to use for connections
+     * @param deadlineSupplier supplies the current transaction's deadline ({@link
+     *                         System#nanoTime()} value), or {@code null} when no timeout applies
+     */
+    public TimeoutAwareQueryRunner(DataSource dataSource, Supplier<Long> deadlineSupplier) {
+        super(dataSource);
+        this.deadlineSupplier = deadlineSupplier;
+    }
+
+    @Override
+    protected PreparedStatement prepareStatement(Connection conn, String sql) throws SQLException {
+        // RED stub (02-09 Task 1): does not yet apply setQueryTimeout -- see
+        // TimeoutAwareQueryRunnerTest for the failing assertions this leaves red.
+        return super.prepareStatement(conn, sql);
+    }
+
+    /**
+     * Converts a {@link System#nanoTime()} deadline into the whole seconds remaining, floored at
+     * {@link #MIN_QUERY_TIMEOUT_SECONDS} so an exhausted or already-passed deadline still
+     * produces a real, enforced limit rather than {@code 0} ("no limit") or a negative value
+     * (which the JDBC driver rejects).
+     *
+     * @param deadlineNanos the deadline, as a {@link System#nanoTime()} value
+     * @return the query timeout to apply, in seconds, always {@code >= MIN_QUERY_TIMEOUT_SECONDS}
+     */
+    private static int remainingSecondsFloored(long deadlineNanos) {
+        long remainingNanos = deadlineNanos - System.nanoTime();
+        long remainingSeconds = TimeUnit.NANOSECONDS.toSeconds(remainingNanos);
+        return (int) Math.max(MIN_QUERY_TIMEOUT_SECONDS, Math.min(Integer.MAX_VALUE, remainingSeconds));
+    }
+}

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonStore.java
@@ -124,6 +124,7 @@ public class JsonStore implements DataStore {
     @Override
     @SuppressWarnings("unchecked")
     public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(UltiToolsPlugin plugin, Class<T> dataEntity) {
+        checkOwnership(plugin, dataEntity);
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new IllegalArgumentException("No @Table annotation is present on: " + dataEntity.getName());
         }
@@ -140,6 +141,7 @@ public class JsonStore implements DataStore {
     @Override
     @SuppressWarnings("unchecked")
     public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(File dataFolder, Class<T> dataEntity) {
+        checkOwnership(dataFolder, dataEntity);
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new IllegalArgumentException("No @Table annotation is present on: " + dataEntity.getName());
         }

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonStore.java
@@ -1,8 +1,10 @@
 package com.ultikits.ultitools.interfaces.impl.data.json;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.bukkit.scheduler.BukkitRunnable;
@@ -19,14 +21,29 @@ import com.ultikits.ultitools.utils.ReflectionUtil;
 
 /**
  * Json Data store.
+ * <p>
+ * The operator cache is keyed by (requesting identity, entity class), not by entity class alone
+ * -- two callers resolving to two different identities (two plugins on the plugin path, or two
+ * data folders on the external {@code File} path) never share a {@link DataOperator} instance
+ * (SILENT-04). Not {@code static}: {@code DataStoreManager} registers exactly one {@code
+ * JsonStore} instance, and instance scoping is what stops the cache from outliving a {@code
+ * /reload}.
  * <br>
- * Json存储方式抽象类
+ * Json存储方式抽象类。操作器缓存按（请求方身份，实体类）而非仅按实体类分组——解析到两个不同身份
+ * 的调用方（插件路径上的两个插件，或外部 {@code File} 路径上的两个数据文件夹）永远不会共享同一个
+ * {@link DataOperator} 实例（SILENT-04）。非 {@code static}：{@code DataStoreManager} 只注册一个
+ * {@code JsonStore} 实例，实例级作用域正是防止缓存在 {@code /reload} 后继续存活的原因。
  *
  * @author wisdomme
  * @version 1.0.0
  */
 public class JsonStore implements DataStore {
-    private static final Map<Class<?>, Cached> dataOperatorMap = new ConcurrentHashMap<>();
+
+    /**
+     * Operator cache, keyed by (requesting identity, entity class). Not static -- see class
+     * javadoc.
+     */
+    private final Map<OperatorKey, Cached> dataOperatorMap = new ConcurrentHashMap<>();
     private static volatile boolean schedulerInitialized = false;
 
     private final String storeLocation;
@@ -34,25 +51,32 @@ public class JsonStore implements DataStore {
     /**
      * Initialize the flush scheduler. Called lazily when first JsonStore is created.
      * This avoids static initializer issues in test environments.
+     * <p>
+     * Only the first {@code JsonStore} instance in a JVM ever starts the periodic flush task
+     * (guarded by the {@code static} {@link #schedulerInitialized} flag, matching pre-existing
+     * behavior); in production there is exactly one {@code JsonStore} instance, so this flushes
+     * that instance's own cache, not a shared static one.
      */
-    private static synchronized void initScheduler() {
-        if (schedulerInitialized) {
-            return;
-        }
-        try {
-            int flushRate = UltiTools.getInstance().getConfig().getInt("datasource.flushRate");
-            flushRate = flushRate == 0 ? 10 : flushRate;
-            new BukkitRunnable() {
+    private void initScheduler() {
+        synchronized (JsonStore.class) {
+            if (schedulerInitialized) {
+                return;
+            }
+            try {
+                int flushRate = UltiTools.getInstance().getConfig().getInt("datasource.flushRate");
+                flushRate = flushRate == 0 ? 10 : flushRate;
+                new BukkitRunnable() {
 
-                @Override
-                public void run() {
-                    flushAllCaches();
-                }
-            }.runTaskTimerAsynchronously(UltiTools.getInstance(), 20L, 20L * flushRate);
-            schedulerInitialized = true;
-        } catch (Exception e) {
-            // Scheduler initialization failed - likely in test environment
-            // This is acceptable as tests don't need periodic flushing
+                    @Override
+                    public void run() {
+                        flushAllCaches();
+                    }
+                }.runTaskTimerAsynchronously(UltiTools.getInstance(), 20L, 20L * flushRate);
+                schedulerInitialized = true;
+            } catch (Exception e) {
+                // Scheduler initialization failed - likely in test environment
+                // This is acceptable as tests don't need periodic flushing
+            }
         }
     }
 
@@ -60,7 +84,7 @@ public class JsonStore implements DataStore {
      * Flush all cached data operators.
      * This method is extracted from BukkitRunnable for testability.
      */
-    static void flushAllCaches() {
+    void flushAllCaches() {
         for (Cached cached : dataOperatorMap.values()) {
             cached.flush();
             cached.gc();
@@ -70,14 +94,14 @@ public class JsonStore implements DataStore {
     /**
      * Get the number of registered data operators. Used for testing.
      */
-    static int getDataOperatorCount() {
+    int getDataOperatorCount() {
         return dataOperatorMap.size();
     }
 
     /**
      * Reset the scheduler state. Used for testing.
      */
-    static void resetSchedulerState() {
+    void resetSchedulerState() {
         schedulerInitialized = false;
     }
 
@@ -88,45 +112,38 @@ public class JsonStore implements DataStore {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(UltiToolsPlugin plugin, Class<T> dataEntity) {
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new IllegalArgumentException("No @Table annotation is present on: " + dataEntity.getName());
         }
-        Cached dataOperator = dataOperatorMap.get(dataEntity);
-        if (dataOperator == null) {
-            SimpleJsonDataOperator<T> tSimpleJsonDataOperator = new SimpleJsonDataOperator<>(
-                    storeLocation +
-                            File.separator +
-                            plugin.getPluginName() +
-                            File.separator +
-                            ReflectionUtil.getAnnotation(dataEntity, Table.class).value()
-                    , dataEntity
-            );
-            dataOperatorMap.putIfAbsent(dataEntity, tSimpleJsonDataOperator);
-            return tSimpleJsonDataOperator;
-        }
-        return (DataOperator<T>) dataOperator;
+        String location = storeLocation + File.separator + plugin.getPluginName() + File.separator
+                + ReflectionUtil.getAnnotation(dataEntity, Table.class).value();
+        Cached cached = dataOperatorMap.computeIfAbsent(new OperatorKey(plugin.getPluginName(), dataEntity),
+                key -> new SimpleJsonDataOperator<>(location, dataEntity));
+        return (DataOperator<T>) cached;
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(File dataFolder, Class<T> dataEntity) {
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new IllegalArgumentException("No @Table annotation is present on: " + dataEntity.getName());
         }
-        Cached dataOperator = dataOperatorMap.get(dataEntity);
-        if (dataOperator == null) {
-            SimpleJsonDataOperator<T> tSimpleJsonDataOperator = new SimpleJsonDataOperator<>(
-                    dataFolder.getAbsolutePath() +
-                            File.separator +
-                            "data" +
-                            File.separator +
-                            ReflectionUtil.getAnnotation(dataEntity, Table.class).value()
-                    , dataEntity
-            );
-            dataOperatorMap.putIfAbsent(dataEntity, tSimpleJsonDataOperator);
-            return tSimpleJsonDataOperator;
+        String identity = canonicalPath(dataFolder);
+        String location = dataFolder.getAbsolutePath() + File.separator + "data" + File.separator
+                + ReflectionUtil.getAnnotation(dataEntity, Table.class).value();
+        Cached cached = dataOperatorMap.computeIfAbsent(new OperatorKey(identity, dataEntity),
+                key -> new SimpleJsonDataOperator<>(location, dataEntity));
+        return (DataOperator<T>) cached;
+    }
+
+    private static String canonicalPath(File dataFolder) {
+        try {
+            return dataFolder.getCanonicalPath();
+        } catch (IOException e) {
+            return dataFolder.getAbsolutePath();
         }
-        return (DataOperator<T>) dataOperator;
     }
 
     @Override
@@ -141,5 +158,38 @@ public class JsonStore implements DataStore {
     @Override
     public String getStoreType() {
         return "json";
+    }
+
+    /**
+     * Composite operator-cache key: the requesting identity (plugin name on the plugin path,
+     * canonical data-folder path on the external {@code File} path) plus the entity class. Both
+     * {@code getOperator} overloads resolve their key through this same shape so the two entry
+     * paths cannot diverge again.
+     */
+    private static final class OperatorKey {
+        private final String identity;
+        private final Class<?> entityClass;
+
+        OperatorKey(String identity, Class<?> entityClass) {
+            this.identity = identity;
+            this.entityClass = entityClass;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof OperatorKey)) {
+                return false;
+            }
+            OperatorKey that = (OperatorKey) o;
+            return identity.equals(that.identity) && entityClass.equals(that.entityClass);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(identity, entityClass);
+        }
     }
 }

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonStore.java
@@ -122,15 +122,52 @@ public class JsonStore implements DataStore {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(UltiToolsPlugin plugin, Class<T> dataEntity) {
         checkOwnership(plugin, dataEntity);
-        if (!dataEntity.isAnnotationPresent(Table.class)) {
-            throw new IllegalArgumentException("No @Table annotation is present on: " + dataEntity.getName());
-        }
+        ensureTableAnnotation(dataEntity);
         String identity = plugin.getPluginName();
-        String location = storeLocation + File.separator + identity + File.separator
-                + ReflectionUtil.getAnnotation(dataEntity, Table.class).value();
+        return getOperatorForIdentity(identity, internalLocation(identity, dataEntity), dataEntity);
+    }
+
+    @Override
+    public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(File dataFolder, Class<T> dataEntity) {
+        checkOwnership(dataFolder, dataEntity);
+        ensureTableAnnotation(dataEntity);
+        String identity = canonicalPath(dataFolder);
+        return getOperatorForIdentity(identity, externalLocation(dataFolder, dataEntity), dataEntity);
+    }
+
+    /**
+     * Internal, unchecked construction path (CR-01/CR-03, 02-13): {@link
+     * com.ultikits.ultitools.interfaces.DataStore#getOperator(DataScope, Class)}'s default body
+     * calls this only after its own {@code scope.owns(...)} check has already passed. Branches
+     * internal/external exactly like {@link #identityOf(DataScope)} already does for {@link
+     * #transactionManagerFor(DataScope)} -- an internal scope resolves to {@link
+     * #internalLocation(String, Class)} keyed on the plugin's own name (never the framework's
+     * shared core folder, the collapse regression 02-07 guarded against and CR-01 found reopened
+     * as a bypass), an external scope to {@link #externalLocation(File, Class)}.
+     */
+    @Override
+    public <T extends BaseDataEntity<String>> DataOperator<T> getOperatorUnchecked(DataScope scope, Class<T> dataEntity) {
+        ensureTableAnnotation(dataEntity);
+        if (isInternalScope(scope)) {
+            String identity = scope.getPluginName();
+            return getOperatorForIdentity(identity, internalLocation(identity, dataEntity), dataEntity);
+        }
+        File dataFolder = scope.getDataFolder();
+        String identity = canonicalPath(dataFolder);
+        return getOperatorForIdentity(identity, externalLocation(dataFolder, dataEntity), dataEntity);
+    }
+
+    /**
+     * Shared operator-construction body for all three entry points above, once ownership and the
+     * {@code @Table} annotation have already been established by whichever one of them was
+     * called. Single-sourced so the operator cache (keyed by (identity, entity)) and the {@code
+     * transactionManagerFor(...)} wiring are each written in exactly one place.
+     */
+    @SuppressWarnings("unchecked")
+    private <T extends BaseDataEntity<String>> DataOperator<T> getOperatorForIdentity(
+            String identity, String location, Class<T> dataEntity) {
         Cached cached = dataOperatorMap.computeIfAbsent(new OperatorKey(identity, dataEntity),
                 key -> new SimpleJsonDataOperator<>(location, dataEntity));
         SimpleJsonDataOperator<T> operator = (SimpleJsonDataOperator<T>) cached;
@@ -138,21 +175,44 @@ public class JsonStore implements DataStore {
         return operator;
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(File dataFolder, Class<T> dataEntity) {
-        checkOwnership(dataFolder, dataEntity);
+    private static void ensureTableAnnotation(Class<?> dataEntity) {
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new IllegalArgumentException("No @Table annotation is present on: " + dataEntity.getName());
         }
-        String identity = canonicalPath(dataFolder);
-        String location = dataFolder.getAbsolutePath() + File.separator + "data" + File.separator
+    }
+
+    /**
+     * The internal-plugin storage location shape: {@code <store location>/<plugin name>/<@Table
+     * value>}. Shared by {@link #getOperator(UltiToolsPlugin, Class)} and {@link
+     * #getOperatorUnchecked(DataScope, Class)}'s internal branch.
+     */
+    private String internalLocation(String identity, Class<?> dataEntity) {
+        return storeLocation + File.separator + identity + File.separator
                 + ReflectionUtil.getAnnotation(dataEntity, Table.class).value();
-        Cached cached = dataOperatorMap.computeIfAbsent(new OperatorKey(identity, dataEntity),
-                key -> new SimpleJsonDataOperator<>(location, dataEntity));
-        SimpleJsonDataOperator<T> operator = (SimpleJsonDataOperator<T>) cached;
-        operator.bindTransactionManager(transactionManagerFor(identity));
-        return operator;
+    }
+
+    /**
+     * The external-plugin storage location shape: {@code <plugin's own data folder>/data/<@Table
+     * value>}. Shared by {@link #getOperator(File, Class)} and {@link
+     * #getOperatorUnchecked(DataScope, Class)}'s external branch.
+     */
+    private static String externalLocation(File dataFolder, Class<?> dataEntity) {
+        return dataFolder.getAbsolutePath() + File.separator + "data" + File.separator
+                + ReflectionUtil.getAnnotation(dataEntity, Table.class).value();
+    }
+
+    /**
+     * Whether {@code scope} is an internal plugin's own scope -- its {@code dataFolder} is exactly
+     * the core framework's own data folder ({@code DataScope.forPlugin}'s construction). The same
+     * disambiguation {@link #identityOf(DataScope)} already uses for {@link
+     * #transactionManagerFor(DataScope)} (02-05), extracted so {@link
+     * #getOperatorUnchecked(DataScope, Class)} can also pick the matching location-construction
+     * formula, not just the matching identity string.
+     */
+    private static boolean isInternalScope(DataScope scope) {
+        File coreDataFolder = UltiTools.getInstance() == null ? null : UltiTools.getInstance().getDataFolder();
+        return coreDataFolder != null
+                && Objects.equals(canonicalPath(scope.getDataFolder()), canonicalPath(coreDataFolder));
     }
 
     /**
@@ -193,12 +253,7 @@ public class JsonStore implements DataStore {
      * #canonicalPath}) is used.
      */
     private static String identityOf(DataScope scope) {
-        File coreDataFolder = UltiTools.getInstance() == null ? null : UltiTools.getInstance().getDataFolder();
-        if (coreDataFolder != null
-                && Objects.equals(canonicalPath(scope.getDataFolder()), canonicalPath(coreDataFolder))) {
-            return scope.getPluginName();
-        }
-        return canonicalPath(scope.getDataFolder());
+        return isInternalScope(scope) ? scope.getPluginName() : canonicalPath(scope.getDataFolder());
     }
 
     private static String canonicalPath(File dataFolder) {

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonStore.java
@@ -16,7 +16,9 @@ import com.ultikits.ultitools.annotations.Table;
 import com.ultikits.ultitools.interfaces.Cached;
 import com.ultikits.ultitools.interfaces.DataOperator;
 import com.ultikits.ultitools.interfaces.DataStore;
+import com.ultikits.ultitools.manager.DataScope;
 import com.ultikits.ultitools.manager.DataStoreManager;
+import com.ultikits.ultitools.manager.JsonTransactionManager;
 import com.ultikits.ultitools.utils.ReflectionUtil;
 
 /**
@@ -47,6 +49,14 @@ public class JsonStore implements DataStore {
     private static volatile boolean schedulerInitialized = false;
 
     private final String storeLocation;
+
+    /**
+     * Per-identity {@link JsonTransactionManager}, one per requesting identity -- the same
+     * identity {@link #dataOperatorMap} already keys by -- shared by every {@link
+     * SimpleJsonDataOperator} this store hands out for that identity (02-05, D-03). Not static,
+     * same reasoning as {@link #dataOperatorMap}.
+     */
+    private final Map<String, JsonTransactionManager> transactionManagers = new ConcurrentHashMap<>();
 
     /**
      * Initialize the flush scheduler. Called lazily when first JsonStore is created.
@@ -117,11 +127,14 @@ public class JsonStore implements DataStore {
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new IllegalArgumentException("No @Table annotation is present on: " + dataEntity.getName());
         }
-        String location = storeLocation + File.separator + plugin.getPluginName() + File.separator
+        String identity = plugin.getPluginName();
+        String location = storeLocation + File.separator + identity + File.separator
                 + ReflectionUtil.getAnnotation(dataEntity, Table.class).value();
-        Cached cached = dataOperatorMap.computeIfAbsent(new OperatorKey(plugin.getPluginName(), dataEntity),
+        Cached cached = dataOperatorMap.computeIfAbsent(new OperatorKey(identity, dataEntity),
                 key -> new SimpleJsonDataOperator<>(location, dataEntity));
-        return (DataOperator<T>) cached;
+        SimpleJsonDataOperator<T> operator = (SimpleJsonDataOperator<T>) cached;
+        operator.bindTransactionManager(transactionManagerFor(identity));
+        return operator;
     }
 
     @Override
@@ -135,10 +148,61 @@ public class JsonStore implements DataStore {
                 + ReflectionUtil.getAnnotation(dataEntity, Table.class).value();
         Cached cached = dataOperatorMap.computeIfAbsent(new OperatorKey(identity, dataEntity),
                 key -> new SimpleJsonDataOperator<>(location, dataEntity));
-        return (DataOperator<T>) cached;
+        SimpleJsonDataOperator<T> operator = (SimpleJsonDataOperator<T>) cached;
+        operator.bindTransactionManager(transactionManagerFor(identity));
+        return operator;
+    }
+
+    /**
+     * Resolves (creating on first use) the {@link JsonTransactionManager} for {@code scope},
+     * giving the JSON backend a real {@link com.ultikits.ultitools.interfaces.TransactionManager}
+     * so {@code @Transactional} is no longer refused on {@code datasource.type: json} (02-05,
+     * D-03). Called by {@code PluginManager.wireAop}'s JSON branch, a different package -- public
+     * for that reason, even though it is not part of the officially-extensible {@link DataStore}
+     * contract; the actual snapshot mechanics it drives stay package-private on {@link
+     * SimpleJsonDataOperator}, reached only from inside this class.
+     * <p>
+     * Shares one instance with every {@link SimpleJsonDataOperator} {@link #getOperator} hands
+     * out for the same identity, so a single {@code @Transactional} method's writes across
+     * several of that plugin's entities are governed by the same transaction.
+     *
+     * @param scope the identity token minted for the caller <br> 为调用方铸造的身份令牌
+     * @return this store's manager for that caller's identity <br> 该调用方身份对应的管理器
+     */
+    public JsonTransactionManager transactionManagerFor(DataScope scope) {
+        return transactionManagerFor(identityOf(scope));
+    }
+
+    private JsonTransactionManager transactionManagerFor(String identity) {
+        return transactionManagers.computeIfAbsent(identity, JsonTransactionManager::new);
+    }
+
+    /**
+     * Derives the same identity {@link #getOperator(UltiToolsPlugin, Class)} and {@link
+     * #getOperator(File, Class)} each already resolve for {@link OperatorKey}, from a {@link
+     * DataScope} instead of a raw plugin or {@link File}.
+     * <p>
+     * {@link DataScope} carries both a plugin name and a data folder but no explicit
+     * internal-vs-external discriminator, so this disambiguates the same way {@link
+     * DataScope#forPlugin} itself is built: an internal scope's data folder is always the core
+     * UltiTools plugin's own folder (shared by every internal plugin), which no external plugin's
+     * own folder can equal. When it matches, the plugin-path identity ({@link
+     * DataScope#getPluginName()}) is used; otherwise the external-path identity ({@link
+     * #canonicalPath}) is used.
+     */
+    private static String identityOf(DataScope scope) {
+        File coreDataFolder = UltiTools.getInstance() == null ? null : UltiTools.getInstance().getDataFolder();
+        if (coreDataFolder != null
+                && Objects.equals(canonicalPath(scope.getDataFolder()), canonicalPath(coreDataFolder))) {
+            return scope.getPluginName();
+        }
+        return canonicalPath(scope.getDataFolder());
     }
 
     private static String canonicalPath(File dataFolder) {
+        if (dataFolder == null) {
+            return null;
+        }
         try {
             return dataFolder.getCanonicalPath();
         } catch (IOException e) {

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperator.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperator.java
@@ -38,6 +38,8 @@ import com.google.gson.reflect.TypeToken;
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
 import com.ultikits.ultitools.annotations.Column;
 import com.ultikits.ultitools.entities.WhereCondition;
+import com.ultikits.ultitools.exceptions.DataAccessException;
+import com.ultikits.ultitools.exceptions.ErrorCode;
 import com.ultikits.ultitools.interfaces.Cached;
 import com.ultikits.ultitools.interfaces.DataOperator;
 import com.ultikits.ultitools.manager.JsonTransactionManager;
@@ -391,12 +393,30 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
      * a hook. {@link #delById(Object)} fetches the entity first and does fire {@code onDelete()}
      * on it (02-08-PLAN.md's delete-hook-path split, mirrored from
      * {@code AbstractRelationalDataOperator}).
+     * <p>
+     * A {@code null} or zero-length {@code whereConditions} is refused with a {@link
+     * DataAccessException}, matching {@code AbstractRelationalDataOperator.del()}'s guard and the
+     * contract {@link com.ultikits.ultitools.interfaces.DataOperator#del}'s interface javadoc
+     * promises (CR-02, 02-13). The refusal runs before {@link #beforeMutate()}, so a refused call
+     * does not capture a transaction snapshot as a side effect.
      */
     @Override
     public synchronized void del(WhereCondition... whereConditions) {
+        // Deliberately does NOT mirror getAll's empty-condition handling: on the query side,
+        // "empty conditions = no filter = return everything" is a reasonable convention; carried
+        // over to the delete side it becomes "delete the entire table", which is precisely the
+        // silent-full-wipe defect class this milestone exists to remove -- refuse both shapes
+        // before beforeMutate() runs (a zero-length array previously made the loop body below
+        // never run, so the call returned normally having deleted nothing; a null array threw a
+        // raw NullPointerException from the enhanced-for loop, not the DataAccessException the
+        // interface promises).
+        if (whereConditions == null || whereConditions.length == 0) {
+            throw new DataAccessException(ErrorCode.DATA_ENTITY_INVALID,
+                    "Refusing to delete every entry of JSON store '" + type.getSimpleName() + "' with no "
+                            + "WhereCondition. Pass an explicit condition, or use a dedicated full-table "
+                            + "operation if one genuinely exists.");
+        }
         beforeMutate();
-        // 这里刻意不照搬 getAll 对空条件的处理：在查询侧「空条件 = 不过滤 = 返回全量」是合理的，
-        // 搬到删除侧就成了「删光全表」。空条件目前会在下面取 getValue() 时抛 NPE，难看但失败方向安全。
         Collection<Map.Entry<Object, T>> results = new ArrayList<>();
         Type mapType = new TypeToken<Map<String, Object>>(){}.getType();
         boolean firstCondition = true;

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperator.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperator.java
@@ -35,6 +35,7 @@ import com.ultikits.ultitools.annotations.Column;
 import com.ultikits.ultitools.entities.WhereCondition;
 import com.ultikits.ultitools.interfaces.Cached;
 import com.ultikits.ultitools.interfaces.DataOperator;
+import com.ultikits.ultitools.manager.JsonTransactionManager;
 import com.ultikits.ultitools.utils.BeanCopyUtil;
 import com.ultikits.ultitools.utils.FileUtils;
 import com.ultikits.ultitools.utils.JsonPathUtil;
@@ -65,6 +66,19 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
      */
     private final Map<String, String> columnToFieldName;
 
+    /**
+     * The per-plugin {@link JsonTransactionManager} governing this operator, or {@code null} if
+     * this operator was never bound to one (e.g. constructed directly, as every pre-existing
+     * caller of the two-arg constructor still does -- see {@link #transaction(Callable)}, which
+     * is a separate, independent snapshot mechanism this field does not affect).
+     * <p>
+     * Set via {@link #bindTransactionManager(JsonTransactionManager)} by {@code JsonStore} (same
+     * package) right after this operator is constructed or retrieved from its cache (02-05, D-03).
+     * {@code volatile} because a write can happen on a different Bukkit worker thread than the one
+     * that bound the manager.
+     */
+    private volatile JsonTransactionManager transactionManager;
+
     public SimpleJsonDataOperator(String storeLocation, Class<T> type) {
         this.storeLocation = storeLocation;
         this.type = type;
@@ -81,6 +95,70 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
                 }
             });
         }
+    }
+
+    /**
+     * Binds the {@link JsonTransactionManager} this operator participates in (02-05, D-03).
+     * <p>
+     * Package-private: called only by {@code JsonStore}, right after it constructs or retrieves
+     * this operator from its cache, with the manager it resolves for the same identity. Not part
+     * of this class's public API.
+     *
+     * @param transactionManager the manager governing the plugin (or external caller) this
+     *                           operator belongs to
+     */
+    void bindTransactionManager(JsonTransactionManager transactionManager) {
+        this.transactionManager = transactionManager;
+    }
+
+    /**
+     * Called as the first statement of every cache-mutating method ({@link #insert}, {@link #del},
+     * {@link #delById}, the two {@code update} overloads). A no-op unless a {@link
+     * #bindTransactionManager bound} {@link JsonTransactionManager} has an active transaction on
+     * this thread and has not already captured this operator this transaction (D-03: lazy
+     * snapshot on first touch, so an operator never written to during the transaction is neither
+     * snapshotted nor restored).
+     * <p>
+     * The actual deep-copy capture ({@link #snapshotCache()}) and restore ({@link
+     * #restoreCache(Map)}) stay entirely inside this class; {@link JsonTransactionManager} only
+     * ever holds the {@code Supplier}/{@code Consumer} lambdas below, never this operator's cache
+     * directly.
+     */
+    private void beforeMutate() {
+        JsonTransactionManager manager = this.transactionManager;
+        if (manager != null) {
+            manager.captureIfAbsent(this, this::snapshotCache, snapshot -> restoreCache(uncheckedCast(snapshot)));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<Object, T> uncheckedCast(Object snapshot) {
+        return (Map<Object, T>) snapshot;
+    }
+
+    /**
+     * Deep-copies this operator's current cache: serialize/deserialize to break references, since
+     * {@code update(T)} mutates cached entities in-place via {@link
+     * BeanCopyUtil#copyProperties}. Package-private hook shared by {@link #transaction(Callable)}
+     * (the pre-existing per-operator mechanism, unchanged) and {@link #beforeMutate()} (the new
+     * per-plugin {@link JsonTransactionManager} hook, 02-05) -- one copy of the deep-copy logic,
+     * two callers.
+     */
+    synchronized Map<Object, T> snapshotCache() {
+        Map<Object, T> snapshot = new HashMap<>();
+        for (Map.Entry<Object, T> entry : cache.entrySet()) {
+            snapshot.put(entry.getKey(), GSON.fromJson(GSON.toJson(entry.getValue()), type));
+        }
+        return snapshot;
+    }
+
+    /**
+     * Restores this operator's cache from a snapshot previously captured by {@link
+     * #snapshotCache()}.
+     */
+    synchronized void restoreCache(Map<Object, T> snapshot) {
+        cache.clear();
+        cache.putAll(snapshot);
     }
 
     /**
@@ -234,6 +312,7 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
 
     @Override
     public synchronized void insert(T obj) {
+        beforeMutate();
         // 关系型后端在 id 为空时自动补一个 UUID（AbstractRelationalDataOperator.insert），
         // 所以模块从来不自己设 id —— 全部 Modules 加起来的 setId 调用是 0 次。
         // JSON 侧过去不补，null 直接进 ConcurrentHashMap 当 key，于是同一份模块代码
@@ -247,6 +326,7 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
 
     @Override
     public synchronized void del(WhereCondition... whereConditions) {
+        beforeMutate();
         // 这里刻意不照搬 getAll 对空条件的处理：在查询侧「空条件 = 不过滤 = 返回全量」是合理的，
         // 搬到删除侧就成了「删光全表」。空条件目前会在下面取 getValue() 时抛 NPE，难看但失败方向安全。
         Collection<Map.Entry<Object, T>> results = new ArrayList<>();
@@ -284,11 +364,13 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
 
     @Override
     public synchronized void delById(Object id) {
+        beforeMutate();
         cache.remove(id);
     }
 
     @Override
     public synchronized void update(String column, Object value, Object id) {
+        beforeMutate();
         if (!Serializable.class.isAssignableFrom(value.getClass())) {
             throw new RuntimeException("Query value is not serializable");
         }
@@ -303,6 +385,7 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
 
     @Override
     public synchronized void update(T obj) {
+        beforeMutate();
         Object id = obj.getId();
         T old = cache.get(id);
         if (old == null) {
@@ -358,16 +441,12 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
     public synchronized <R> R transaction(Callable<R> action) throws Exception {
         // Deep copy: serialize/deserialize to break references
         // (update(T) mutates entities in-place via BeanCopyUtil.copyProperties)
-        Map<Object, T> snapshot = new HashMap<>();
-        for (Map.Entry<Object, T> entry : cache.entrySet()) {
-            snapshot.put(entry.getKey(), GSON.fromJson(GSON.toJson(entry.getValue()), type));
-        }
+        Map<Object, T> snapshot = snapshotCache();
         try {
             return action.call();
         } catch (Exception e) {
             // Rollback: restore cache from deep copy
-            cache.clear();
-            cache.putAll(snapshot);
+            restoreCache(snapshot);
             throw e;
         }
     }

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperator.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperator.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -29,6 +30,10 @@ import org.bukkit.ChatColor;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializer;
 import com.google.gson.reflect.TypeToken;
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
 import com.ultikits.ultitools.annotations.Column;
@@ -51,7 +56,25 @@ import com.ultikits.ultitools.utils.ReflectionUtil;
  * @version 1.0.0
  */
 public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements DataOperator<T>, Cached {
-    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    /**
+     * Default Gson has no bundled adapter for {@code java.time.LocalDateTime}: its reflective
+     * fallback tries to reach {@code LocalDateTime}'s private fields, which JDK 9+'s module
+     * system refuses without {@code --add-opens java.base/java.time}, throwing
+     * {@code JsonIOException} the first time this operator serializes an entity carrying a
+     * non-null {@code LocalDateTime}-typed {@code @Column} (02-08 --
+     * {@code AuditableDataEntity#createdAt}/{@code updatedAt} were always {@code null} before
+     * this plan, so the whole-entity {@code GSON.toJson(...)} calls below never reached this type
+     * until the lifecycle hooks started populating it). Mirrors
+     * {@code AbstractRelationalDataOperator}'s identical adapter (02-08), serializing to/from
+     * {@link LocalDateTime#toString()}'s ISO-8601 form.
+     */
+    private static final Gson GSON = new GsonBuilder()
+            .setPrettyPrinting()
+            .registerTypeAdapter(LocalDateTime.class, (JsonSerializer<LocalDateTime>) (src, type, context) ->
+                    src == null ? JsonNull.INSTANCE : new JsonPrimitive(src.toString()))
+            .registerTypeAdapter(LocalDateTime.class, (JsonDeserializer<LocalDateTime>) (json, type, context) ->
+                    json.isJsonNull() ? null : LocalDateTime.parse(json.getAsString()))
+            .create();
 
     private final String storeLocation;
     private final Class<T> type;
@@ -205,12 +228,18 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
 
     @Override
     public boolean exist(WhereCondition... whereConditions) {
-        return !getAll(whereConditions).isEmpty();
+        // getAllRaw, not getAll: an existence check is not a read that returns entities to the
+        // caller, so it must not fire onLoad() as a side effect of computing a boolean.
+        return !getAllRaw(whereConditions).isEmpty();
     }
 
     @Override
     public T getById(Object id) {
-        return cache.get(id);
+        T entity = cache.get(id);
+        if (entity != null) {
+            entity.onLoad();
+        }
+        return entity;
     }
 
     @Override
@@ -218,8 +247,23 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
         return getAll(WhereCondition.empty());
     }
 
+    /**
+     * Fires {@code onLoad()} once per entity actually returned to the caller. Delegates the
+     * matching logic to {@link #getAllRaw}, which {@link #exist(WhereCondition...)} and
+     * {@link #page} also call directly -- {@code exist} because a boolean check should not fire
+     * a load hook, and {@code page} because firing on every matched row (rather than only the
+     * page's slice) would fire {@code onLoad()} for entities the caller never actually receives.
+     */
     @Override
     public List<T> getAll(WhereCondition... whereConditions) {
+        List<T> results = getAllRaw(whereConditions);
+        for (T entity : results) {
+            entity.onLoad();
+        }
+        return results;
+    }
+
+    private List<T> getAllRaw(WhereCondition... whereConditions) {
         // 空条件表示「不施加过滤」，先摘出去，免得它出现在第二个位置时中途返回全量。
         List<WhereCondition> effective = new ArrayList<>();
         for (WhereCondition condition : whereConditions) {
@@ -293,12 +337,19 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
                     break;
             }
         }
+        for (T entity : res) {
+            entity.onLoad();
+        }
         return res;
     }
 
     @Override
     public List<T> page(int page, int size, WhereCondition... whereConditions) {
-        List<T> all = new ArrayList<>(getAll(whereConditions));
+        // getAllRaw, not getAll: firing onLoad() on every matched row here (rather than only
+        // the slice actually returned below) would fire the hook for entities outside the
+        // requested page -- mirrors AbstractRelationalDataOperator's LIMIT/OFFSET behavior,
+        // which only ever materializes the page it returns.
+        List<T> all = new ArrayList<>(getAllRaw(whereConditions));
         int start = (page - 1) * size;
         int end = page * size;
         if (start > all.size()) {
@@ -307,7 +358,11 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
         if (end > all.size()) {
             end = all.size();
         }
-        return all.subList(start, end);
+        List<T> slice = all.subList(start, end);
+        for (T entity : slice) {
+            entity.onLoad();
+        }
+        return slice;
     }
 
     @Override
@@ -321,9 +376,22 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
         if (obj.getId() == null) {
             obj.setId(UUID.randomUUID().toString());
         }
+        // Fires before the cache is touched, mirroring AbstractRelationalDataOperator.insert:
+        // whatever onCreate() writes (e.g. AuditableDataEntity's createdAt/createdBy) is exactly
+        // what ends up cached (and, on flush(), persisted) -- obj is the same instance stored
+        // below, not a copy.
+        obj.onCreate();
         cache.putIfAbsent(obj.getId(), obj);
     }
 
+    /**
+     * Deletes by predicate, without loading matched entries into entities first. Consequently
+     * this overload does <strong>not</strong> fire {@code onDelete()} -- there is no entity to
+     * fire it on without fabricating one, and this class does not fabricate entities to satisfy
+     * a hook. {@link #delById(Object)} fetches the entity first and does fire {@code onDelete()}
+     * on it (02-08-PLAN.md's delete-hook-path split, mirrored from
+     * {@code AbstractRelationalDataOperator}).
+     */
     @Override
     public synchronized void del(WhereCondition... whereConditions) {
         beforeMutate();
@@ -362,9 +430,20 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
         }
     }
 
+    /**
+     * Deletes by id, fetching the entity first so {@code onDelete()} can fire on it -- unlike
+     * {@link #del(WhereCondition...)}, which deletes by predicate without materializing entries
+     * and therefore does not fire the hook. If no entry matches {@code id}, nothing fires. Reads
+     * the cache directly (not {@link #getById}) so this does not also fire {@code onLoad()} --
+     * deleting is not loading.
+     */
     @Override
     public synchronized void delById(Object id) {
         beforeMutate();
+        T entity = cache.get(id);
+        if (entity != null) {
+            entity.onDelete();
+        }
         cache.remove(id);
     }
 
@@ -392,6 +471,12 @@ public class SimpleJsonDataOperator<T extends BaseDataEntity<String>> implements
             old = cache.get(id.toString());
         }
         BeanCopyUtil.copyProperties(obj, old, "id");
+        // Fires on old (the instance actually cached below), after the incoming obj's fields have
+        // been copied onto it -- callers may pass either the same cached instance (the common
+        // get-mutate-update pattern) or a fresh detached instance with the same id; either way,
+        // whatever onUpdate() writes on the entity that ends up cached is what persists. Mirrors
+        // AbstractRelationalDataOperator.update(T)'s "fires before the row is written" ordering.
+        old.onUpdate();
         cache.put(old.getId(), old);
     }
 

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataStore.java
@@ -79,6 +79,7 @@ public class MysqlDataStore implements DataStore {
     @Override
     @SuppressWarnings("unchecked")
     public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(UltiToolsPlugin plugin, Class<T> dataEntity) {
+        checkOwnership(plugin, dataEntity);
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new RuntimeException("No Table annotation is presented!");
         }
@@ -89,6 +90,7 @@ public class MysqlDataStore implements DataStore {
     @Override
     @SuppressWarnings("unchecked")
     public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(File dataFolder, Class<T> dataEntity) {
+        checkOwnership(dataFolder, dataEntity);
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new RuntimeException("No Table annotation is presented!");
         }

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataStore.java
@@ -6,7 +6,9 @@ import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
 import com.ultikits.ultitools.annotations.Table;
 import com.ultikits.ultitools.interfaces.DataOperator;
 import com.ultikits.ultitools.interfaces.DataStore;
+import com.ultikits.ultitools.interfaces.JdbcTransactionManager;
 import com.ultikits.ultitools.manager.DataScope;
+import com.ultikits.ultitools.manager.DataSourceTransactionManager;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import lombok.Getter;
@@ -49,6 +51,21 @@ public class MysqlDataStore implements DataStore {
     @Getter
     private HikariDataSource dataSource;
 
+    /**
+     * {@link JdbcTransactionManager} cache, keyed by requesting identity -- one manager per
+     * plugin container even though every plugin shares the one global {@link #dataSource} (D-02):
+     * {@code contextHolder} is a per-instance {@code ThreadLocal} (FOUND-04), so two plugins each
+     * doing a {@code @Transactional} write on MySQL must never cross transaction state, exactly
+     * as {@code PluginManager.wireTransactional}'s own javadoc already documents for the JDBC
+     * path. Not static -- same reload-safety reasoning as {@link #dataOperatorMap}.
+     * <p>
+     * The single seam through which both {@link #transactionManagerFor(DataScope)} (called by
+     * {@code PluginManager.wireTransactional} for the AOP interceptor) and {@link #getOperator}
+     * (below) resolve a manager for the same identity -- {@code computeIfAbsent} guarantees the
+     * second caller gets back the exact instance the first one built (T-02-TAM-11).
+     */
+    private final Map<String, JdbcTransactionManager> transactionManagerMap = new ConcurrentHashMap<>();
+
     public MysqlDataStore() {
         MysqlConfig mysqlConfig = new MysqlConfig(UltiTools.getInstance().getConfig());
 
@@ -83,8 +100,13 @@ public class MysqlDataStore implements DataStore {
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new RuntimeException("No Table annotation is presented!");
         }
-        return (DataOperator<T>) dataOperatorMap.computeIfAbsent(new OperatorKey(plugin.getPluginName(), dataEntity),
-                key -> new MysqlDataOperator<>(dataSource, dataEntity));
+        String identity = plugin.getPluginName();
+        return (DataOperator<T>) dataOperatorMap.computeIfAbsent(new OperatorKey(identity, dataEntity),
+                key -> {
+                    MysqlDataOperator<T> operator = new MysqlDataOperator<>(dataSource, dataEntity);
+                    operator.setTransactionManager(transactionManagerForIdentity(identity));
+                    return operator;
+                });
     }
 
     @Override
@@ -94,13 +116,44 @@ public class MysqlDataStore implements DataStore {
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new RuntimeException("No Table annotation is presented!");
         }
-        return (DataOperator<T>) dataOperatorMap.computeIfAbsent(new OperatorKey(canonicalPath(dataFolder), dataEntity),
-                key -> new MysqlDataOperator<>(dataSource, dataEntity));
+        String identity = canonicalPath(dataFolder);
+        return (DataOperator<T>) dataOperatorMap.computeIfAbsent(new OperatorKey(identity, dataEntity),
+                key -> {
+                    MysqlDataOperator<T> operator = new MysqlDataOperator<>(dataSource, dataEntity);
+                    operator.setTransactionManager(transactionManagerForIdentity(identity));
+                    return operator;
+                });
     }
 
     @Override
     public javax.sql.DataSource getDataSource(DataScope scope) {
         return dataSource;
+    }
+
+    /**
+     * Resolves the same per-plugin-container {@link JdbcTransactionManager} instance {@link
+     * #getOperator} wires onto the operators it hands out for {@code scope}'s own identity -- the
+     * seam {@code PluginManager.wireTransactional} calls to bind the AOP {@code @Transactional}
+     * interceptor to it, so a module's data operators and its {@code @Transactional} beans share
+     * one transaction, not two (T-02-TAM-11), despite every plugin sharing the one global {@link
+     * #dataSource}.
+     *
+     * @param scope the identity token to resolve the manager for <br> 待解析管理器的身份令牌
+     * @return the shared manager for that scope's identity <br> 该 scope 身份共享的管理器
+     */
+    public JdbcTransactionManager transactionManagerFor(DataScope scope) {
+        UltiTools ultiTools = UltiTools.getInstance();
+        boolean internal = ultiTools != null && ultiTools.getDataFolder() != null
+                && ultiTools.getDataFolder().equals(scope.getDataFolder());
+        String identity = internal ? scope.getPluginName() : canonicalPath(scope.getDataFolder());
+        return transactionManagerForIdentity(identity);
+    }
+
+    /**
+     * Returns the manager for {@code identity}, building it on first touch.
+     */
+    private JdbcTransactionManager transactionManagerForIdentity(String identity) {
+        return transactionManagerMap.computeIfAbsent(identity, key -> new DataSourceTransactionManager(dataSource));
     }
 
     private static String canonicalPath(File dataFolder) {
@@ -115,6 +168,7 @@ public class MysqlDataStore implements DataStore {
     public void destroyAllOperators() {
         dataSource.close();
         dataOperatorMap.clear();
+        transactionManagerMap.clear();
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataStore.java
@@ -94,29 +94,43 @@ public class MysqlDataStore implements DataStore {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(UltiToolsPlugin plugin, Class<T> dataEntity) {
         checkOwnership(plugin, dataEntity);
-        if (!dataEntity.isAnnotationPresent(Table.class)) {
-            throw new RuntimeException("No Table annotation is presented!");
-        }
-        String identity = plugin.getPluginName();
-        return (DataOperator<T>) dataOperatorMap.computeIfAbsent(new OperatorKey(identity, dataEntity),
-                key -> {
-                    MysqlDataOperator<T> operator = new MysqlDataOperator<>(dataSource, dataEntity);
-                    operator.setTransactionManager(transactionManagerForIdentity(identity));
-                    return operator;
-                });
+        return getOperatorForIdentity(plugin.getPluginName(), dataEntity);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(File dataFolder, Class<T> dataEntity) {
         checkOwnership(dataFolder, dataEntity);
+        return getOperatorForIdentity(canonicalPath(dataFolder), dataEntity);
+    }
+
+    /**
+     * Internal, unchecked construction path (CR-01/CR-03, 02-13): {@link
+     * com.ultikits.ultitools.interfaces.DataStore#getOperator(DataScope, Class)}'s default body
+     * calls this only after its own {@code scope.owns(...)} check has already passed. Resolves
+     * {@code scope} to the exact same identity {@link #identityFor(DataScope)} already derives for
+     * {@link #transactionManagerFor(DataScope)} -- internal scopes resolve to the plugin's own
+     * name, external scopes to the canonical data-folder path -- so an internal scope's operator
+     * cache entry is keyed identically whether reached through here or through {@link
+     * #getOperator(UltiToolsPlugin, Class)}.
+     */
+    @Override
+    public <T extends BaseDataEntity<String>> DataOperator<T> getOperatorUnchecked(DataScope scope, Class<T> dataEntity) {
+        return getOperatorForIdentity(identityFor(scope), dataEntity);
+    }
+
+    /**
+     * Shared operator-construction body for all three entry points above, once ownership has
+     * already been established by whichever one of them was called. Single-sourced so the
+     * operator cache (keyed by (identity, entity)) and the {@code transactionManagerForIdentity}
+     * wiring are each written in exactly one place.
+     */
+    @SuppressWarnings("unchecked")
+    private <T extends BaseDataEntity<String>> DataOperator<T> getOperatorForIdentity(String identity, Class<T> dataEntity) {
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new RuntimeException("No Table annotation is presented!");
         }
-        String identity = canonicalPath(dataFolder);
         return (DataOperator<T>) dataOperatorMap.computeIfAbsent(new OperatorKey(identity, dataEntity),
                 key -> {
                     MysqlDataOperator<T> operator = new MysqlDataOperator<>(dataSource, dataEntity);
@@ -142,11 +156,24 @@ public class MysqlDataStore implements DataStore {
      * @return the shared manager for that scope's identity <br> 该 scope 身份共享的管理器
      */
     public JdbcTransactionManager transactionManagerFor(DataScope scope) {
+        return transactionManagerForIdentity(identityFor(scope));
+    }
+
+    /**
+     * Resolves {@code scope}'s operator-cache identity, matching whichever legacy {@code
+     * getOperator} overload the same scope would actually route through: the internal (plugin
+     * name) shape when {@code scope} is an internal plugin's own scope (its {@code dataFolder} is
+     * exactly the core framework's own data folder, {@code DataScope.forPlugin}'s construction --
+     * the same disambiguation {@code JsonStore.identityOf(DataScope)} and {@code
+     * SQLiteDataStore.dbPathFor(DataScope)} use, 02-05), the external (canonical folder path)
+     * shape otherwise. Shared by {@link #transactionManagerFor(DataScope)} and {@link
+     * #getOperatorUnchecked(DataScope, Class)} (02-13) so the two never disagree on identity.
+     */
+    private static String identityFor(DataScope scope) {
         UltiTools ultiTools = UltiTools.getInstance();
         boolean internal = ultiTools != null && ultiTools.getDataFolder() != null
                 && ultiTools.getDataFolder().equals(scope.getDataFolder());
-        String identity = internal ? scope.getPluginName() : canonicalPath(scope.getDataFolder());
-        return transactionManagerForIdentity(identity);
+        return internal ? scope.getPluginName() : canonicalPath(scope.getDataFolder());
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataStore.java
@@ -6,17 +6,47 @@ import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
 import com.ultikits.ultitools.annotations.Table;
 import com.ultikits.ultitools.interfaces.DataOperator;
 import com.ultikits.ultitools.interfaces.DataStore;
+import com.ultikits.ultitools.manager.DataScope;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import lombok.Getter;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
-@Getter
+/**
+ * MySQL-backed {@link DataStore}.
+ * <p>
+ * There is exactly one global {@link HikariDataSource} for the whole server (constructed once
+ * from {@code config.yml}'s {@code mysql.*} settings), so re-scoping does not move any MySQL data
+ * -- but the operator cache below is keyed by (requesting identity, entity class), not by entity
+ * class alone, so two plugins sharing an entity class no longer share one {@link DataOperator}
+ * instance and cannot read each other's rows through it (SILENT-04). Neither map is {@code
+ * static}: {@code DataStoreManager} registers exactly one {@code MysqlDataStore} instance.
+ * <p>
+ * 基于 MySQL 的 {@link DataStore} 实现。整个服务器只有一个全局 {@link HikariDataSource}
+ * （从 {@code config.yml} 的 {@code mysql.*} 配置中构造一次），因此重新划定作用域不会迁移任何
+ * MySQL 数据——但下面的操作器缓存按（请求方身份，实体类）而非仅按实体类分组，因此两个共享同一
+ * 实体类的插件不再共享同一个 {@link DataOperator} 实例，也就无法通过它读到对方的数据行
+ * （SILENT-04）。两个 Map 均非 {@code static}：{@code DataStoreManager} 只注册一个
+ * {@code MysqlDataStore} 实例。
+ *
+ * @author wisdomme
+ * @version 1.0.0
+ */
 public class MysqlDataStore implements DataStore {
-    private static final Map<Class<?>, DataOperator<?>> dataOperatorMap = new ConcurrentHashMap<>();
+
+    /**
+     * Operator cache, keyed by (requesting identity, entity class). Not static -- see class
+     * javadoc. Deliberately not Lombok-{@code @Getter}'d -- it must stay encapsulated, unlike
+     * {@link #dataSource} below which the framework already exposes.
+     */
+    private final Map<OperatorKey, DataOperator<?>> dataOperatorMap = new ConcurrentHashMap<>();
+    @Getter
     private HikariDataSource dataSource;
 
     public MysqlDataStore() {
@@ -47,34 +77,74 @@ public class MysqlDataStore implements DataStore {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(UltiToolsPlugin plugin, Class<T> dataEntity) {
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new RuntimeException("No Table annotation is presented!");
         }
-        DataOperator<T> tMysqlDataOperator = (DataOperator<T>) dataOperatorMap.get(dataEntity);
-        if (tMysqlDataOperator == null) {
-            tMysqlDataOperator = new MysqlDataOperator<>(dataSource, dataEntity);
-            dataOperatorMap.put(dataEntity, tMysqlDataOperator);
-        }
-        return tMysqlDataOperator;
+        return (DataOperator<T>) dataOperatorMap.computeIfAbsent(new OperatorKey(plugin.getPluginName(), dataEntity),
+                key -> new MysqlDataOperator<>(dataSource, dataEntity));
     }
 
     @Override
-    public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(java.io.File dataFolder, Class<T> dataEntity) {
+    @SuppressWarnings("unchecked")
+    public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(File dataFolder, Class<T> dataEntity) {
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new RuntimeException("No Table annotation is presented!");
         }
-        DataOperator<T> tMysqlDataOperator = (DataOperator<T>) dataOperatorMap.get(dataEntity);
-        if (tMysqlDataOperator == null) {
-            tMysqlDataOperator = new MysqlDataOperator<>(dataSource, dataEntity);
-            dataOperatorMap.put(dataEntity, tMysqlDataOperator);
+        return (DataOperator<T>) dataOperatorMap.computeIfAbsent(new OperatorKey(canonicalPath(dataFolder), dataEntity),
+                key -> new MysqlDataOperator<>(dataSource, dataEntity));
+    }
+
+    @Override
+    public javax.sql.DataSource getDataSource(DataScope scope) {
+        return dataSource;
+    }
+
+    private static String canonicalPath(File dataFolder) {
+        try {
+            return dataFolder.getCanonicalPath();
+        } catch (IOException e) {
+            return dataFolder.getAbsolutePath();
         }
-        return tMysqlDataOperator;
     }
 
     @Override
     public void destroyAllOperators() {
         dataSource.close();
+        dataOperatorMap.clear();
     }
 
+    /**
+     * Composite operator-cache key: the requesting identity (plugin name on the plugin path,
+     * canonical data-folder path on the external {@code File} path) plus the entity class. Both
+     * {@code getOperator} overloads resolve their key through this same shape so the two entry
+     * paths cannot diverge again.
+     */
+    private static final class OperatorKey {
+        private final String identity;
+        private final Class<?> entityClass;
+
+        OperatorKey(String identity, Class<?> entityClass) {
+            this.identity = identity;
+            this.entityClass = entityClass;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof OperatorKey)) {
+                return false;
+            }
+            OperatorKey that = (OperatorKey) o;
+            return identity.equals(that.identity) && entityClass.equals(that.entityClass);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(identity, entityClass);
+        }
+    }
 }

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStore.java
@@ -83,29 +83,45 @@ public class SQLiteDataStore implements DataStore {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(UltiToolsPlugin plugin, Class<T> dataEntity) {
         checkOwnership(plugin, dataEntity);
-        if (!dataEntity.isAnnotationPresent(Table.class)) {
-            throw new RuntimeException("No Table annotation is presented!");
-        }
-        String dbPath = dbPathForPlugin(plugin.getPluginName());
-        return (DataOperator<T>) dataOperatorMap.computeIfAbsent(new OperatorKey(dbPath, dataEntity),
-                key -> {
-                    SQLiteDataOperator<T> operator = new SQLiteDataOperator<>(poolFor(dbPath), dataEntity);
-                    operator.setTransactionManager(transactionManagerForPath(dbPath));
-                    return operator;
-                });
+        return getOperatorForPath(dbPathForPlugin(plugin.getPluginName()), dataEntity);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(File dataFolder, Class<T> dataEntity) {
         checkOwnership(dataFolder, dataEntity);
+        return getOperatorForPath(dbPathForFolder(dataFolder), dataEntity);
+    }
+
+    /**
+     * Internal, unchecked construction path (CR-01/CR-03, 02-13): {@link
+     * com.ultikits.ultitools.interfaces.DataStore#getOperator(DataScope, Class)}'s default body
+     * calls this only after its own {@code scope.owns(...)} check has already passed. Resolves
+     * {@code scope} to the exact same {@code .db} path {@link #dbPathFor(DataScope)} already
+     * derives for {@link #transactionManagerFor(DataScope)} -- internal scopes resolve to {@link
+     * #dbPathForPlugin(String)} keyed on the plugin's own name, external scopes to {@link
+     * #dbPathForFolder(File)} -- so an internal scope never collapses onto the framework's shared
+     * core folder the way routing through the public {@code getOperator(File, Class)} overload
+     * used to (the exact regression 02-07 guarded against and CR-01 found reopened as a security
+     * bypass).
+     */
+    @Override
+    public <T extends BaseDataEntity<String>> DataOperator<T> getOperatorUnchecked(DataScope scope, Class<T> dataEntity) {
+        return getOperatorForPath(dbPathFor(scope), dataEntity);
+    }
+
+    /**
+     * Shared operator-construction body for all three entry points above, once ownership has
+     * already been established by whichever one of them was called. Single-sourced so the pool
+     * cache (keyed by backing-file path), the operator cache (keyed by (path, entity)), and the
+     * {@code transactionManagerFor(...)} wiring are each written in exactly one place.
+     */
+    @SuppressWarnings("unchecked")
+    private <T extends BaseDataEntity<String>> DataOperator<T> getOperatorForPath(String dbPath, Class<T> dataEntity) {
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new RuntimeException("No Table annotation is presented!");
         }
-        String dbPath = dbPathForFolder(dataFolder);
         return (DataOperator<T>) dataOperatorMap.computeIfAbsent(new OperatorKey(dbPath, dataEntity),
                 key -> {
                     SQLiteDataOperator<T> operator = new SQLiteDataOperator<>(poolFor(dbPath), dataEntity);

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStore.java
@@ -1,8 +1,12 @@
 package com.ultikits.ultitools.interfaces.impl.data.sqlite;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.sql.DataSource;
 
@@ -16,13 +20,43 @@ import com.ultikits.ultitools.manager.DataScope;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
+/**
+ * SQLite-backed {@link DataStore}.
+ * <p>
+ * A connection pool is keyed by the canonical path of the backing {@code .db} file, independent
+ * of any single entity class -- two entity classes stored in the same file share exactly one
+ * {@link HikariDataSource}. The operator cache is keyed by (that same file path, entity class), so
+ * two callers resolving to two different files (two plugins, or the plugin path vs. the external
+ * {@code File} path) never share a {@link DataOperator} instance. Neither map is {@code static}:
+ * {@code DataStoreManager} registers exactly one {@code SQLiteDataStore} instance, and instance
+ * scoping is what stops both maps from outliving a {@code /reload}.
+ * <p>
+ * 基于 SQLite 的 {@link DataStore} 实现。连接池按底层 {@code .db} 文件的规范路径分组，与具体
+ * 实体类无关——存储在同一文件中的多个实体类共享同一个 {@link HikariDataSource}。操作器缓存按
+ * （同一个文件路径，实体类）的组合键分组，因此解析到两个不同文件的调用方（两个插件，或插件路径
+ * 与外部 {@code File} 路径）永远不会共享同一个 {@link DataOperator} 实例。两个 Map 均非
+ * {@code static}：{@code DataStoreManager} 只注册一个 {@code SQLiteDataStore} 实例，实例级作用域
+ * 正是防止两个 Map 在 {@code /reload} 后继续存活的原因。
+ *
+ * @author wisdomme
+ * @since 1.0.0
+ */
 public class SQLiteDataStore implements DataStore {
-    private static final Map<Class<?>, DataOperator<?>> dataOperatorMap = new ConcurrentHashMap<>();
-    // Keyed by resolved .db file path, not by entity class -- independent of dataOperatorMap above.
-    // A JDBC connection pool needs only a file path, not @Table metadata. SILENT-03's re-key of
-    // dataOperatorMap itself is a later plan's work; this map exists solely to serve
-    // getDataSource(DataScope) before any entity operator has ever been requested.
-    private static final Map<String, DataSource> dataSourceMap = new ConcurrentHashMap<>();
+
+    private static final Logger LOGGER = Logger.getLogger(SQLiteDataStore.class.getName());
+
+    /**
+     * Operator cache, keyed by (backing .db file canonical path, entity class). Not static -- see
+     * class javadoc.
+     */
+    private final Map<OperatorKey, DataOperator<?>> dataOperatorMap = new ConcurrentHashMap<>();
+
+    /**
+     * Connection pool cache, keyed by the backing .db file's canonical path. One pool per file,
+     * regardless of how many entity classes or callers resolve to it. Not static -- see class
+     * javadoc.
+     */
+    private final Map<String, HikariDataSource> dataSourceMap = new ConcurrentHashMap<>();
 
     @Override
     public String getStoreType() {
@@ -30,70 +64,124 @@ public class SQLiteDataStore implements DataStore {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(UltiToolsPlugin plugin, Class<T> dataEntity) {
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new RuntimeException("No Table annotation is presented!");
         }
-        DataOperator<T> tSQLiteDataOperator = (DataOperator<T>) dataOperatorMap.get(dataEntity);
-        if (tSQLiteDataOperator == null) {
-            File dataFolder = new File(UltiTools.getInstance().getDataFolder() + File.separator + "sqliteDB");
-            if (!dataFolder.exists()) {
-                dataFolder.mkdirs();
-            }
-            HikariConfig config = new HikariConfig();
-            config.setJdbcUrl("jdbc:sqlite://" + dataFolder.getAbsolutePath() + "/" + plugin.getPluginName() + ".db");
-            config.setDriverClassName("org.sqlite.JDBC");
-            config.setMaximumPoolSize(10);
-            DataSource dataSource = new HikariDataSource(config);
-            tSQLiteDataOperator = new SQLiteDataOperator<>(dataSource, dataEntity);
-            dataOperatorMap.put(dataEntity, tSQLiteDataOperator);
-        }
-        return tSQLiteDataOperator;
+        File dataFolder = new File(UltiTools.getInstance().getDataFolder(), "sqliteDB");
+        ensureExists(dataFolder);
+        String dbPath = canonicalPath(new File(dataFolder, plugin.getPluginName() + ".db"));
+        return (DataOperator<T>) dataOperatorMap.computeIfAbsent(new OperatorKey(dbPath, dataEntity),
+                key -> new SQLiteDataOperator<>(poolFor(dbPath), dataEntity));
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(File dataFolder, Class<T> dataEntity) {
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new RuntimeException("No Table annotation is presented!");
         }
-        DataOperator<T> tSQLiteDataOperator = (DataOperator<T>) dataOperatorMap.get(dataEntity);
-        if (tSQLiteDataOperator == null) {
-            if (!dataFolder.exists()) {
-                dataFolder.mkdirs();
-            }
-            HikariConfig config = new HikariConfig();
-            config.setJdbcUrl("jdbc:sqlite://" + dataFolder.getAbsolutePath() + "/data.db");
-            config.setDriverClassName("org.sqlite.JDBC");
-            config.setMaximumPoolSize(10);
-            DataSource dataSource = new HikariDataSource(config);
-            tSQLiteDataOperator = new SQLiteDataOperator<>(dataSource, dataEntity);
-            dataOperatorMap.put(dataEntity, tSQLiteDataOperator);
-        }
-        return tSQLiteDataOperator;
+        ensureExists(dataFolder);
+        String dbPath = canonicalPath(new File(dataFolder, "data.db"));
+        return (DataOperator<T>) dataOperatorMap.computeIfAbsent(new OperatorKey(dbPath, dataEntity),
+                key -> new SQLiteDataOperator<>(poolFor(dbPath), dataEntity));
     }
 
     @Override
     public DataSource getDataSource(DataScope scope) {
         File dataFolder = new File(scope.getDataFolder(), "sqliteDB");
+        ensureExists(dataFolder);
+        String dbPath = canonicalPath(new File(dataFolder, scope.getPluginName() + ".db"));
+        return poolFor(dbPath);
+    }
+
+    /**
+     * Returns the pool for {@code dbPath}, building it on first touch. {@link Map#computeIfAbsent}
+     * makes a concurrent first touch by two callers build exactly one pool, never two.
+     *
+     * @param dbPath canonical path of the backing .db file <br> 底层 .db 文件的规范路径
+     * @return the shared pool for that file <br> 该文件共享的连接池
+     */
+    private HikariDataSource poolFor(String dbPath) {
+        return dataSourceMap.computeIfAbsent(dbPath, path -> {
+            HikariConfig config = new HikariConfig();
+            config.setJdbcUrl("jdbc:sqlite://" + path);
+            config.setDriverClassName("org.sqlite.JDBC");
+            config.setMaximumPoolSize(10);
+            return new HikariDataSource(config);
+        });
+    }
+
+    private static void ensureExists(File dataFolder) {
         if (!dataFolder.exists()) {
             dataFolder.mkdirs();
         }
-        String dbPath = dataFolder.getAbsolutePath() + "/" + scope.getPluginName() + ".db";
-        DataSource cached = dataSourceMap.get(dbPath);
-        if (cached != null) {
-            return cached;
-        }
-        HikariConfig config = new HikariConfig();
-        config.setJdbcUrl("jdbc:sqlite://" + dbPath);
-        config.setDriverClassName("org.sqlite.JDBC");
-        config.setMaximumPoolSize(10);
-        DataSource dataSource = new HikariDataSource(config);
-        dataSourceMap.put(dbPath, dataSource);
-        return dataSource;
     }
 
+    private static String canonicalPath(File dbFile) {
+        try {
+            return dbFile.getCanonicalPath();
+        } catch (IOException e) {
+            return dbFile.getAbsolutePath();
+        }
+    }
+
+    /**
+     * Closes every pool this store holds and empties both caches. Idempotent -- calling it twice
+     * closes nothing the second time, since the first call already emptied {@link #dataSourceMap}.
+     * A failure closing one pool is logged and does not stop the rest from being closed.
+     * <p>
+     * 关闭本 store 持有的每一个连接池，并清空两个缓存。幂等——因为第一次调用已经清空了
+     * {@link #dataSourceMap}，第二次调用不会关闭任何东西。关闭某个连接池失败只会被记录，
+     * 不会中断其余连接池的关闭。
+     */
     @Override
     public void destroyAllOperators() {
+        for (Map.Entry<String, HikariDataSource> entry : dataSourceMap.entrySet()) {
+            HikariDataSource pool = entry.getValue();
+            try {
+                if (!pool.isClosed()) {
+                    pool.close();
+                }
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Failed to close SQLite connection pool for " + entry.getKey(), e);
+            }
+        }
+        dataSourceMap.clear();
+        dataOperatorMap.clear();
     }
 
+    /**
+     * Composite operator-cache key: the backing .db file's canonical path plus the entity class.
+     * Both {@code getOperator} overloads resolve their key through this same shape so the two
+     * entry paths cannot diverge again (see 02-CONTEXT.md's "Per-backend path rules differ between
+     * the two entry paths" note).
+     */
+    private static final class OperatorKey {
+        private final String dbPath;
+        private final Class<?> entityClass;
+
+        OperatorKey(String dbPath, Class<?> entityClass) {
+            this.dbPath = dbPath;
+            this.entityClass = entityClass;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof OperatorKey)) {
+                return false;
+            }
+            OperatorKey that = (OperatorKey) o;
+            return dbPath.equals(that.dbPath) && entityClass.equals(that.entityClass);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(dbPath, entityClass);
+        }
+    }
 }

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStore.java
@@ -16,7 +16,9 @@ import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
 import com.ultikits.ultitools.annotations.Table;
 import com.ultikits.ultitools.interfaces.DataOperator;
 import com.ultikits.ultitools.interfaces.DataStore;
+import com.ultikits.ultitools.interfaces.JdbcTransactionManager;
 import com.ultikits.ultitools.manager.DataScope;
+import com.ultikits.ultitools.manager.DataSourceTransactionManager;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
@@ -58,6 +60,23 @@ public class SQLiteDataStore implements DataStore {
      */
     private final Map<String, HikariDataSource> dataSourceMap = new ConcurrentHashMap<>();
 
+    /**
+     * {@link JdbcTransactionManager} cache, keyed identically to {@link #dataSourceMap} -- the
+     * backing .db file's canonical path (D-02: one JDBC {@link DataSource} per file already means
+     * one manager per file is "one per plugin container", since each plugin has its own file).
+     * Not static -- same reload-safety reasoning as the other two maps.
+     * <p>
+     * This is the single seam through which BOTH {@link #transactionManagerFor(DataScope)}
+     * (called by {@code PluginManager.wireTransactional} for the AOP interceptor) and {@link
+     * #getOperator} (below, for the operators this store hands module authors) resolve a manager
+     * for the same file -- {@code computeIfAbsent} guarantees the second caller to touch a given
+     * key gets back the exact instance the first one built, never a second, independent one
+     * (T-02-TAM-11: two managers over one file would give a {@code @Transactional} method calling
+     * {@code insertAll} two independent transactions, which is worse than no transaction at all
+     * because it looks correct).
+     */
+    private final Map<String, JdbcTransactionManager> transactionManagerMap = new ConcurrentHashMap<>();
+
     @Override
     public String getStoreType() {
         return "sqlite";
@@ -70,11 +89,13 @@ public class SQLiteDataStore implements DataStore {
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new RuntimeException("No Table annotation is presented!");
         }
-        File dataFolder = new File(UltiTools.getInstance().getDataFolder(), "sqliteDB");
-        ensureExists(dataFolder);
-        String dbPath = canonicalPath(new File(dataFolder, plugin.getPluginName() + ".db"));
+        String dbPath = dbPathForPlugin(plugin.getPluginName());
         return (DataOperator<T>) dataOperatorMap.computeIfAbsent(new OperatorKey(dbPath, dataEntity),
-                key -> new SQLiteDataOperator<>(poolFor(dbPath), dataEntity));
+                key -> {
+                    SQLiteDataOperator<T> operator = new SQLiteDataOperator<>(poolFor(dbPath), dataEntity);
+                    operator.setTransactionManager(transactionManagerForPath(dbPath));
+                    return operator;
+                });
     }
 
     @Override
@@ -84,18 +105,75 @@ public class SQLiteDataStore implements DataStore {
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new RuntimeException("No Table annotation is presented!");
         }
-        ensureExists(dataFolder);
-        String dbPath = canonicalPath(new File(dataFolder, "data.db"));
+        String dbPath = dbPathForFolder(dataFolder);
         return (DataOperator<T>) dataOperatorMap.computeIfAbsent(new OperatorKey(dbPath, dataEntity),
-                key -> new SQLiteDataOperator<>(poolFor(dbPath), dataEntity));
+                key -> {
+                    SQLiteDataOperator<T> operator = new SQLiteDataOperator<>(poolFor(dbPath), dataEntity);
+                    operator.setTransactionManager(transactionManagerForPath(dbPath));
+                    return operator;
+                });
     }
 
     @Override
     public DataSource getDataSource(DataScope scope) {
-        File dataFolder = new File(scope.getDataFolder(), "sqliteDB");
+        return poolFor(dbPathFor(scope));
+    }
+
+    /**
+     * Resolves the same per-plugin-container {@link JdbcTransactionManager} instance {@link
+     * #getOperator} wires onto the operators it hands out for {@code scope}'s own database file
+     * -- the seam {@code PluginManager.wireTransactional} calls to bind the AOP {@code
+     * @Transactional} interceptor to it, so a module's data operators and its {@code
+     * @Transactional} beans share one transaction, not two (T-02-TAM-11).
+     *
+     * @param scope the identity token to resolve the manager for <br> 待解析管理器的身份令牌
+     * @return the shared manager for that scope's database file <br> 该 scope 数据库文件共享的管理器
+     */
+    public JdbcTransactionManager transactionManagerFor(DataScope scope) {
+        return transactionManagerForPath(dbPathFor(scope));
+    }
+
+    /**
+     * Returns the manager for {@code dbPath}, building it on first touch -- the same {@code
+     * computeIfAbsent} single-construction guarantee {@link #poolFor(String)} already gives the
+     * connection pool for that file.
+     */
+    private JdbcTransactionManager transactionManagerForPath(String dbPath) {
+        return transactionManagerMap.computeIfAbsent(dbPath, path -> new DataSourceTransactionManager(poolFor(path)));
+    }
+
+    /**
+     * Resolves {@code scope}'s backing .db file path, matching whichever legacy {@code
+     * getOperator} overload the same scope would actually route through: the internal ({@code
+     * dbPathForPlugin}) shape when {@code scope} is an internal plugin's own scope (its {@code
+     * dataFolder} is exactly the core framework's own data folder, {@code DataScope.forPlugin}'s
+     * construction -- the same disambiguation {@code JsonStore.identityOf(DataScope)} uses, 02-05),
+     * the external ({@code dbPathForFolder}) shape otherwise.
+     */
+    private static String dbPathFor(DataScope scope) {
+        UltiTools ultiTools = UltiTools.getInstance();
+        boolean internal = ultiTools != null && ultiTools.getDataFolder() != null
+                && ultiTools.getDataFolder().equals(scope.getDataFolder());
+        return internal ? dbPathForPlugin(scope.getPluginName()) : dbPathForFolder(scope.getDataFolder());
+    }
+
+    /**
+     * The internal-plugin .db path shape: {@code <core data folder>/sqliteDB/<plugin name>.db}.
+     * Shared by {@link #getOperator(UltiToolsPlugin, Class)} and {@link #dbPathFor(DataScope)}.
+     */
+    private static String dbPathForPlugin(String pluginName) {
+        File dataFolder = new File(UltiTools.getInstance().getDataFolder(), "sqliteDB");
         ensureExists(dataFolder);
-        String dbPath = canonicalPath(new File(dataFolder, scope.getPluginName() + ".db"));
-        return poolFor(dbPath);
+        return canonicalPath(new File(dataFolder, pluginName + ".db"));
+    }
+
+    /**
+     * The external-plugin .db path shape: {@code <plugin's own data folder>/data.db}. Shared by
+     * {@link #getOperator(File, Class)} and {@link #dbPathFor(DataScope)}.
+     */
+    private static String dbPathForFolder(File dataFolder) {
+        ensureExists(dataFolder);
+        return canonicalPath(new File(dataFolder, "data.db"));
     }
 
     /**
@@ -152,6 +230,7 @@ public class SQLiteDataStore implements DataStore {
         }
         dataSourceMap.clear();
         dataOperatorMap.clear();
+        transactionManagerMap.clear();
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStore.java
@@ -12,11 +12,17 @@ import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
 import com.ultikits.ultitools.annotations.Table;
 import com.ultikits.ultitools.interfaces.DataOperator;
 import com.ultikits.ultitools.interfaces.DataStore;
+import com.ultikits.ultitools.manager.DataScope;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
 public class SQLiteDataStore implements DataStore {
     private static final Map<Class<?>, DataOperator<?>> dataOperatorMap = new ConcurrentHashMap<>();
+    // Keyed by resolved .db file path, not by entity class -- independent of dataOperatorMap above.
+    // A JDBC connection pool needs only a file path, not @Table metadata. SILENT-03's re-key of
+    // dataOperatorMap itself is a later plan's work; this map exists solely to serve
+    // getDataSource(DataScope) before any entity operator has ever been requested.
+    private static final Map<String, DataSource> dataSourceMap = new ConcurrentHashMap<>();
 
     @Override
     public String getStoreType() {
@@ -64,6 +70,26 @@ public class SQLiteDataStore implements DataStore {
             dataOperatorMap.put(dataEntity, tSQLiteDataOperator);
         }
         return tSQLiteDataOperator;
+    }
+
+    @Override
+    public DataSource getDataSource(DataScope scope) {
+        File dataFolder = new File(scope.getDataFolder(), "sqliteDB");
+        if (!dataFolder.exists()) {
+            dataFolder.mkdirs();
+        }
+        String dbPath = dataFolder.getAbsolutePath() + "/" + scope.getPluginName() + ".db";
+        DataSource cached = dataSourceMap.get(dbPath);
+        if (cached != null) {
+            return cached;
+        }
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:sqlite://" + dbPath);
+        config.setDriverClassName("org.sqlite.JDBC");
+        config.setMaximumPoolSize(10);
+        DataSource dataSource = new HikariDataSource(config);
+        dataSourceMap.put(dbPath, dataSource);
+        return dataSource;
     }
 
     @Override

--- a/src/main/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStore.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStore.java
@@ -66,6 +66,7 @@ public class SQLiteDataStore implements DataStore {
     @Override
     @SuppressWarnings("unchecked")
     public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(UltiToolsPlugin plugin, Class<T> dataEntity) {
+        checkOwnership(plugin, dataEntity);
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new RuntimeException("No Table annotation is presented!");
         }
@@ -79,6 +80,7 @@ public class SQLiteDataStore implements DataStore {
     @Override
     @SuppressWarnings("unchecked")
     public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(File dataFolder, Class<T> dataEntity) {
+        checkOwnership(dataFolder, dataEntity);
         if (!dataEntity.isAnnotationPresent(Table.class)) {
             throw new RuntimeException("No Table annotation is presented!");
         }

--- a/src/main/java/com/ultikits/ultitools/manager/DataScope.java
+++ b/src/main/java/com/ultikits/ultitools/manager/DataScope.java
@@ -16,14 +16,14 @@ import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
  * Unlike a raw {@link File}, a {@code DataScope} cannot be constructed outside this package: both
  * the constructor and the static factories are package-private, so the only way to obtain one is
  * through {@code PluginManager} (internal modules) or {@code DataStoreManager} / the external
- * plugin registration path (external plugins). {@link com.ultikits.ultitools.UltiTools#getDataStore()}
+ * plugin registration path (external plugins). {@code UltiTools#getDataStore()}
  * being {@code public} in the published jar is therefore no longer a bypass: a caller outside the
  * framework has no way to mint the token {@code DataStore.getOperator(DataScope, Class)} requires.
  * <p>
  * 框架签发的身份凭证，标识调用 {@link com.ultikits.ultitools.interfaces.DataStore} 方法的一方。
  * 与裸露的 {@link File} 不同，{@code DataScope} 无法在本包之外被构造——构造器和静态工厂方法均为
  * 包私有，只能经由 {@code PluginManager}（内部模块）或 {@code DataStoreManager} /
- * 外部插件注册路径（外部插件）获得。这使得 {@link com.ultikits.ultitools.UltiTools#getDataStore()}
+ * 外部插件注册路径（外部插件）获得。这使得 {@code UltiTools#getDataStore()}
  * 在已发布 jar 中是 {@code public} 这一事实不再构成绕过：框架之外的调用方没有任何办法铸造
  * {@code DataStore.getOperator(DataScope, Class)} 所需要的令牌。
  *

--- a/src/main/java/com/ultikits/ultitools/manager/DataScope.java
+++ b/src/main/java/com/ultikits/ultitools/manager/DataScope.java
@@ -45,18 +45,21 @@ public final class DataScope {
     /**
      * Mints a scope for an internal {@link UltiToolsPlugin} module.
      * <p>
-     * The entity set is left empty here — populating it from the plugin's own JAR is D-19's work
-     * in a later plan, not this one.
+     * {@code ownedEntities} is the result of {@code PluginManager}'s D-19 scan of the plugin's own
+     * JAR (classes carrying {@code @Table}), unioned with anything declared via
+     * {@code @UltiToolsModule#additionalEntities()}.
      * <p>
-     * 为内部 {@link UltiToolsPlugin} 模块铸造一个 scope。实体集合在此留空——从插件自身 JAR
-     * 中扫描填充是 D-19 在后续计划里的工作，不属于本计划。
+     * 为内部 {@link UltiToolsPlugin} 模块铸造一个 scope。{@code ownedEntities} 是
+     * {@code PluginManager} 对插件自身 JAR 做 D-19 扫描（携带 {@code @Table} 的类）的结果，
+     * 并与通过 {@code @UltiToolsModule#additionalEntities()} 声明的实体取并集。
      *
-     * @param plugin the internal plugin module <br> 内部插件模块
+     * @param plugin        the internal plugin module <br> 内部插件模块
+     * @param ownedEntities the entity classes this plugin owns <br> 该插件拥有的实体类
      * @return a scope identifying that plugin <br> 标识该插件的 scope
      */
-    static DataScope forPlugin(UltiToolsPlugin plugin) {
+    static DataScope forPlugin(UltiToolsPlugin plugin, Set<Class<?>> ownedEntities) {
         return new DataScope(plugin.getPluginName(), UltiTools.getInstance().getDataFolder(),
-                Collections.emptySet());
+                ownedEntities);
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/manager/DataScope.java
+++ b/src/main/java/com/ultikits/ultitools/manager/DataScope.java
@@ -1,0 +1,117 @@
+package com.ultikits.ultitools.manager;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import com.ultikits.ultitools.UltiTools;
+import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
+
+/**
+ * A framework-issued credential identifying the caller of a {@link com.ultikits.ultitools.interfaces.DataStore}
+ * method.
+ * <p>
+ * Unlike a raw {@link File}, a {@code DataScope} cannot be constructed outside this package: both
+ * the constructor and the static factories are package-private, so the only way to obtain one is
+ * through {@code PluginManager} (internal modules) or {@code DataStoreManager} / the external
+ * plugin registration path (external plugins). {@link com.ultikits.ultitools.UltiTools#getDataStore()}
+ * being {@code public} in the published jar is therefore no longer a bypass: a caller outside the
+ * framework has no way to mint the token {@code DataStore.getOperator(DataScope, Class)} requires.
+ * <p>
+ * 框架签发的身份凭证，标识调用 {@link com.ultikits.ultitools.interfaces.DataStore} 方法的一方。
+ * 与裸露的 {@link File} 不同，{@code DataScope} 无法在本包之外被构造——构造器和静态工厂方法均为
+ * 包私有，只能经由 {@code PluginManager}（内部模块）或 {@code DataStoreManager} /
+ * 外部插件注册路径（外部插件）获得。这使得 {@link com.ultikits.ultitools.UltiTools#getDataStore()}
+ * 在已发布 jar 中是 {@code public} 这一事实不再构成绕过：框架之外的调用方没有任何办法铸造
+ * {@code DataStore.getOperator(DataScope, Class)} 所需要的令牌。
+ *
+ * @author wisdomme
+ * @since 6.3.0
+ */
+public final class DataScope {
+
+    private final String pluginName;
+    private final File dataFolder;
+    private final Set<Class<?>> ownedEntities;
+
+    DataScope(String pluginName, File dataFolder, Set<Class<?>> ownedEntities) {
+        this.pluginName = pluginName;
+        this.dataFolder = dataFolder;
+        this.ownedEntities = Collections.unmodifiableSet(new HashSet<>(ownedEntities));
+    }
+
+    /**
+     * Mints a scope for an internal {@link UltiToolsPlugin} module.
+     * <p>
+     * The entity set is left empty here — populating it from the plugin's own JAR is D-19's work
+     * in a later plan, not this one.
+     * <p>
+     * 为内部 {@link UltiToolsPlugin} 模块铸造一个 scope。实体集合在此留空——从插件自身 JAR
+     * 中扫描填充是 D-19 在后续计划里的工作，不属于本计划。
+     *
+     * @param plugin the internal plugin module <br> 内部插件模块
+     * @return a scope identifying that plugin <br> 标识该插件的 scope
+     */
+    static DataScope forPlugin(UltiToolsPlugin plugin) {
+        return new DataScope(plugin.getPluginName(), UltiTools.getInstance().getDataFolder(),
+                Collections.emptySet());
+    }
+
+    /**
+     * Mints a scope for an external Bukkit plugin borrowing the framework via
+     * {@code UltiToolsAPI.connect(...)}.
+     * <p>
+     * 为通过 {@code UltiToolsAPI.connect(...)} 借用框架的外部 Bukkit 插件铸造一个 scope。
+     *
+     * @param pluginName    the external plugin's name <br> 外部插件的名称
+     * @param dataFolder    the external plugin's own data folder <br> 外部插件自己的数据文件夹
+     * @param ownedEntities the entity classes this plugin owns <br> 该插件拥有的实体类
+     * @return a scope identifying that external plugin <br> 标识该外部插件的 scope
+     */
+    static DataScope forExternal(String pluginName, File dataFolder, Set<Class<?>> ownedEntities) {
+        return new DataScope(pluginName, dataFolder, ownedEntities);
+    }
+
+    /**
+     * Whether the given entity class belongs to this scope.
+     * <p>
+     * 给定的实体类是否属于该 scope。
+     *
+     * @param entityClass the entity class to check <br> 待检查的实体类
+     * @return true if this scope owns the entity <br> 该 scope 是否拥有此实体
+     */
+    public boolean owns(Class<?> entityClass) {
+        return ownedEntities.contains(entityClass);
+    }
+
+    public String getPluginName() {
+        return pluginName;
+    }
+
+    public File getDataFolder() {
+        return dataFolder;
+    }
+
+    public Set<Class<?>> getOwnedEntities() {
+        return ownedEntities;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DataScope)) {
+            return false;
+        }
+        DataScope that = (DataScope) o;
+        return Objects.equals(pluginName, that.pluginName) && Objects.equals(dataFolder, that.dataFolder);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pluginName, dataFolder);
+    }
+}

--- a/src/main/java/com/ultikits/ultitools/manager/DataScope.java
+++ b/src/main/java/com/ultikits/ultitools/manager/DataScope.java
@@ -8,6 +8,8 @@ import java.util.Set;
 
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
+import com.ultikits.ultitools.exceptions.DataAccessException;
+import com.ultikits.ultitools.exceptions.ErrorCode;
 
 /**
  * A framework-issued credential identifying the caller of a {@link com.ultikits.ultitools.interfaces.DataStore}
@@ -87,6 +89,45 @@ public final class DataScope {
      */
     public boolean owns(Class<?> entityClass) {
         return ownedEntities.contains(entityClass);
+    }
+
+    /**
+     * Builds the refusal for a caller in this scope requesting {@code dataEntity}, which this
+     * scope does not own (D-14, D-15). Framework-internal; the single source every
+     * {@code getOperator} overload routes through so the refusal is identical regardless of which
+     * one a caller reaches. When another loaded module's scope is known to own the entity, the
+     * message names it -- "confirmed to belong to another module"; otherwise it says the entity is
+     * not registered to the requester and no owner is known -- "not registered to you" (D-15). The
+     * message carries only the entity's fully-qualified name, the requesting plugin's name, and the
+     * route (the owning module's exposed service or the EventBus) -- never a table name, column
+     * name, row count, or file path, so a refusal cannot be used to enumerate another module's
+     * schema.
+     * <p>
+     * 为本 scope 中请求 {@code dataEntity}（本 scope 并不拥有）的调用方构建拒绝信息（D-14、
+     * D-15）。框架内部使用；所有 {@code getOperator} 重载都会走这唯一的来源，因此无论调用方
+     * 走到哪一个重载，拒绝结果都一致。当已知某个已加载模块的 scope 拥有该实体时，消息会点名该
+     * 模块——「确认属于另一个模块」；否则消息只说明该实体未向请求方注册且未知归属——
+     * 「未向你注册」（D-15）。消息只携带实体的完全限定名、请求方插件名和正确路径（拥有者模块
+     * 暴露的服务，或 EventBus）——绝不包含表名、列名、行数或文件路径，因此拒绝信息不能被用来
+     * 枚举另一个模块的 schema。
+     *
+     * @param dataEntity the entity class this scope does not own <br> 本 scope 不拥有的实体类
+     * @return the exception to throw <br> 应抛出的异常
+     */
+    public DataAccessException refusalFor(Class<?> dataEntity) {
+        String owner = null;
+        if (UltiTools.getInstance() != null && UltiTools.getInstance().getPluginManager() != null) {
+            owner = UltiTools.getInstance().getPluginManager().findOwningPlugin(dataEntity);
+        }
+        String message;
+        if (owner != null) {
+            message = "Entity " + dataEntity.getName() + " belongs to module '" + owner + "', not '"
+                    + pluginName + "' -- use " + owner + "'s exposed service or the EventBus instead.";
+        } else {
+            message = "Entity " + dataEntity.getName() + " is not registered to '" + pluginName
+                    + "' -- use the owning module's exposed service or the EventBus instead.";
+        }
+        return new DataAccessException(ErrorCode.ENTITY_NOT_OWNED, message);
     }
 
     public String getPluginName() {

--- a/src/main/java/com/ultikits/ultitools/manager/DataSourceTransactionManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/DataSourceTransactionManager.java
@@ -2,6 +2,7 @@ package com.ultikits.ultitools.manager;
 
 import com.ultikits.ultitools.exceptions.DataAccessException;
 import com.ultikits.ultitools.exceptions.ErrorCode;
+import com.ultikits.ultitools.exceptions.UnexpectedRollbackException;
 import com.ultikits.ultitools.interfaces.JdbcTransactionManager;
 import com.ultikits.ultitools.interfaces.TransactionManager;
 
@@ -104,6 +105,23 @@ public class DataSourceTransactionManager implements JdbcTransactionManager {
             return;
         }
 
+        // D-08: an inner rollback() at a depth this commit() has now unwound to may have marked
+        // the context rollback-only instead of tearing it down. At depth 1 that marker must be
+        // honoured with a real rollback, not silently overridden by a commit the caller never
+        // asked to happen after all. cleanup(ctx) runs before the throw so a caller catching this
+        // exception never observes a still-live context (T-02-TAM-2).
+        if (ctx.rollbackOnly) {
+            try {
+                ctx.connection.rollback();
+                LOGGER.fine("Transaction rolled back (was marked rollback-only by a nested scope)");
+            } catch (SQLException e) {
+                LOGGER.log(Level.SEVERE, "Failed to rollback rollback-only transaction", e);
+            } finally {
+                cleanup(ctx);
+            }
+            throw UnexpectedRollbackException.markedBy("a nested transaction scope");
+        }
+
         try {
             ctx.connection.commit();
             LOGGER.fine("Transaction committed");
@@ -122,13 +140,24 @@ public class DataSourceTransactionManager implements JdbcTransactionManager {
             return;
         }
 
+        // D-08: an inner rollback() must not tear down the whole context -- that would silently
+        // discard whatever the outer scope(s) still have to do, and the outer commit() would then
+        // proceed as if nothing had gone wrong. Mark rollback-only and decrement instead; only the
+        // depth-1 rollback below performs a real connection.rollback() and cleanup, exactly as at
+        // HEAD.
+        if (ctx.depth > 1) {
+            ctx.rollbackOnly = true;
+            ctx.depth--;
+            LOGGER.fine("Nested transaction marked rollback-only, depth: " + ctx.depth);
+            return;
+        }
+
         try {
             ctx.connection.rollback();
             LOGGER.fine("Transaction rolled back");
         } catch (SQLException e) {
             LOGGER.log(Level.SEVERE, "Failed to rollback transaction", e);
         } finally {
-            // Always cleanup on rollback, regardless of depth
             cleanup(ctx);
         }
     }
@@ -220,5 +249,14 @@ public class DataSourceTransactionManager implements JdbcTransactionManager {
         int depth;
         int originalIsolation = -1;
         boolean originalAutoCommit = true;
+
+        /**
+         * D-08: set by an inner {@code rollback()} at depth &gt; 1 instead of tearing the context
+         * down. The outer {@code commit()} at depth 1 checks this before committing - if set, it
+         * performs a real rollback, cleans up, and throws {@link UnexpectedRollbackException}
+         * rather than silently committing (or silently returning) as if the inner rollback never
+         * happened.
+         */
+        boolean rollbackOnly;
     }
 }

--- a/src/main/java/com/ultikits/ultitools/manager/DataSourceTransactionManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/DataSourceTransactionManager.java
@@ -2,6 +2,7 @@ package com.ultikits.ultitools.manager;
 
 import com.ultikits.ultitools.exceptions.DataAccessException;
 import com.ultikits.ultitools.exceptions.ErrorCode;
+import com.ultikits.ultitools.interfaces.JdbcTransactionManager;
 import com.ultikits.ultitools.interfaces.TransactionManager;
 
 import javax.sql.DataSource;
@@ -12,7 +13,8 @@ import java.util.logging.Logger;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
- * DataSource-based implementation of {@link TransactionManager}.
+ * DataSource-based implementation of {@link TransactionManager}, and its JDBC-specific
+ * sub-interface {@link JdbcTransactionManager}.
  * <p>
  * Uses ThreadLocal to associate transactions with threads, ensuring thread safety.
  * Each thread can have at most one active transaction at a time.
@@ -21,7 +23,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @since 6.2.0
  */
 @ApiStatus.Internal
-public class DataSourceTransactionManager implements TransactionManager {
+public class DataSourceTransactionManager implements JdbcTransactionManager {
 
     private static final Logger LOGGER = Logger.getLogger(DataSourceTransactionManager.class.getName());
 

--- a/src/main/java/com/ultikits/ultitools/manager/DataSourceTransactionManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/DataSourceTransactionManager.java
@@ -9,6 +9,8 @@ import com.ultikits.ultitools.interfaces.TransactionManager;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.ApiStatus;
@@ -41,6 +43,20 @@ public class DataSourceTransactionManager implements JdbcTransactionManager {
      * static", not "no longer ThreadLocal".
      */
     private final ThreadLocal<TransactionContext> contextHolder = new ThreadLocal<>();
+
+    /**
+     * ThreadLocal holding the stack of contexts {@link #suspend()} has detached and not yet
+     * {@link #resume(Object)}d, most-recently-suspended on top (D-09).
+     * <p>
+     * Deliberately a sibling of {@link #contextHolder} rather than folding the active context
+     * into the same structure: {@link #getTransactionDepth()}, {@link #hasActiveTransaction()},
+     * {@link #commit()} and {@link #rollback()} all read the single active context and stay
+     * completely unchanged by this field's existence. Only {@link #suspend()}/
+     * {@link #resume(Object)} ever touch it. Never left holding an empty {@link Deque} - the last
+     * pop calls {@code ThreadLocal.remove()} so a Bukkit worker thread returned to the pool does
+     * not carry a stale frame (T-02-DOS-5).
+     */
+    private final ThreadLocal<Deque<TransactionContext>> suspendedStack = new ThreadLocal<>();
 
     /**
      * Creates a new DataSourceTransactionManager.
@@ -206,6 +222,67 @@ public class DataSourceTransactionManager implements JdbcTransactionManager {
     public int getTransactionDepth() {
         TransactionContext ctx = contextHolder.get();
         return ctx != null ? ctx.depth : 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Detaches the current {@link TransactionContext} (connection included) from this thread and
+     * pushes it onto {@link #suspendedStack}, leaving {@link #hasActiveTransaction()} {@code
+     * false}. A {@code begin()} that runs while the original stays suspended opens a fully
+     * independent transaction, on its own connection - the suspended one is never touched until
+     * {@link #resume(Object)} restores it.
+     */
+    @Override
+    public Object suspend() {
+        TransactionContext current = contextHolder.get();
+        if (current == null) {
+            return null;
+        }
+        Deque<TransactionContext> stack = suspendedStack.get();
+        if (stack == null) {
+            stack = new ArrayDeque<>();
+            suspendedStack.set(stack);
+        }
+        stack.push(current);
+        contextHolder.remove();
+        LOGGER.fine("Transaction suspended, depth: " + current.depth);
+        return current;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * {@code null} is a no-op - {@link #suspend()} found nothing active in the first place, so
+     * there is nothing on {@link #suspendedStack} for this call to pop. A non-null handle must be
+     * exactly what this manager's own {@link #suspend()} most recently returned; restoring it sets
+     * it back as the active context (same {@link TransactionContext} instance, same {@link
+     * Connection}, same depth) and pops it off {@link #suspendedStack}, removing the {@code
+     * ThreadLocal} entirely once the stack is empty rather than leaving a dangling empty {@link
+     * Deque} behind.
+     *
+     * @throws IllegalArgumentException if {@code suspended} is non-null but was not produced by
+     *                                   this manager's own {@link #suspend()}
+     */
+    @Override
+    public void resume(Object suspended) {
+        if (suspended == null) {
+            return;
+        }
+        if (!(suspended instanceof TransactionContext)) {
+            throw new IllegalArgumentException(
+                    "resume() called with a handle this TransactionManager did not produce: " + suspended);
+        }
+        TransactionContext ctx = (TransactionContext) suspended;
+        Deque<TransactionContext> stack = suspendedStack.get();
+        if (stack != null) {
+            stack.remove(ctx);
+            if (stack.isEmpty()) {
+                suspendedStack.remove();
+            }
+        }
+        contextHolder.set(ctx);
+        LOGGER.fine("Transaction resumed, depth: " + ctx.depth);
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/manager/DataSourceTransactionManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/DataSourceTransactionManager.java
@@ -11,6 +11,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.ApiStatus;
@@ -209,13 +210,45 @@ public class DataSourceTransactionManager implements JdbcTransactionManager {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * D-10: records a deadline on the active {@link TransactionContext} rather than a wall-clock
+     * bound on the transaction as a whole -- {@link #getTimeoutDeadlineNanos()} exposes it so
+     * each statement issued afterward can be given the time <em>remaining</em>, not a fresh full
+     * allowance. {@code seconds <= 0} is inert (no deadline recorded), matching
+     * {@code @Transactional(timeout=0)}'s default -- {@code TransactionInterceptor} itself never
+     * calls this method for a non-positive value in the first place, so this is a second,
+     * defensive guard for any other caller. Called with no active transaction, this logs a
+     * warning and records nothing, the same shape {@link #commit()}/{@link #rollback()} already
+     * use for that case.
+     */
     @Override
     public void setTimeout(int seconds) {
-        // JDBC doesn't directly support transaction timeout
-        // This could be implemented using a scheduled task to cancel the connection
-        if (seconds > 0) {
-            LOGGER.fine("Transaction timeout set to " + seconds + " seconds (note: not enforced by JDBC)");
+        TransactionContext ctx = contextHolder.get();
+        if (ctx == null || !ctx.active) {
+            LOGGER.warning("setTimeout called but no active transaction");
+            return;
         }
+        if (seconds > 0) {
+            ctx.timeoutDeadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(seconds);
+            LOGGER.fine("Transaction timeout set to " + seconds + " seconds");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Reads {@link TransactionContext#timeoutDeadlineNanos} off the active context -- {@code
+     * null} when no transaction is active, or when {@link #setTimeout(int)} was never called (or
+     * called only with a non-positive value) for it. {@link #suspend()}/{@link #resume(Object)}
+     * detach and restore the whole {@link TransactionContext} object, so a suspended-then-resumed
+     * transaction's deadline travels with it automatically -- no separate handling needed here.
+     */
+    @Override
+    public Long getTimeoutDeadlineNanos() {
+        TransactionContext ctx = contextHolder.get();
+        return ctx != null && ctx.active ? ctx.timeoutDeadlineNanos : null;
     }
 
     @Override
@@ -335,5 +368,13 @@ public class DataSourceTransactionManager implements JdbcTransactionManager {
          * happened.
          */
         boolean rollbackOnly;
+
+        /**
+         * D-10: set by {@link #setTimeout(int)} to the {@link System#nanoTime()} value at which
+         * this transaction's query-timeout budget expires. {@code null} means no timeout is
+         * configured -- {@link #getTimeoutDeadlineNanos()} reports that as-is, never coercing it
+         * to a sentinel like {@code 0} or {@code -1}.
+         */
+        Long timeoutDeadlineNanos;
     }
 }

--- a/src/main/java/com/ultikits/ultitools/manager/DataSourceTransactionManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/DataSourceTransactionManager.java
@@ -29,8 +29,15 @@ public class DataSourceTransactionManager implements TransactionManager {
 
     /**
      * ThreadLocal holding the current transaction context for each thread.
+     * <p>
+     * Instance-scoped on purpose (FOUND-04) - one {@code DataSourceTransactionManager} per plugin
+     * container, built once in {@code PluginManager.wireAop}. A {@code static} field here would
+     * let two plugin containers' transactions cross: manager A's {@code rollback()} would be able
+     * to reach a {@link TransactionContext} manager B set up for a completely different
+     * {@link DataSource}, on the same thread. Still a {@code ThreadLocal} - the fix is "no longer
+     * static", not "no longer ThreadLocal".
      */
-    private static final ThreadLocal<TransactionContext> contextHolder = new ThreadLocal<>();
+    private final ThreadLocal<TransactionContext> contextHolder = new ThreadLocal<>();
 
     /**
      * Creates a new DataSourceTransactionManager.
@@ -194,8 +201,11 @@ public class DataSourceTransactionManager implements TransactionManager {
 
     /**
      * Gets the current transaction context (for testing).
+     * <p>
+     * Instance method, not static, per the same FOUND-04 fix as {@link #contextHolder} itself:
+     * two {@code DataSourceTransactionManager} instances now have independent state.
      */
-    static TransactionContext getCurrentContext() {
+    TransactionContext getCurrentContext() {
         return contextHolder.get();
     }
 

--- a/src/main/java/com/ultikits/ultitools/manager/JsonTransactionManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/JsonTransactionManager.java
@@ -1,5 +1,7 @@
 package com.ultikits.ultitools.manager;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -62,6 +64,21 @@ public class JsonTransactionManager implements TransactionManager {
      * {@code JsonStore}, so two identities can never cross transaction state.
      */
     private final ThreadLocal<Context> contextHolder = new ThreadLocal<>();
+
+    /**
+     * ThreadLocal holding the stack of contexts {@link #suspend()} has detached and not yet
+     * {@link #resume(Object)}d, most-recently-suspended on top -- the JSON analogue of {@code
+     * DataSourceTransactionManager}'s field of the same name (02-11, D-09).
+     * <p>
+     * Deliberately a sibling of {@link #contextHolder} rather than folding the active context
+     * into the same structure: {@link #getTransactionDepth()}, {@link #hasActiveTransaction()},
+     * {@link #commit()} and {@link #rollback()} all read the single active context and stay
+     * completely unchanged by this field's existence. Only {@link #suspend()}/
+     * {@link #resume(Object)} ever touch it. Never left holding an empty {@link Deque} -- the
+     * last pop calls {@code ThreadLocal.remove()} so a Bukkit worker thread returned to the pool
+     * does not carry a stale frame.
+     */
+    private final ThreadLocal<Deque<Context>> suspendedStack = new ThreadLocal<>();
 
     /**
      * Constructed only by {@code JsonStore} (a different package, hence {@code public}) when it
@@ -167,6 +184,72 @@ public class JsonTransactionManager implements TransactionManager {
     public int getTransactionDepth() {
         Context ctx = contextHolder.get();
         return ctx != null ? ctx.depth : 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Detaches the current {@code Context} (captured restorers included) from this thread and
+     * pushes it onto {@code suspendedStack}, leaving {@link #hasActiveTransaction()} {@code
+     * false}. A {@link #begin()} that runs while the original stays suspended opens a fully
+     * independent transaction with its own empty snapshot map -- the suspended one is never
+     * touched until {@link #resume(Object)} restores it.
+     * <p>
+     * Like everything else this class does, this is in-process suspension of cached state, not a
+     * durable one: nothing here changes what is on disk, and a server killed mid-suspension still
+     * has whatever the flush scheduler last wrote.
+     */
+    @Override
+    public Object suspend() {
+        Context current = contextHolder.get();
+        if (current == null) {
+            return null;
+        }
+        Deque<Context> stack = suspendedStack.get();
+        if (stack == null) {
+            stack = new ArrayDeque<>();
+            suspendedStack.set(stack);
+        }
+        stack.push(current);
+        contextHolder.remove();
+        LOGGER.fine("JSON transaction suspended for " + identity + ", depth: " + current.depth);
+        return current;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * {@code null} is a no-op -- {@link #suspend()} found nothing active in the first place, so
+     * there is nothing on {@code suspendedStack} for this call to pop. A non-null handle must be
+     * exactly what this manager's own {@link #suspend()} most recently returned; restoring it
+     * sets it back as the active context (same {@code Context} instance, same depth, same
+     * captured restorers) and pops it off {@code suspendedStack}, removing the {@code
+     * ThreadLocal} entirely once the stack is empty rather than leaving a dangling empty
+     * {@code Deque} behind.
+     *
+     * @throws IllegalArgumentException if {@code suspended} is non-null but was not produced by
+     *                                   this manager's own {@link #suspend()}
+     */
+    @Override
+    public void resume(Object suspended) {
+        if (suspended == null) {
+            return;
+        }
+        if (!(suspended instanceof Context)) {
+            throw new IllegalArgumentException(
+                    "resume() called with a handle this JsonTransactionManager (identity: " + identity
+                            + ") did not produce: " + suspended);
+        }
+        Context ctx = (Context) suspended;
+        Deque<Context> stack = suspendedStack.get();
+        if (stack != null) {
+            stack.remove(ctx);
+            if (stack.isEmpty()) {
+                suspendedStack.remove();
+            }
+        }
+        contextHolder.set(ctx);
+        LOGGER.fine("JSON transaction resumed for " + identity + ", depth: " + ctx.depth);
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/manager/JsonTransactionManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/JsonTransactionManager.java
@@ -1,0 +1,56 @@
+package com.ultikits.ultitools.manager;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import com.ultikits.ultitools.interfaces.TransactionManager;
+
+/**
+ * RED scaffold (02-05 Task 1) -- compiles and provides the vocabulary
+ * {@code JsonTransactionTest$PerPluginTransactionScopeTests} needs, but every lifecycle method is
+ * still a no-op stub. The real per-plugin snapshot/restore/rollback-only implementation lands in
+ * the paired {@code feat(02-05)} commit.
+ *
+ * @author wisdomme
+ * @since 6.3.0
+ */
+public class JsonTransactionManager implements TransactionManager {
+
+    public JsonTransactionManager(String identity) {
+        // RED scaffold: no-op.
+    }
+
+    @Override
+    public void begin() {
+        // RED scaffold: no-op.
+    }
+
+    @Override
+    public void commit() {
+        // RED scaffold: no-op.
+    }
+
+    @Override
+    public void rollback() {
+        // RED scaffold: no-op.
+    }
+
+    @Override
+    public boolean hasActiveTransaction() {
+        return false;
+    }
+
+    @Override
+    public int getTransactionDepth() {
+        return 0;
+    }
+
+    @Override
+    public void setTimeout(int seconds) {
+        // RED scaffold: no-op.
+    }
+
+    public void captureIfAbsent(Object operatorKey, Supplier<Object> snapshotSupplier, Consumer<Object> restorer) {
+        // RED scaffold: no-op -- nothing is ever captured, so rollback has nothing to restore.
+    }
+}

--- a/src/main/java/com/ultikits/ultitools/manager/JsonTransactionManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/JsonTransactionManager.java
@@ -1,56 +1,251 @@
 package com.ultikits.ultitools.manager;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.logging.Logger;
 
+import com.ultikits.ultitools.exceptions.UnexpectedRollbackException;
 import com.ultikits.ultitools.interfaces.TransactionManager;
 
 /**
- * RED scaffold (02-05 Task 1) -- compiles and provides the vocabulary
- * {@code JsonTransactionTest$PerPluginTransactionScopeTests} needs, but every lifecycle method is
- * still a no-op stub. The real per-plugin snapshot/restore/rollback-only implementation lands in
- * the paired {@code feat(02-05)} commit.
+ * Snapshot-based {@link TransactionManager} for the JSON backend (D-03), giving
+ * {@code @Transactional} the same consistent behaviour on {@code datasource.type: json} that
+ * {@link DataSourceTransactionManager} already gives the two JDBC backends.
+ * <p>
+ * Scoped to one requesting identity (a plugin name on the internal path, a canonical data-folder
+ * path on the external one) and shared by every {@code SimpleJsonDataOperator} that
+ * {@code JsonStore} hands out for that identity. {@link #begin()} opens (or, by depth, joins) a
+ * transaction on the current thread. The first write reaching any one of that identity's JSON
+ * operators captures a deep-copy snapshot of that operator's cache, lazily -- an operator never
+ * written to during the transaction is neither snapshotted nor restored (see
+ * {@link #captureIfAbsent}). {@link #rollback()} at depth 1 restores every captured snapshot; at
+ * depth greater than 1 it marks the transaction rollback-only instead of tearing it down, exactly
+ * mirroring {@link DataSourceTransactionManager}'s D-08 semantics so
+ * {@code TransactionInterceptor} sees one behaviour regardless of which backend built this
+ * manager. {@link #commit()} at depth 1 discards the captured snapshots, or -- when the marker is
+ * set -- restores them and throws {@link UnexpectedRollbackException}, exactly as the JDBC
+ * manager does.
+ * <p>
+ * <b>This is not a durable transaction.</b> It is an in-process rollback of cached state, not a
+ * crash-safe one: a server killed mid-transaction has whatever the flush scheduler last wrote to
+ * disk. Nothing here, and nothing this plan's javadoc, log output, or {@code COMPATIBILITY.md}
+ * text produces, should read as a claim that a JSON transaction survives a crash the way a JDBC
+ * transaction's commit/rollback does.
+ * <p>
+ * 面向 JSON 后端的快照式 {@link TransactionManager}（D-03），使 {@code @Transactional} 在
+ * {@code datasource.type: json} 下拥有与两个 JDBC 后端一致的行为。按请求方身份分实例
+ * （内部路径下为插件名，外部路径下为规范化的数据文件夹路径），同一身份下 {@code JsonStore}
+ * 派发的每一个 {@code SimpleJsonDataOperator} 共享同一个管理器实例。事务范围内第一次写入某个
+ * 操作器时才惰性捕获该操作器缓存的深拷贝快照——事务期间从未写入的操作器既不会被快照，
+ * 也不会被回滚。<b>这不是持久化事务</b>：它只是对内存中缓存状态的进程内回滚，不具备崩溃安全性——
+ * 服务器在事务执行中途被杀掉，磁盘上留下的是刷新调度器最后一次写入的内容。
  *
  * @author wisdomme
  * @since 6.3.0
  */
 public class JsonTransactionManager implements TransactionManager {
 
+    private static final Logger LOGGER = Logger.getLogger(JsonTransactionManager.class.getName());
+
+    /**
+     * The requesting identity this manager governs -- a plugin name or a canonical data-folder
+     * path, matching whatever {@code JsonStore} used to key the operators it hands out for this
+     * manager. Used only for diagnostic log/exception messages; never compared against anything.
+     */
+    private final String identity;
+
+    /**
+     * Instance-scoped {@link ThreadLocal}, matching the FOUND-04 reasoning already documented on
+     * {@link DataSourceTransactionManager#contextHolder}: one manager per identity, built once by
+     * {@code JsonStore}, so two identities can never cross transaction state.
+     */
+    private final ThreadLocal<Context> contextHolder = new ThreadLocal<>();
+
+    /**
+     * Constructed only by {@code JsonStore} (a different package, hence {@code public}) when it
+     * first resolves a manager for a given identity.
+     *
+     * @param identity the requesting identity this manager governs, used only for diagnostics
+     */
     public JsonTransactionManager(String identity) {
-        // RED scaffold: no-op.
+        this.identity = identity;
     }
 
     @Override
     public void begin() {
-        // RED scaffold: no-op.
+        Context ctx = contextHolder.get();
+        if (ctx != null) {
+            ctx.depth++;
+            LOGGER.fine("Nested JSON transaction started for " + identity + ", depth: " + ctx.depth);
+            return;
+        }
+        ctx = new Context();
+        ctx.depth = 1;
+        contextHolder.set(ctx);
+        LOGGER.fine("JSON transaction started for " + identity);
     }
 
     @Override
     public void commit() {
-        // RED scaffold: no-op.
+        Context ctx = contextHolder.get();
+        if (ctx == null) {
+            LOGGER.warning("Commit called but no active JSON transaction for " + identity);
+            return;
+        }
+
+        if (ctx.depth > 1) {
+            ctx.depth--;
+            LOGGER.fine("Nested JSON transaction committed for " + identity + ", depth: " + ctx.depth);
+            return;
+        }
+
+        // D-08: an inner rollback() at a depth this commit() has now unwound to may have marked
+        // the context rollback-only instead of tearing it down. At depth 1 that marker must be
+        // honoured with a real restore, not silently overridden by a commit the caller never
+        // asked to happen after all -- exactly the same reasoning as
+        // DataSourceTransactionManager#commit().
+        if (ctx.rollbackOnly) {
+            try {
+                restore(ctx);
+                LOGGER.fine("JSON transaction rolled back for " + identity
+                        + " (was marked rollback-only by a nested scope)");
+            } finally {
+                contextHolder.remove();
+            }
+            throw UnexpectedRollbackException.markedBy("a nested transaction scope in " + identity);
+        }
+
+        // Nothing further to do: the cache already reflects every write made during the
+        // transaction. Discarding the captured snapshots (by simply dropping the context) is the
+        // JSON equivalent of a JDBC connection.commit().
+        LOGGER.fine("JSON transaction committed for " + identity);
+        contextHolder.remove();
     }
 
     @Override
     public void rollback() {
-        // RED scaffold: no-op.
+        Context ctx = contextHolder.get();
+        if (ctx == null) {
+            LOGGER.warning("Rollback called but no active JSON transaction for " + identity);
+            return;
+        }
+
+        // D-08: an inner rollback() must not tear down the whole context -- that would silently
+        // discard whatever the outer scope(s) still have to do, and the outer commit() would then
+        // proceed as if nothing had gone wrong. Mark rollback-only and decrement instead; only the
+        // depth-1 rollback below actually restores anything.
+        if (ctx.depth > 1) {
+            ctx.rollbackOnly = true;
+            ctx.depth--;
+            LOGGER.fine("Nested JSON transaction marked rollback-only for " + identity + ", depth: " + ctx.depth);
+            return;
+        }
+
+        try {
+            restore(ctx);
+            LOGGER.fine("JSON transaction rolled back for " + identity);
+        } finally {
+            contextHolder.remove();
+        }
+    }
+
+    private void restore(Context ctx) {
+        for (Runnable restorer : ctx.restorers.values()) {
+            restorer.run();
+        }
     }
 
     @Override
     public boolean hasActiveTransaction() {
-        return false;
+        Context ctx = contextHolder.get();
+        return ctx != null && ctx.depth > 0;
     }
 
     @Override
     public int getTransactionDepth() {
-        return 0;
+        Context ctx = contextHolder.get();
+        return ctx != null ? ctx.depth : 0;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The JSON backend has no statement or connection layer for a timeout to apply to -- there is
+     * nothing here that could time out. Rather than silently accept the value and do nothing (the
+     * shape {@link DataSourceTransactionManager#setTimeout(int)} itself uses, since JDBC has no
+     * portable timeout mechanism either, but at least genuinely has a connection the value could
+     * theoretically apply to), this refuses outright: {@code @Transactional(timeout=)} is refused
+     * rather than silently ignored on the JSON backend. {@code TransactionInterceptor} only calls
+     * this when a positive timeout is actually configured on the annotation, so a
+     * {@code @Transactional} method that never specifies one is unaffected.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     public void setTimeout(int seconds) {
-        // RED scaffold: no-op.
+        throw new UnsupportedOperationException(
+                "JsonTransactionManager (identity: " + identity + ") has no statement to time out -- "
+                        + "the JSON backend has no connection/statement layer for a timeout to apply to. "
+                        + "@Transactional(timeout=) is not supported on datasource.type: json.");
     }
 
+    /**
+     * Called by a {@code SimpleJsonDataOperator} write path (through {@code JsonStore}, its own
+     * package) the first time that operator is touched inside the active transaction on this
+     * thread. A no-op when no transaction is active on this thread, or when {@code operatorKey}
+     * was already captured earlier in this same transaction.
+     * <p>
+     * Public because the caller lives in a different package ({@code
+     * interfaces.impl.data.json}) than this class. The actual deep-copy capture/restore logic
+     * stays package-private on {@code SimpleJsonDataOperator} itself, reached only from inside
+     * {@code JsonStore}: {@code snapshotSupplier} and {@code restorer} are lambdas built there,
+     * closing over that package-private access, so this manager never touches an operator's cache
+     * directly and never needs to.
+     *
+     * @param operatorKey      identifies the operator -- the operator instance itself, in
+     *                         practice
+     * @param snapshotSupplier produces the deep-copy snapshot; invoked at most once per operator
+     *                         per transaction
+     * @param restorer         restores {@code operatorKey}'s cache from the captured snapshot;
+     *                         invoked by {@link #rollback()}, and by {@link #commit()} when the
+     *                         transaction was marked rollback-only
+     */
     public void captureIfAbsent(Object operatorKey, Supplier<Object> snapshotSupplier, Consumer<Object> restorer) {
-        // RED scaffold: no-op -- nothing is ever captured, so rollback has nothing to restore.
+        Context ctx = contextHolder.get();
+        if (ctx == null || ctx.depth == 0) {
+            return;
+        }
+        if (!ctx.restorers.containsKey(operatorKey)) {
+            Object snapshot = snapshotSupplier.get();
+            ctx.restorers.put(operatorKey, () -> restorer.accept(snapshot));
+        }
+    }
+
+    /**
+     * Internal class to hold JSON transaction state -- the JSON analogue of
+     * {@link DataSourceTransactionManager.TransactionContext}, minus anything JDBC-specific.
+     */
+    private static final class Context {
+        int depth;
+
+        /**
+         * D-08: set by an inner {@link #rollback()} at depth &gt; 1 instead of tearing the
+         * context down. The outer {@link #commit()} at depth 1 checks this before committing --
+         * if set, it restores every captured snapshot and throws
+         * {@link UnexpectedRollbackException} rather than silently committing (or silently
+         * returning) as if the inner rollback never happened.
+         */
+        boolean rollbackOnly;
+
+        /**
+         * One entry per operator captured so far this transaction, in first-touch order --
+         * insertion order matters if two operators' restores could ever interact, so this is a
+         * {@link LinkedHashMap} rather than a {@link java.util.HashMap}. Each value is a
+         * zero-argument {@link Runnable} that restores exactly one operator from the snapshot
+         * captured for it, built once by {@link #captureIfAbsent} and never mutated afterward.
+         */
+        final Map<Object, Runnable> restorers = new LinkedHashMap<>();
     }
 }

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -45,6 +45,8 @@ import com.ultikits.ultitools.api.UltiToolsAPI;
 import com.ultikits.ultitools.events.EventBus;
 import com.ultikits.ultitools.events.ModuleEvent;
 import com.ultikits.ultitools.context.SimpleContainer;
+import com.ultikits.ultitools.exceptions.ErrorCode;
+import com.ultikits.ultitools.exceptions.PluginModuleException;
 import com.ultikits.ultitools.interfaces.DataStore;
 import com.ultikits.ultitools.interfaces.JdbcTransactionManager;
 import com.ultikits.ultitools.interfaces.TransactionManager;
@@ -251,7 +253,7 @@ public class PluginManager {
             pluginContext.registerShutdownHook();
             pluginContext.setClassLoader(classLoader);
             pluginContext.getBeanFactory().registerSingleton(plugin.getClass().getSimpleName(), plugin);
-            DataScope scope = DataScope.forPlugin(plugin, scanPluginEntities(plugin.getClass()));
+            DataScope scope = DataScope.forPlugin(plugin, scanPluginEntities(plugin.getPluginName(), plugin.getClass()));
             registerEntityOwnership(scope);
             plugin.setDataScope(scope);
             wireAop(pluginContext, scope);
@@ -568,11 +570,20 @@ public class PluginManager {
      * {@code CodeSource} and the class-level {@code @UltiToolsModule} annotation) is a class-level
      * fact, and {@code initializePlugin} already has {@code pluginClass} in hand before the
      * instance exists.
+     * <p>
+     * Every class named in {@code additionalEntities()} is validated (02-14) before being folded
+     * in -- see the private provenance-check method below this one. A plugin can declare an entity
+     * that legitimately lives outside its own JAR (D-19's purpose), but not one that structurally
+     * belongs to a different, already-known module.
      *
+     * @param pluginName  the plugin's own name, for the refusal message and the ownership-conflict
+     *                     check <br> 插件自身名称，用于拒绝信息和所有权冲突检查
      * @param pluginClass the plugin whose scope is being minted <br> 正在铸造 scope 的插件
      * @return the entity set for that plugin's scope <br> 该插件 scope 的实体集合
+     * @throws PluginModuleException fail-closed, when {@code additionalEntities()} names an entity
+     *                                that does not live on this plugin's own classpath (02-14)
      */
-    private Set<Class<?>> scanPluginEntities(Class<? extends UltiToolsPlugin> pluginClass) {
+    private Set<Class<?>> scanPluginEntities(String pluginName, Class<? extends UltiToolsPlugin> pluginClass) {
         Set<Class<?>> entities = new HashSet<>();
         File jarFile = resolveOwnJarFile(pluginClass);
         if (jarFile != null) {
@@ -580,7 +591,10 @@ public class PluginManager {
         }
         UltiToolsModule module = pluginClass.getAnnotation(UltiToolsModule.class);
         if (module != null) {
-            Collections.addAll(entities, module.additionalEntities());
+            for (Class<?> entity : module.additionalEntities()) {
+                validateAdditionalEntity(pluginName, pluginClass, jarFile, entity);
+                entities.add(entity);
+            }
         }
         return entities;
     }
@@ -593,22 +607,196 @@ public class PluginManager {
      * 为外部插件的 {@link DataScope} 构建实体集合（D-19）：扫描插件自身 jar 得到的每一个
      * {@code @Table} 类，加上通过 {@code UltiToolsAPI.connect(plugin, additionalEntities)} 声明的
      * 实体。
+     * <p>
+     * Every class named in {@code additionalEntities} is validated (02-14) before being folded in
+     * -- see the private provenance-check method below {@code scanPluginEntities}. This is the
+     * public, reachable side of D-19: {@code UltiToolsAPI.connect(plugin, additionalEntities...)}
+     * lands here with zero prior trust established, so the validation matters most on this path.
      *
      * @param adapter            the external plugin adapter <br> 外部插件适配器
      * @param additionalEntities entity classes declared via {@code connect(...)} <br> 通过
      *                           {@code connect(...)} 声明的实体类
      * @return the entity set for that external plugin's scope <br> 该外部插件 scope 的实体集合
+     * @throws PluginModuleException fail-closed, when {@code additionalEntities} names an entity
+     *                                that does not live on this plugin's own classpath (02-14)
      */
     private Set<Class<?>> scanExternalEntities(ExternalPluginAdapter adapter, Class<?>[] additionalEntities) {
         Set<Class<?>> entities = new HashSet<>();
-        File jarFile = resolveOwnJarFile(adapter.getJavaPlugin().getClass());
+        Class<?> declaringClass = adapter.getJavaPlugin().getClass();
+        File jarFile = resolveOwnJarFile(declaringClass);
         if (jarFile != null) {
             entities.addAll(scanEntitiesInJar(jarFile));
         }
         if (additionalEntities != null) {
-            Collections.addAll(entities, additionalEntities);
+            for (Class<?> entity : additionalEntities) {
+                validateAdditionalEntity(adapter.getPluginName(), declaringClass, jarFile, entity);
+                entities.add(entity);
+            }
         }
         return entities;
+    }
+
+    /**
+     * Validates that {@code entityClass}, declared via {@code additionalEntities} (D-19) by
+     * {@code declaringPluginName}, does not structurally belong to a DIFFERENT, already-known
+     * plugin before it is folded into that plugin's {@link DataScope} (02-14 finding: this
+     * attribute previously accepted any {@code Class<?>} the caller named, with zero validation --
+     * letting any plugin claim ownership of any other module's real {@code @Table} entity through
+     * the public {@code UltiToolsAPI.connect(plugin, additionalEntities...)} surface, or the
+     * internal {@code @UltiToolsModule#additionalEntities()} equivalent).
+     * <p>
+     * The discriminator is "does this class belong to a DIFFERENT plugin", not "is this class
+     * mine" -- deliberately, since D-19 exists precisely so a module can declare an entity that
+     * lives outside its own JAR:
+     * <ul>
+     *   <li>{@code entityClass} living in the SAME physical jar as {@code declaringOwnJarFile} (a
+     *       shared library shaded into the declaring plugin's own artifact, or a harmless
+     *       redundant re-declaration of an entity the automatic scan already found) -- legitimate,
+     *       accept.</li>
+     *   <li>{@code entityClass} already recorded in {@link #entityOwnership} under a DIFFERENT
+     *       plugin name -- refuse, naming the confirmed owner (matches
+     *       {@code DataScope.refusalFor}'s message shape).</li>
+     *   <li>{@code entityClass}'s own jar is itself the own jar of a DIFFERENT, already-discovered
+     *       {@link UltiToolsPlugin} module ({@link #pluginClassList}, populated by {@code init()}'s
+     *       upfront jar scan BEFORE any individual plugin registers) or of a currently-loaded
+     *       Bukkit plugin ({@code Bukkit.getPluginManager().getPlugins()}, populated by Bukkit's
+     *       own plugin loading, independent of whether that plugin has called
+     *       {@code UltiToolsAPI.connect(...)} yet) -- structurally confirmed as belonging to a
+     *       different plugin, refuse. This is what closes the first-registration-wins window
+     *       {@link #entityOwnership}'s {@code putIfAbsent} semantics alone cannot: it does not
+     *       depend on which plugin happened to register first, only on which jar actually defines
+     *       the class.</li>
+     *   <li>Anything else -- {@code entityClass} lives outside the declarer's own jar but is not
+     *       structurally tied to any other known plugin, and no registry conflict exists -- a
+     *       genuine shared-library / multi-module common artifact, D-19's stated purpose. Accept.</li>
+     * </ul>
+     * Deliberately does not compare classloaders: every internal {@link UltiToolsPlugin} module is
+     * loaded through ONE shared {@code URLClassLoader} covering the whole {@code plugins/} folder
+     * (see {@code init(ClassLoader)}), so two different internal modules' classes always report
+     * the same classloader -- using that as a signal would make this check a no-op for the
+     * internal path, silently failing to close the exact vulnerability it exists to close. Jar
+     * identity (via {@code java.security.CodeSource}) remains meaningful even when many jars share
+     * one classloader, which is why it is the signal used here instead.
+     * <p>
+     * A residual gap, disclosed rather than silently accepted: an attacker who can obtain a
+     * byte-identical copy of another plugin's entity class (e.g. by depending on its published jar
+     * at build time) and shade that copy into their own jar would pass this check -- from the
+     * JVM's perspective it genuinely is a different, attacker-owned {@code Class} object,
+     * structurally indistinguishable from a legitimate shared-library entity. This method
+     * validates class PROVENANCE (which jar/module actually defined this exact class), not table
+     * name collision; a plugin that simply writes its own class with a matching {@code @Table}
+     * name never reaches this method at all (no {@code additionalEntities} declaration involved),
+     * and is a pre-existing, out-of-scope risk inherent to a single shared MySQL DataSource across
+     * all plugins -- not the vulnerability 02-SECURITY.md described or this plan closes.
+     *
+     * @param declaringPluginName the plugin declaring {@code entityClass} <br> 声明
+     *                             {@code entityClass} 的插件
+     * @param declaringClass      the declaring plugin's own main/adapter class, used to look it up
+     *                             in {@link #pluginClassList} and excluded from the
+     *                             "belongs to another known plugin" check <br> 声明方插件自身的主类
+     *                             /适配器类，用于在 {@link #pluginClassList} 中查找自身并将其排除在
+     *                             「属于另一个已知插件」检查之外
+     * @param declaringOwnJarFile the declaring plugin's own resolved jar, or {@code null} when
+     *                             unresolvable (e.g. a directly-constructed test instance) <br>
+     *                             声明方插件自身解析出的 jar；无法解析时（例如直接构造、无真实
+     *                             jar 的测试实例）为 {@code null}
+     * @param entityClass          the entity class named in {@code additionalEntities} <br>
+     *                             {@code additionalEntities} 中声明的实体类
+     * @throws PluginModuleException fail-closed (D-15), naming the declarer, the entity, and the
+     *                                actual owner where one is known
+     */
+    private void validateAdditionalEntity(String declaringPluginName, Class<?> declaringClass,
+            File declaringOwnJarFile, Class<?> entityClass) {
+        File entityJarFile = resolveOwnJarFile(entityClass);
+
+        if (entityJarFile != null && declaringOwnJarFile != null
+                && canonicalPath(entityJarFile).equals(canonicalPath(declaringOwnJarFile))) {
+            return; // same physical jar as the declarer's own artifact -- legitimate (D-19)
+        }
+
+        String owner = findOwningPlugin(entityClass);
+        if (owner != null && !owner.equals(declaringPluginName)) {
+            throw new PluginModuleException(ErrorCode.ENTITY_NOT_OWNED,
+                    additionalEntityRefusalMessage(declaringPluginName, entityClass, owner));
+        }
+
+        if (entityJarFile != null && belongsToAnotherKnownPlugin(entityJarFile, declaringClass)) {
+            throw new PluginModuleException(ErrorCode.ENTITY_NOT_OWNED,
+                    additionalEntityRefusalMessage(declaringPluginName, entityClass, null));
+        }
+    }
+
+    /**
+     * Whether {@code entityJarFile} is itself the own jar of some plugin OTHER than
+     * {@code declaringClass} -- checked against every internal module {@code init()} has already
+     * discovered ({@link #pluginClassList}, regardless of load order) and every Bukkit plugin
+     * currently loaded ({@code Bukkit.getPluginManager().getPlugins()}, regardless of whether it
+     * has called {@code UltiToolsAPI.connect(...)} yet). See the caller directly above this method
+     * for the full reasoning.
+     * <p>
+     * {@code entityJarFile} 是否正是除 {@code declaringClass} 之外某个插件自身的 jar——依次比对
+     * {@code init()} 已经发现的每一个内部模块（{@link #pluginClassList}，与加载顺序无关）和每一个
+     * 当前已加载的 Bukkit 插件（{@code Bukkit.getPluginManager().getPlugins()}，无论其是否已调用
+     * {@code UltiToolsAPI.connect(...)}）。完整推理见上一个方法（本方法唯一的调用方）。
+     *
+     * @param entityJarFile  the entity's resolved own jar, never null <br> 实体自身解析出的 jar，
+     *                       不会为 null
+     * @param declaringClass the declaring plugin's own class, excluded from the comparison <br>
+     *                       声明方插件自身的类，比对时会被排除
+     * @return true if a different, already-known plugin's own jar matches <br>
+     *         若匹配到另一个已知插件自身的 jar 则为 true
+     */
+    private boolean belongsToAnotherKnownPlugin(File entityJarFile, Class<?> declaringClass) {
+        String entityPath = canonicalPath(entityJarFile);
+        for (Class<? extends UltiToolsPlugin> known : pluginClassList) {
+            if (known == declaringClass) {
+                continue;
+            }
+            File knownJar = resolveOwnJarFile(known);
+            if (knownJar != null && entityPath.equals(canonicalPath(knownJar))) {
+                return true;
+            }
+        }
+        for (org.bukkit.plugin.Plugin loaded : Bukkit.getPluginManager().getPlugins()) {
+            if (loaded.getClass() == declaringClass) {
+                continue;
+            }
+            File loadedJar = resolveOwnJarFile(loaded.getClass());
+            if (loadedJar != null && entityPath.equals(canonicalPath(loadedJar))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Builds the refusal message for an {@code additionalEntities} declaration that does not live
+     * on the declarer's own classpath -- the same "confirmed owner" vs. "no confirmed owner"
+     * distinction {@code DataScope.refusalFor(Class)} makes (D-15), applied at declaration time
+     * instead of data-access time.
+     * <p>
+     * 为不在声明方自身 classpath 上的 {@code additionalEntities} 声明构建拒绝信息——与
+     * {@code DataScope.refusalFor(Class)}（D-15）相同的「已确认归属方」与「归属方未知」区分，
+     * 只是发生在声明时而非数据访问时。
+     *
+     * @param declaringPluginName the plugin whose declaration is refused <br> 被拒绝声明的插件
+     * @param entityClass          the entity class that was declared <br> 被声明的实体类
+     * @param owner                the confirmed owning plugin's name, or {@code null} when none is
+     *                             known <br> 已确认的拥有者插件名；未知时为 {@code null}
+     * @return the refusal message <br> 拒绝信息
+     */
+    private static String additionalEntityRefusalMessage(String declaringPluginName, Class<?> entityClass,
+            String owner) {
+        if (owner != null) {
+            return "Plugin '" + declaringPluginName + "' declared additionalEntities entity "
+                    + entityClass.getName() + ", which is confirmed to belong to module '" + owner
+                    + "' -- refusing (the entity does not live on '" + declaringPluginName
+                    + "'s own classpath; use " + owner + "'s exposed service or the EventBus instead).";
+        }
+        return "Plugin '" + declaringPluginName + "' declared additionalEntities entity "
+                + entityClass.getName() + ", which is confirmed to belong to a different, "
+                + "already-known plugin -- refusing (the entity does not live on '" + declaringPluginName
+                + "'s own classpath).";
     }
 
     /**
@@ -652,12 +840,45 @@ public class PluginManager {
      * {@link #findScopeForDataFolder} 能把 {@code DataStore.getOperator(File, Class)} 的调用方
      * 解析回一个 scope（D-18）——沿用 02-02 Task 2 为 SQLite 连接池 Map 采用的规范路径键法，
      * 让同一个文件夹的两种写法解析到同一条记录。
+     * <p>
+     * Refuses (02-14 Task 2) rather than silently replacing when the canonical path already maps
+     * to a DIFFERENT plugin's scope -- {@code externalScopesByFolder} used a plain {@code .put()}
+     * before this, so wrapping another plugin (all public calls -- {@code new
+     * ExternalPluginAdapter(Bukkit.getPluginManager().getPlugin("Victim"))}) and calling the
+     * public {@code registerExternal} would displace the victim's legitimate scope here, poisoning
+     * the D-18 reverse lookup {@code checkOwnership(File, Class)} depends on. Re-registration by
+     * the SAME plugin (matched by name) is idempotent, not refused -- a plugin reconnecting after
+     * {@link #unregisterExternal(ExternalPluginAdapter)} must not be permanently locked out.
+     * <p>
+     * 当规范路径已经映射到另一个不同插件的 scope 时拒绝（02-14 Task 2），而不是静默替换——此前
+     * {@code externalScopesByFolder} 用的是普通 {@code .put()}，于是包装另一个插件（全部为公开
+     * 调用——{@code new ExternalPluginAdapter(Bukkit.getPluginManager().getPlugin("Victim"))}）
+     * 并调用公开的 {@code registerExternal}，就能在这里覆盖受害插件的合法 scope，污染
+     * {@code checkOwnership(File, Class)} 依赖的 D-18 反向查找。同一个插件（按名称匹配）重复
+     * 注册是幂等的、不会被拒绝——插件在 {@link #unregisterExternal(ExternalPluginAdapter)} 后
+     * 重连不应被永久锁死。
      *
      * @param dataFolder the external plugin's own data folder <br> 外部插件自己的数据文件夹
      * @param scope      the scope just minted for it <br> 刚为它铸造的 scope
+     * @throws PluginModuleException fail-closed, when {@code dataFolder} already maps to a
+     *                                DIFFERENT plugin's registered scope (02-14)
      */
     private void registerExternalScope(File dataFolder, DataScope scope) {
-        externalScopesByFolder.put(canonicalPath(dataFolder), scope);
+        String path = canonicalPath(dataFolder);
+        // putIfAbsent, not get()-then-put(): atomic check-and-insert, so two concurrent
+        // registrations for the same folder can't both observe "nothing registered yet" and both
+        // proceed to write -- the same race a plain get()/put() pair would leave open.
+        DataScope existing = externalScopesByFolder.putIfAbsent(path, scope);
+        if (existing != null && !existing.getPluginName().equals(scope.getPluginName())) {
+            throw new PluginModuleException(ErrorCode.PLUGIN_LOAD_FAILED,
+                    "Refusing to register external plugin '" + scope.getPluginName() + "' for data folder '"
+                            + path + "': already registered to '" + existing.getPluginName() + "' -- an "
+                            + "external scope registration cannot displace an existing one.");
+        }
+        // existing == null: this call's putIfAbsent just inserted scope, nothing left to do.
+        // existing != null && same plugin name: idempotent re-registration -- the map keeps the
+        // ALREADY-registered scope (putIfAbsent never overwrites on a hit); same plugin, so this
+        // is a no-op rather than an attack.
     }
 
     /**
@@ -671,6 +892,22 @@ public class PluginManager {
      */
     public DataScope findScopeForDataFolder(File dataFolder) {
         return externalScopesByFolder.get(canonicalPath(dataFolder));
+    }
+
+    /**
+     * Removes a data folder's registered external plugin scope (02-14 Task 2), so a subsequent
+     * {@link #registerExternal(ExternalPluginAdapter, Class[])} for the same folder -- a legitimate
+     * reconnect -- is not refused by {@link #registerExternalScope}'s displacement guard as if it
+     * were a different plugin still holding the folder.
+     * <p>
+     * 移除某个数据文件夹已注册的外部插件 scope（02-14 Task 2），使随后针对同一文件夹的
+     * {@link #registerExternal(ExternalPluginAdapter, Class[])}（合法的重新连接）不会被
+     * {@link #registerExternalScope} 的覆盖防护误判成「该文件夹仍被另一个插件占用」而拒绝。
+     *
+     * @param dataFolder the folder whose registration should be cleared <br> 待清除注册的文件夹
+     */
+    private void unregisterExternalScope(File dataFolder) {
+        externalScopesByFolder.remove(canonicalPath(dataFolder));
     }
 
     private static String canonicalPath(File folder) {
@@ -1226,7 +1463,7 @@ public class PluginManager {
             // can call Xxx.getInstance().getDataOperator() etc.
             setPluginStaticInstance(pluginClass, plugin);
 
-            DataScope scope = DataScope.forPlugin(plugin, scanPluginEntities(plugin.getClass()));
+            DataScope scope = DataScope.forPlugin(plugin, scanPluginEntities(plugin.getPluginName(), plugin.getClass()));
             registerEntityOwnership(scope);
             plugin.setDataScope(scope);
             wireAop(pluginContext, scope);
@@ -1440,9 +1677,12 @@ public class PluginManager {
         // 3. Refresh container to instantiate beans
         DataScope scope = DataScope.forExternal(adapter.getPluginName(), adapter.getDataFolder(),
                 scanExternalEntities(adapter, additionalEntities));
+        // registerExternalScope runs FIRST (02-14 Task 2): if it refuses (another plugin already
+        // holds this data folder), nothing below has run yet -- no entity ownership recorded, no
+        // DataScope attached to the adapter. A refused registerExternal() leaves no partial state.
+        registerExternalScope(adapter.getDataFolder(), scope);
         registerEntityOwnership(scope);
         adapter.setDataScope(scope);
-        registerExternalScope(adapter.getDataFolder(), scope);
         wireAop(context, scope);
         context.refresh();
         adapter.setContext(context);
@@ -1519,6 +1759,14 @@ public class PluginManager {
             adapter.getContext().close();
             adapter.setContext(null);
         }
+
+        // Clear the folder->scope registration (02-14 Task 2) so a fresh registerExternal(...) for
+        // the same folder -- a legitimate reconnect -- is not refused by registerExternalScope's
+        // displacement guard as if the folder were still held by a different plugin. This was
+        // previously left behind entirely (a second, disclosed finding beyond the displacement
+        // guard itself): unregisterExternal never removed the entry, so findScopeForDataFolder
+        // kept resolving a disconnected plugin's stale scope indefinitely.
+        unregisterExternalScope(adapter.getDataFolder());
 
         Bukkit.getLogger().log(Level.INFO,
                 "[UltiTools-API] External plugin unregistered: " + pluginName);

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -10,7 +10,9 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.logging.Level;
@@ -71,6 +73,21 @@ public class PluginManager {
     private TaskManager taskManager;
     @Getter
     private PlayerCacheManager playerCacheManager;
+
+    /**
+     * Entity class -&gt; owning plugin name, populated every time a {@link DataScope} is minted
+     * (both internal modules and external plugins). Lets a refusal built by {@link
+     * DataScope#refusalFor(Class)} say "belongs to module X" instead of only "not registered to
+     * you" -- D-15 requires the two to be distinguishable. First registration wins; a genuine
+     * collision has never been observed across this project's 21 {@code @Table} classes / 17
+     * repositories (02-CONTEXT.md), so this is a defensive tie-break, not a load-bearing one.
+     * <p>
+     * 实体类 -&gt; 拥有它的插件名，每次铸造 {@link DataScope} 时都会填充（内部模块和外部插件均
+     * 会）。使得 {@link DataScope#refusalFor(Class)} 构造的拒绝信息能说「属于模块 X」而不只是
+     * 「未向你注册」——D-15 要求二者可区分。先注册者优先；本项目 21 个 {@code @Table} 类 /
+     * 17 个仓库中从未观测到真实冲突（见 02-CONTEXT.md），所以这只是防御性的兜底，不是关键路径。
+     */
+    private final Map<Class<?>, String> entityOwnership = new ConcurrentHashMap<>();
 
     /**
      * Initialize plugin manager. Please do not call this method manually.
@@ -219,7 +236,9 @@ public class PluginManager {
             pluginContext.registerShutdownHook();
             pluginContext.setClassLoader(classLoader);
             pluginContext.getBeanFactory().registerSingleton(plugin.getClass().getSimpleName(), plugin);
-            wireAop(pluginContext, DataScope.forPlugin(plugin, scanPluginEntities(plugin)));
+            DataScope scope = DataScope.forPlugin(plugin, scanPluginEntities(plugin.getClass()));
+            registerEntityOwnership(scope);
+            wireAop(pluginContext, scope);
             pluginContext.refresh();
             if (plugin.getClass().isAnnotationPresent(ContextEntry.class)) {
                 ContextEntry contextEntry = plugin.getClass().getAnnotation(ContextEntry.class);
@@ -528,17 +547,22 @@ public class PluginManager {
      * {@code @Table} 类，加上模块通过 {@code @UltiToolsModule#additionalEntities()} 声明的、
      * 合法存放在别处的实体。永不抛出异常——jar 无法解析时（例如直接构造、没有真实 jar 的测试
      * 实例），实体集合仅由其声明的 {@code additionalEntities()} 构成，默认为空。
+     * <p>
+     * Takes the plugin's class rather than an instance -- everything this reads (the JAR's own
+     * {@code CodeSource} and the class-level {@code @UltiToolsModule} annotation) is a class-level
+     * fact, and {@code initializePlugin} already has {@code pluginClass} in hand before the
+     * instance exists.
      *
-     * @param plugin the plugin whose scope is being minted <br> 正在铸造 scope 的插件
+     * @param pluginClass the plugin whose scope is being minted <br> 正在铸造 scope 的插件
      * @return the entity set for that plugin's scope <br> 该插件 scope 的实体集合
      */
-    private Set<Class<?>> scanPluginEntities(UltiToolsPlugin plugin) {
+    private Set<Class<?>> scanPluginEntities(Class<? extends UltiToolsPlugin> pluginClass) {
         Set<Class<?>> entities = new HashSet<>();
-        File jarFile = resolveOwnJarFile(plugin.getClass());
+        File jarFile = resolveOwnJarFile(pluginClass);
         if (jarFile != null) {
             entities.addAll(scanEntitiesInJar(jarFile));
         }
-        UltiToolsModule module = plugin.getClass().getAnnotation(UltiToolsModule.class);
+        UltiToolsModule module = pluginClass.getAnnotation(UltiToolsModule.class);
         if (module != null) {
             Collections.addAll(entities, module.additionalEntities());
         }
@@ -570,7 +594,38 @@ public class PluginManager {
         }
         return entities;
     }
-    
+
+    /**
+     * Records {@code scope}'s owned entities in {@link #entityOwnership}, so a later ownership
+     * refusal (D-15) can name the actual owning module instead of only saying "not registered to
+     * you". Called every time a {@link DataScope} is minted, for both internal modules and
+     * external plugins.
+     * <p>
+     * 把 {@code scope} 拥有的实体记录进 {@link #entityOwnership}，使后续的所有权拒绝（D-15）
+     * 能够点名真正的拥有者模块，而不只是说「未向你注册」。每次铸造 {@link DataScope} 时都会
+     * 调用，内部模块和外部插件均适用。
+     *
+     * @param scope the scope just minted <br> 刚铸造的 scope
+     */
+    private void registerEntityOwnership(DataScope scope) {
+        for (Class<?> entity : scope.getOwnedEntities()) {
+            entityOwnership.putIfAbsent(entity, scope.getPluginName());
+        }
+    }
+
+    /**
+     * Looks up which loaded plugin owns {@code entityClass}, per {@link #entityOwnership}.
+     * <p>
+     * 按 {@link #entityOwnership} 查找哪个已加载插件拥有 {@code entityClass}。
+     *
+     * @param entityClass the entity class to look up <br> 待查找的实体类
+     * @return the owning plugin's name, or {@code null} if no loaded scope owns it <br>
+     *         拥有者插件的名称；若没有任何已加载 scope 拥有该实体则为 {@code null}
+     */
+    public String findOwningPlugin(Class<?> entityClass) {
+        return entityOwnership.get(entityClass);
+    }
+
     /**
      * Validate jar file security.
      * <br>
@@ -1063,7 +1118,9 @@ public class PluginManager {
             // can call Xxx.getInstance().getDataOperator() etc.
             setPluginStaticInstance(pluginClass, plugin);
 
-            wireAop(pluginContext, DataScope.forPlugin(plugin, scanPluginEntities(plugin)));
+            DataScope scope = DataScope.forPlugin(plugin, scanPluginEntities(plugin.getClass()));
+            registerEntityOwnership(scope);
+            wireAop(pluginContext, scope);
             pluginContext.refresh();
             plugin.setContext(pluginContext);
             return plugin;
@@ -1274,6 +1331,7 @@ public class PluginManager {
         // 3. Refresh container to instantiate beans
         DataScope scope = DataScope.forExternal(adapter.getPluginName(), adapter.getDataFolder(),
                 scanExternalEntities(adapter, additionalEntities));
+        registerEntityOwnership(scope);
         wireAop(context, scope);
         context.refresh();
         adapter.setContext(context);

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -44,6 +44,7 @@ import com.ultikits.ultitools.events.EventBus;
 import com.ultikits.ultitools.events.ModuleEvent;
 import com.ultikits.ultitools.context.SimpleContainer;
 import com.ultikits.ultitools.interfaces.DataStore;
+import com.ultikits.ultitools.interfaces.JdbcTransactionManager;
 import com.ultikits.ultitools.interfaces.TransactionManager;
 import com.ultikits.ultitools.manager.PluginDependencyResolver.CircularDependencyException;
 import com.ultikits.ultitools.manager.PluginDependencyResolver.MissingDependencyException;
@@ -748,9 +749,13 @@ public class PluginManager {
 
         // One DataSourceTransactionManager per plugin container (D-01/D-02, FOUND-04): built here,
         // from this plugin's own DataSource, so two plugin containers can never share transaction
-        // state. Registered into the container so DataOperator/service beans that need to join the
-        // active transaction (e.g. via setTransactionManager) can resolve it by type.
-        TransactionManager transactionManager = new DataSourceTransactionManager(dataSource);
+        // state. Typed as JdbcTransactionManager here (02-04, D-04) even though the interceptor's
+        // own constructor still takes the base TransactionManager type - the local's type is what
+        // documents that this advisor is bound to a JDBC-backed manager, not a future JSON one.
+        // Registered into the container under the base TransactionManager type so DataOperator/
+        // service beans that need to join the active transaction (e.g. via setTransactionManager)
+        // can resolve it regardless of backend.
+        JdbcTransactionManager transactionManager = new DataSourceTransactionManager(dataSource);
         context.registerType(TransactionManager.class, transactionManager);
 
         TransactionInterceptor transactionInterceptor = new TransactionInterceptor(transactionManager);

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -90,6 +90,19 @@ public class PluginManager {
     private final Map<Class<?>, String> entityOwnership = new ConcurrentHashMap<>();
 
     /**
+     * External plugin data folder (canonical path) -&gt; the {@link DataScope} minted for it,
+     * populated by {@link #registerExternal(ExternalPluginAdapter, Class[])}. Lets {@code
+     * DataStore.getOperator(File, Class)} resolve its caller back to a scope (D-18), for the
+     * default body a third-party {@code DataStore} that does not override that method inherits.
+     * <p>
+     * 外部插件数据文件夹（规范路径）-&gt; 为其铸造的 {@link DataScope}，由
+     * {@link #registerExternal(ExternalPluginAdapter, Class[])} 填充。使
+     * {@code DataStore.getOperator(File, Class)} 能把调用方解析回一个 scope（D-18）——针对未覆写
+     * 该方法的第三方 {@code DataStore} 所继承的默认实现。
+     */
+    private final Map<String, DataScope> externalScopesByFolder = new ConcurrentHashMap<>();
+
+    /**
      * Initialize plugin manager. Please do not call this method manually.
      * <br>
      * 初始化插件管理器。请不要手动调用此方法。
@@ -238,6 +251,7 @@ public class PluginManager {
             pluginContext.getBeanFactory().registerSingleton(plugin.getClass().getSimpleName(), plugin);
             DataScope scope = DataScope.forPlugin(plugin, scanPluginEntities(plugin.getClass()));
             registerEntityOwnership(scope);
+            plugin.setDataScope(scope);
             wireAop(pluginContext, scope);
             pluginContext.refresh();
             if (plugin.getClass().isAnnotationPresent(ContextEntry.class)) {
@@ -624,6 +638,45 @@ public class PluginManager {
      */
     public String findOwningPlugin(Class<?> entityClass) {
         return entityOwnership.get(entityClass);
+    }
+
+    /**
+     * Records an external plugin's {@link DataScope} under its data folder's canonical path, so
+     * {@link #findScopeForDataFolder} can resolve the caller of {@code DataStore.getOperator(File,
+     * Class)} back to a scope (D-18) -- the same canonical-path keying 02-02's Task 2 used for the
+     * SQLite pool map, so two spellings of the same folder resolve to one entry.
+     * <p>
+     * 把外部插件的 {@link DataScope} 按其数据文件夹的规范路径记录下来，使
+     * {@link #findScopeForDataFolder} 能把 {@code DataStore.getOperator(File, Class)} 的调用方
+     * 解析回一个 scope（D-18）——沿用 02-02 Task 2 为 SQLite 连接池 Map 采用的规范路径键法，
+     * 让同一个文件夹的两种写法解析到同一条记录。
+     *
+     * @param dataFolder the external plugin's own data folder <br> 外部插件自己的数据文件夹
+     * @param scope      the scope just minted for it <br> 刚为它铸造的 scope
+     */
+    private void registerExternalScope(File dataFolder, DataScope scope) {
+        externalScopesByFolder.put(canonicalPath(dataFolder), scope);
+    }
+
+    /**
+     * Resolves a data folder back to the registered external plugin scope that owns it (D-18).
+     * <p>
+     * 把数据文件夹解析回拥有它的、已注册的外部插件 scope（D-18）。
+     *
+     * @param dataFolder the folder to resolve <br> 待解析的文件夹
+     * @return the registered scope, or {@code null} if the folder matches no registered adapter
+     *         <br> 已注册的 scope；若该文件夹不匹配任何已注册的适配器则为 {@code null}
+     */
+    public DataScope findScopeForDataFolder(File dataFolder) {
+        return externalScopesByFolder.get(canonicalPath(dataFolder));
+    }
+
+    private static String canonicalPath(File folder) {
+        try {
+            return folder.getCanonicalPath();
+        } catch (IOException e) {
+            return folder.getAbsolutePath();
+        }
     }
 
     /**
@@ -1120,6 +1173,7 @@ public class PluginManager {
 
             DataScope scope = DataScope.forPlugin(plugin, scanPluginEntities(plugin.getClass()));
             registerEntityOwnership(scope);
+            plugin.setDataScope(scope);
             wireAop(pluginContext, scope);
             pluginContext.refresh();
             plugin.setContext(pluginContext);
@@ -1332,6 +1386,8 @@ public class PluginManager {
         DataScope scope = DataScope.forExternal(adapter.getPluginName(), adapter.getDataFolder(),
                 scanExternalEntities(adapter, additionalEntities));
         registerEntityOwnership(scope);
+        adapter.setDataScope(scope);
+        registerExternalScope(adapter.getDataFolder(), scope);
         wireAop(context, scope);
         context.refresh();
         adapter.setContext(context);

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -46,6 +46,7 @@ import com.ultikits.ultitools.context.SimpleContainer;
 import com.ultikits.ultitools.interfaces.DataStore;
 import com.ultikits.ultitools.interfaces.JdbcTransactionManager;
 import com.ultikits.ultitools.interfaces.TransactionManager;
+import com.ultikits.ultitools.interfaces.impl.data.json.JsonStore;
 import com.ultikits.ultitools.manager.PluginDependencyResolver.CircularDependencyException;
 import com.ultikits.ultitools.manager.PluginDependencyResolver.MissingDependencyException;
 import com.ultikits.ultitools.utils.AnnotationUtils;
@@ -602,14 +603,17 @@ public class PluginManager {
      * Must be called before {@link SimpleContainer#refresh()}: the resolver participates in bean
      * instantiation, so beans created earlier are never proxied.
      * <p>
-     * {@code @ExceptionCatch} and {@code @Transactional} are both wired in this release, for the
-     * JDBC backends (SQLite, MySQL). {@code DataStore} now exposes the plugin's {@code DataSource}
-     * via {@code getDataSource(DataScope)}, keyed by database file rather than by entity class,
-     * and this method builds one {@code TransactionManager} per plugin container from it and
-     * registers a {@code TransactionInterceptor} advisor for that manager. Issues #195 and #196
-     * are both addressed for the JDBC backends. The JSON backend does not implement
-     * {@code getDataSource(DataScope)} yet, so {@code @Transactional} stays declared unavailable
-     * there until a snapshot-based transaction manager lands.
+     * {@code @ExceptionCatch} and {@code @Transactional} are both wired in this release, on all
+     * three backends. {@code DataStore} now exposes the plugin's {@code DataSource} via
+     * {@code getDataSource(DataScope)}, keyed by database file rather than by entity class, and
+     * this method builds one {@code TransactionManager} per plugin container from it and
+     * registers a {@code TransactionInterceptor} advisor for that manager, for the two JDBC
+     * backends (SQLite, MySQL). Issues #195 and #196 are both addressed for the JDBC backends.
+     * The JSON backend has its own {@code TransactionManager} instead (02-05, D-03): a per-plugin
+     * snapshot manager that rolls back every JSON operator a {@code @Transactional} method
+     * touched, obtained from {@code JsonStore} when {@code getDataSource(DataScope)} throws. Only
+     * a {@code DataStore} that can supply neither a {@code DataSource} nor its own
+     * {@code TransactionManager} still declares {@code @Transactional} unavailable.
      * <p>
      * <b>Scope limit 1 — {@code registerSingleton} bypasses this entirely.</b> Only beans the
      * container constructs itself (through {@code registerBean} or component scanning) are ever
@@ -651,12 +655,14 @@ public class PluginManager {
      * {@code @ExceptionCatch} silently does nothing there and {@code @Transactional} is not
      * even refused. Unchanged from 6.2.x, and not fixed here.
      * <p>
-     * 本版本同时接线 @ExceptionCatch 与 @Transactional（面向 SQLite、MySQL 两个 JDBC 后端）。
+     * 本版本同时接线 @ExceptionCatch 与 @Transactional（覆盖全部三种后端）。
      * DataStore 现在通过 getDataSource(DataScope) 暴露插件的 DataSource——按数据库文件而非
      * 实体类分池，本方法据此为每个插件容器构建一个 TransactionManager，并为其注册
-     * TransactionInterceptor 通知器。issue #195、#196 在 JDBC 后端上均已解决。JSON 后端尚未
-     * 实现 getDataSource(DataScope)，因此 @Transactional 在该后端仍声明为不可用，直到基于
-     * 快照的事务管理器落地。
+     * TransactionInterceptor 通知器，覆盖 SQLite、MySQL 两个 JDBC 后端。issue #195、#196
+     * 在 JDBC 后端上均已解决。JSON 后端改为拥有自己的 TransactionManager（02-05，D-03）：
+     * 一个按插件快照的管理器，回滚 @Transactional 方法触碰过的每一个 JSON 操作器；
+     * 当 getDataSource(DataScope) 抛出异常时从 JsonStore 获取。只有既不能提供 DataSource
+     * 也不能提供自身 TransactionManager 的 DataStore，才仍会把 @Transactional 声明为不可用。
      * <p>
      * 范围限制一：以 registerSingleton 方式注册的对象完全绕开这套机制——插件实例本身、
      * {@code @ContextEntry} bean（反射手工构造）、config 实体、{@code @Configuration} 类
@@ -715,13 +721,18 @@ public class PluginManager {
     }
 
     /**
-     * Builds and registers the {@code @Transactional} advisor for one plugin container, or
-     * declares the annotation unavailable if the configured backend cannot supply a
-     * {@code DataSource} yet (the JSON backend, until 02-05's snapshot-based manager lands).
+     * Builds and registers the {@code @Transactional} advisor for one plugin container. For a
+     * backend whose {@code DataStore} exposes a JDBC {@code DataSource} (SQLite, MySQL), the
+     * advisor is bound to a {@link DataSourceTransactionManager}. For the JSON backend, it is
+     * bound to a per-plugin snapshot {@code JsonTransactionManager} instead (02-05, D-03),
+     * obtained from the store itself. A {@code DataStore} that can supply neither still declares
+     * the annotation unavailable, naming the configured backend.
      * <p>
-     * 为一个插件容器构建并注册 {@code @Transactional} 通知器；若配置的后端还不能提供
-     * {@code DataSource}（JSON 后端，直到 02-05 的快照式管理器落地为止），则将该注解声明为
-     * 不可用。
+     * 为一个插件容器构建并注册 {@code @Transactional} 通知器。对于其 {@code DataStore} 暴露
+     * JDBC {@code DataSource} 的后端（SQLite、MySQL），通知器绑定到
+     * {@link DataSourceTransactionManager}；对于 JSON 后端，则改为绑定到按插件快照的
+     * {@code JsonTransactionManager}（02-05，D-03），从该存储自身获取。既不能提供以上任何一种的
+     * {@code DataStore}，仍会声明该注解不可用，并指明所配置的后端。
      *
      * @param context  the plugin container, before refresh <br> 插件容器，尚未 refresh
      * @param scope    the identity token used to resolve the plugin's {@code DataSource}
@@ -734,10 +745,22 @@ public class PluginManager {
         try {
             dataSource = dataStore.getDataSource(scope);
         } catch (UnsupportedOperationException e) {
+            // Branch on the store's own capability, not on a string comparison of
+            // datasource.type (D-04's split already removed backend-name knowledge from this
+            // bootstrap; an instanceof check here is the smallest re-introduction of that
+            // knowledge that still avoids it living inside JsonStore's own construction logic --
+            // see 02-05's SUMMARY for why an interface method on DataStore was out of this plan's
+            // scope). A store that is neither JDBC-capable nor JsonStore keeps the pre-6.3.0
+            // refusal, naming itself so a third-party DataStore gets an honest answer instead of
+            // an NPE.
+            if (dataStore instanceof JsonStore) {
+                wireJsonTransactional(context, scope, resolver, (JsonStore) dataStore);
+                return;
+            }
             resolver.addUnavailableAnnotation(Transactional.class,
-                    "@Transactional needs a TransactionManager bound to a DataSource. The "
-                            + "configured datasource.type (" + dataStore.getStoreType() + ") does "
-                            + "not expose one yet. Until then use "
+                    "@Transactional needs a TransactionManager. The configured datasource.type ("
+                            + dataStore.getStoreType() + ") does not expose a DataSource or a "
+                            + "snapshot-based TransactionManager of its own. Until then use "
                             + "DataOperator.transaction(Callable) explicitly.");
             return;
         }
@@ -763,6 +786,42 @@ public class PluginManager {
         // matching the documented interceptor order Transaction -> Exception -> target, and the
         // "Transaction advisors typically use order 100" convention AopAdvisor#getOrder already
         // documents.
+        resolver.addAdvisor(AopAdvisor.forAnnotation(
+                Transactional.class, transactionInterceptor, 100, transactionalCache));
+    }
+
+    /**
+     * Builds and registers the {@code @Transactional} advisor for a plugin container backed by
+     * the JSON store, once {@link #wireTransactional} has determined {@code dataStore} cannot
+     * supply a JDBC {@code DataSource} but is a {@link JsonStore} (02-05, D-03).
+     * <p>
+     * 为由 JSON 存储支撑的插件容器构建并注册 {@code @Transactional} 通知器——在
+     * {@link #wireTransactional} 判定 {@code dataStore} 无法提供 JDBC {@code DataSource}
+     * 但确实是 {@link JsonStore} 之后调用（02-05，D-03）。
+     *
+     * @param context   the plugin container, before refresh <br> 插件容器，尚未 refresh
+     * @param scope     the identity token used to resolve the manager <br> 用于解析管理器的身份令牌
+     * @param resolver  the resolver {@code wireAop} is assembling <br> {@code wireAop} 正在组装的解析器
+     * @param jsonStore the JSON store to obtain the per-identity manager from <br>
+     *                  用于获取按身份划分的管理器的 JSON 存储
+     */
+    private static void wireJsonTransactional(SimpleContainer context, DataScope scope,
+            AopProxyResolver resolver, JsonStore jsonStore) {
+        // Same reasoning as the shared exceptionCatchCache above (D-38): one AnnotationLookupCache
+        // instance per plugin container, constructor-injected into the interceptor, never static.
+        AnnotationLookupCache<Transactional> transactionalCache =
+                new AnnotationLookupCache<>(Transactional.class);
+
+        // jsonStore.transactionManagerFor(scope) shares one JsonTransactionManager instance with
+        // every SimpleJsonDataOperator that store hands out for this identity (JsonStore binds it
+        // at getOperator() time), so a single @Transactional method's writes across several of
+        // this plugin's entities are governed by the same transaction (D-03).
+        TransactionManager transactionManager = jsonStore.transactionManagerFor(scope);
+        context.registerType(TransactionManager.class, transactionManager);
+
+        TransactionInterceptor transactionInterceptor = new TransactionInterceptor(transactionManager);
+        // Same order as the JDBC path above -- the interceptor does not know or care which
+        // backend built the manager it was given.
         resolver.addAdvisor(AopAdvisor.forAnnotation(
                 Transactional.class, transactionInterceptor, 100, transactionalCache));
     }

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -49,6 +49,8 @@ import com.ultikits.ultitools.interfaces.DataStore;
 import com.ultikits.ultitools.interfaces.JdbcTransactionManager;
 import com.ultikits.ultitools.interfaces.TransactionManager;
 import com.ultikits.ultitools.interfaces.impl.data.json.JsonStore;
+import com.ultikits.ultitools.interfaces.impl.data.mysql.MysqlDataStore;
+import com.ultikits.ultitools.interfaces.impl.data.sqlite.SQLiteDataStore;
 import com.ultikits.ultitools.manager.PluginDependencyResolver.CircularDependencyException;
 import com.ultikits.ultitools.manager.PluginDependencyResolver.MissingDependencyException;
 import com.ultikits.ultitools.utils.AnnotationUtils;
@@ -987,14 +989,19 @@ public class PluginManager {
     /**
      * Builds and registers the {@code @Transactional} advisor for one plugin container. For a
      * backend whose {@code DataStore} exposes a JDBC {@code DataSource} (SQLite, MySQL), the
-     * advisor is bound to a {@link DataSourceTransactionManager}. For the JSON backend, it is
-     * bound to a per-plugin snapshot {@code JsonTransactionManager} instead (02-05, D-03),
-     * obtained from the store itself. A {@code DataStore} that can supply neither still declares
-     * the annotation unavailable, naming the configured backend.
+     * advisor is bound to a {@link DataSourceTransactionManager} -- resolved via {@link
+     * #resolveJdbcTransactionManager}, which for these two shipped backends is the SAME instance
+     * the store itself wires onto the {@code DataOperator}s it hands out (02-09, T-02-TAM-11), not
+     * an independent second one. For the JSON backend, it is bound to a per-plugin snapshot
+     * {@code JsonTransactionManager} instead (02-05, D-03), obtained from the store itself. A
+     * {@code DataStore} that can supply neither still declares the annotation unavailable, naming
+     * the configured backend.
      * <p>
      * 为一个插件容器构建并注册 {@code @Transactional} 通知器。对于其 {@code DataStore} 暴露
      * JDBC {@code DataSource} 的后端（SQLite、MySQL），通知器绑定到
-     * {@link DataSourceTransactionManager}；对于 JSON 后端，则改为绑定到按插件快照的
+     * {@link DataSourceTransactionManager}——通过 {@link #resolveJdbcTransactionManager} 解析，
+     * 对这两个自带后端而言，与该存储自身绑定到其分发的 {@code DataOperator} 上的实例完全相同
+     * （02-09，T-02-TAM-11），而非独立构造的第二个；对于 JSON 后端，则改为绑定到按插件快照的
      * {@code JsonTransactionManager}（02-05，D-03），从该存储自身获取。既不能提供以上任何一种的
      * {@code DataStore}，仍会声明该注解不可用，并指明所配置的后端。
      *
@@ -1034,15 +1041,20 @@ public class PluginManager {
         AnnotationLookupCache<Transactional> transactionalCache =
                 new AnnotationLookupCache<>(Transactional.class);
 
-        // One DataSourceTransactionManager per plugin container (D-01/D-02, FOUND-04): built here,
-        // from this plugin's own DataSource, so two plugin containers can never share transaction
-        // state. Typed as JdbcTransactionManager here (02-04, D-04) even though the interceptor's
-        // own constructor still takes the base TransactionManager type - the local's type is what
-        // documents that this advisor is bound to a JDBC-backed manager, not a future JSON one.
-        // Registered into the container under the base TransactionManager type so DataOperator/
-        // service beans that need to join the active transaction (e.g. via setTransactionManager)
-        // can resolve it regardless of backend.
-        JdbcTransactionManager transactionManager = new DataSourceTransactionManager(dataSource);
+        // One DataSourceTransactionManager per plugin container (D-01/D-02, FOUND-04), so two
+        // plugin containers can never share transaction state. Typed as JdbcTransactionManager
+        // here (02-04, D-04) even though the interceptor's own constructor still takes the base
+        // TransactionManager type - the local's type is what documents that this advisor is bound
+        // to a JDBC-backed manager, not a future JSON one. Registered into the container under
+        // the base TransactionManager type so DataOperator/service beans that need to join the
+        // active transaction (e.g. via setTransactionManager) can resolve it regardless of
+        // backend.
+        //
+        // resolveJdbcTransactionManager (02-09, T-02-TAM-11) resolves the SAME instance
+        // SQLiteDataStore/MysqlDataStore wire onto the operators they hand out for this scope's
+        // own database file/identity, instead of constructing an independent second manager here
+        // - a @Transactional method calling insertAll must open exactly one transaction, not two.
+        JdbcTransactionManager transactionManager = resolveJdbcTransactionManager(dataStore, scope, dataSource);
         context.registerType(TransactionManager.class, transactionManager);
 
         TransactionInterceptor transactionInterceptor = new TransactionInterceptor(transactionManager);
@@ -1052,6 +1064,49 @@ public class PluginManager {
         // documents.
         resolver.addAdvisor(AopAdvisor.forAnnotation(
                 Transactional.class, transactionInterceptor, 100, transactionalCache));
+    }
+
+    /**
+     * Resolves the {@link JdbcTransactionManager} {@link #wireTransactional} should bind the AOP
+     * interceptor to, for a JDBC-capable {@code dataStore} (02-09, T-02-TAM-11).
+     * <p>
+     * For the two backends this framework ships, {@code dataStore} itself owns a per-identity
+     * registry of these managers -- {@code SQLiteDataStore.transactionManagerFor(DataScope)} /
+     * {@code MysqlDataStore.transactionManagerFor(DataScope)} -- and every {@code getOperator}
+     * call on that same store resolves a manager through the identical registry before handing an
+     * operator to a module author. Calling that method here, instead of constructing a fresh
+     * {@code new DataSourceTransactionManager(dataSource)}, is what makes the two paths converge
+     * on one shared instance: a {@code @Transactional} method that calls {@code
+     * DataOperator.insertAll} joins the same transaction the interceptor already opened, rather
+     * than opening an independent second one on its own connection (a defect worse than no
+     * transaction at all, because it looks correct).
+     * <p>
+     * A third-party {@code DataStore} that supplies a JDBC {@code DataSource} but is neither of
+     * the two concrete types this framework ships has no such registry to share -- this method
+     * falls back to a manager scoped only to the AOP interceptor, exactly {@code
+     * wireTransactional}'s pre-6.3.0 behavior. A {@code DataOperator} that store hands out
+     * separately (if any) would not join this manager's transactions; there is no seam on the
+     * {@code DataStore} interface (out of this plan's file scope) to close that gap generically.
+     *
+     * @param dataStore  the store {@link #wireTransactional} resolved a {@code DataSource} from
+     *                    <br> {@link #wireTransactional} 解析出 {@code DataSource} 的存储
+     * @param scope      the identity token used to resolve the manager <br> 用于解析管理器的身份令牌
+     * @param dataSource the {@code DataSource} {@code dataStore.getDataSource(scope)} returned,
+     *                    used only for the third-party fallback <br> {@code
+     *                    dataStore.getDataSource(scope)} 返回的 {@code DataSource}，仅供第三方
+     *                    回退分支使用
+     * @return the {@link JdbcTransactionManager} to bind the interceptor to <br> 应绑定到通知器的
+     *         {@link JdbcTransactionManager}
+     */
+    private static JdbcTransactionManager resolveJdbcTransactionManager(
+            DataStore dataStore, DataScope scope, DataSource dataSource) {
+        if (dataStore instanceof SQLiteDataStore) {
+            return ((SQLiteDataStore) dataStore).transactionManagerFor(scope);
+        }
+        if (dataStore instanceof MysqlDataStore) {
+            return ((MysqlDataStore) dataStore).transactionManagerFor(scope);
+        }
+        return new DataSourceTransactionManager(dataSource);
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -11,6 +11,7 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.jar.JarEntry;
@@ -484,16 +485,8 @@ public class PluginManager {
 
             while (entryEnumeration.hasMoreElements()) {
                 JarEntry entry = entryEnumeration.nextElement();
-                if (!entry.getName().endsWith(".class") || entry.getName().contains("META-INF")) {
-                    continue;
-                }
-
-                String className = entry
-                        .getName()
-                        .replace('/', '.')
-                        .replace(".class", "");
-
-                if (!scannedClasses.add(className)) {
+                String className = classNameForEntityScan(entry);
+                if (className == null || !scannedClasses.add(className)) {
                     continue;
                 }
 
@@ -505,24 +498,64 @@ public class PluginManager {
                             + "not enforced, so no entity is silently dropped).");
                 }
 
-                try {
-                    Class<?> aClass = ClassLoaderUtils.loadClass(className);
-                    if (aClass.isAnnotationPresent(com.ultikits.ultitools.annotations.Table.class)) {
-                        entities.add(aClass);
-                    }
-                } catch (ClassNotFoundException | LinkageError e) {
-                    Bukkit.getLogger().log(Level.FINE,
-                        "[UltiTools-API] Could not load class during entity scan: " + className + " - " + e.getMessage());
-                } catch (SecurityException e) {
-                    Bukkit.getLogger().log(Level.WARNING,
-                        "[UltiTools-API] Security violation during entity scan: " + className + " - " + e.getMessage());
-                }
+                resolveEntityClass(className).ifPresent(entities::add);
             }
         } catch (IOException | LinkageError | RuntimeException e) {
             Bukkit.getLogger().log(Level.SEVERE,
                 "[UltiTools-API] Failed to scan jar for entities: " + pluginJar.getName(), e);
         }
         return entities;
+    }
+
+    /**
+     * Converts one {@code JarEntry} from {@link #scanEntitiesInJar} into a dotted class name,
+     * or {@code null} when the entry is not a class file the entity scan cares about (a
+     * {@code META-INF} entry, or anything not ending in {@code .class}).
+     * <p>
+     * 把 {@link #scanEntitiesInJar} 中的一个 {@code JarEntry} 转换为点分隔的类名；如果这个条目不是
+     * 实体扫描关心的 class 文件（{@code META-INF} 条目，或任何不以 {@code .class} 结尾的条目），
+     * 返回 {@code null}。
+     *
+     * @param entry the jar entry under inspection <br> 正在检查的 jar 条目
+     * @return the dotted class name, or null to skip the entry <br> 点分隔的类名，或 null 表示跳过该条目
+     */
+    private static String classNameForEntityScan(JarEntry entry) {
+        if (!entry.getName().endsWith(".class") || entry.getName().contains("META-INF")) {
+            return null;
+        }
+        return entry
+                .getName()
+                .replace('/', '.')
+                .replace(".class", "");
+    }
+
+    /**
+     * Loads {@code className} and returns it wrapped in an {@code Optional} when it carries
+     * {@code @Table}, for {@link #scanEntitiesInJar}'s per-entry step. Never throws: a class that
+     * cannot be loaded, or is loaded but is not an entity, both resolve to {@code Optional.empty()}.
+     * <p>
+     * 加载 {@code className}，若其携带 {@code @Table} 注解则以 {@code Optional} 包裹返回，供
+     * {@link #scanEntitiesInJar} 逐条目使用。永不抛出异常：无法加载的类，或加载成功但不是实体的类，
+     * 都会解析为 {@code Optional.empty()}。
+     *
+     * @param className the dotted class name to load <br> 待加载的点分隔类名
+     * @return the loaded class if it is a {@code @Table} entity, otherwise empty <br>
+     *         若加载的类是 {@code @Table} 实体则返回该类，否则为空
+     */
+    private static Optional<Class<?>> resolveEntityClass(String className) {
+        try {
+            Class<?> aClass = ClassLoaderUtils.loadClass(className);
+            if (aClass.isAnnotationPresent(com.ultikits.ultitools.annotations.Table.class)) {
+                return Optional.of(aClass);
+            }
+        } catch (ClassNotFoundException | LinkageError e) {
+            Bukkit.getLogger().log(Level.FINE,
+                "[UltiTools-API] Could not load class during entity scan: " + className + " - " + e.getMessage());
+        } catch (SecurityException e) {
+            Bukkit.getLogger().log(Level.WARNING,
+                "[UltiTools-API] Security violation during entity scan: " + className + " - " + e.getMessage());
+        }
+        return Optional.empty();
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -15,6 +15,8 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.logging.Level;
 
+import javax.sql.DataSource;
+
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -35,11 +37,14 @@ import com.ultikits.ultitools.aop.AnnotationLookupCache;
 import com.ultikits.ultitools.aop.AopAdvisor;
 import com.ultikits.ultitools.aop.AopProxyResolver;
 import com.ultikits.ultitools.aop.ExceptionInterceptor;
+import com.ultikits.ultitools.aop.TransactionInterceptor;
 import com.ultikits.ultitools.api.ExternalPluginAdapter;
 import com.ultikits.ultitools.api.UltiToolsAPI;
 import com.ultikits.ultitools.events.EventBus;
 import com.ultikits.ultitools.events.ModuleEvent;
 import com.ultikits.ultitools.context.SimpleContainer;
+import com.ultikits.ultitools.interfaces.DataStore;
+import com.ultikits.ultitools.interfaces.TransactionManager;
 import com.ultikits.ultitools.manager.PluginDependencyResolver.CircularDependencyException;
 import com.ultikits.ultitools.manager.PluginDependencyResolver.MissingDependencyException;
 import com.ultikits.ultitools.utils.AnnotationUtils;
@@ -212,7 +217,7 @@ public class PluginManager {
             pluginContext.registerShutdownHook();
             pluginContext.setClassLoader(classLoader);
             pluginContext.getBeanFactory().registerSingleton(plugin.getClass().getSimpleName(), plugin);
-            wireAop(pluginContext);
+            wireAop(pluginContext, DataScope.forPlugin(plugin));
             pluginContext.refresh();
             if (plugin.getClass().isAnnotationPresent(ContextEntry.class)) {
                 ContextEntry contextEntry = plugin.getClass().getAnnotation(ContextEntry.class);
@@ -596,11 +601,14 @@ public class PluginManager {
      * Must be called before {@link SimpleContainer#refresh()}: the resolver participates in bean
      * instantiation, so beans created earlier are never proxied.
      * <p>
-     * Only {@code @ExceptionCatch} is wired in this release. {@code @Transactional} is declared
-     * unavailable rather than silently inert: the framework has no reachable
-     * {@code TransactionManager} today, because {@code DataStore} does not expose its
-     * {@code DataSource} and the default SQLite backend opens one connection pool per entity class
-     * against a per-plugin {@code .db} file. Tracked in issues #195 and #196.
+     * {@code @ExceptionCatch} and {@code @Transactional} are both wired in this release, for the
+     * JDBC backends (SQLite, MySQL). {@code DataStore} now exposes the plugin's {@code DataSource}
+     * via {@code getDataSource(DataScope)}, keyed by database file rather than by entity class,
+     * and this method builds one {@code TransactionManager} per plugin container from it and
+     * registers a {@code TransactionInterceptor} advisor for that manager. Issues #195 and #196
+     * are both addressed for the JDBC backends. The JSON backend does not implement
+     * {@code getDataSource(DataScope)} yet, so {@code @Transactional} stays declared unavailable
+     * there until a snapshot-based transaction manager lands.
      * <p>
      * <b>Scope limit 1 — {@code registerSingleton} bypasses this entirely.</b> Only beans the
      * container constructs itself (through {@code registerBean} or component scanning) are ever
@@ -642,8 +650,12 @@ public class PluginManager {
      * {@code @ExceptionCatch} silently does nothing there and {@code @Transactional} is not
      * even refused. Unchanged from 6.2.x, and not fixed here.
      * <p>
-     * 本版本只接线 @ExceptionCatch。@Transactional 声明为不可用而非静默失效，
-     * 因为框架当前没有可达的 TransactionManager。见 issue #195 / #196。
+     * 本版本同时接线 @ExceptionCatch 与 @Transactional（面向 SQLite、MySQL 两个 JDBC 后端）。
+     * DataStore 现在通过 getDataSource(DataScope) 暴露插件的 DataSource——按数据库文件而非
+     * 实体类分池，本方法据此为每个插件容器构建一个 TransactionManager，并为其注册
+     * TransactionInterceptor 通知器。issue #195、#196 在 JDBC 后端上均已解决。JSON 后端尚未
+     * 实现 getDataSource(DataScope)，因此 @Transactional 在该后端仍声明为不可用，直到基于
+     * 快照的事务管理器落地。
      * <p>
      * 范围限制一：以 registerSingleton 方式注册的对象完全绕开这套机制——插件实例本身、
      * {@code @ContextEntry} bean（反射手工构造）、config 实体、{@code @Configuration} 类
@@ -670,8 +682,12 @@ public class PluginManager {
      * {@code @Transactional} 连拒绝都不会触发。与 6.2.x 行为相同，本批未修复。
      *
      * @param context the plugin container, before refresh
+     * @param scope   the identity token minted for the caller, used to resolve that plugin's
+     *                {@code DataSource} for the {@code @Transactional} advisor <br>
+     *                为调用方铸造的身份令牌，用于解析该插件的 {@code DataSource}，供
+     *                {@code @Transactional} 通知器使用
      */
-    static void wireAop(SimpleContainer context) {
+    static void wireAop(SimpleContainer context, DataScope scope) {
         AopProxyResolver resolver = new AopProxyResolver();
 
         // One AnnotationLookupCache instance per annotation type, shared between the advisor and
@@ -690,17 +706,60 @@ public class PluginManager {
         resolver.addAdvisor(AopAdvisor.forAnnotation(
                 ExceptionCatch.class, exceptionInterceptor, 200, exceptionCatchCache));
 
-        resolver.addUnavailableAnnotation(Transactional.class,
-                "@Transactional needs a TransactionManager bound to a DataSource. The framework "
-                        + "cannot provide one yet: DataStore does not expose its DataSource, and "
-                        + "the default SQLite backend opens one connection pool per entity class, "
-                        + "so a single .db file would have several unrelated transaction managers. "
-                        + "Tracked in issues #195 and #196. Until then use "
-                        + "DataOperator.transaction(Callable) explicitly.");
+        wireTransactional(context, scope, resolver);
 
         resolver.validateAnnotationCoverage();
 
         context.setAopProxyResolver(resolver);
+    }
+
+    /**
+     * Builds and registers the {@code @Transactional} advisor for one plugin container, or
+     * declares the annotation unavailable if the configured backend cannot supply a
+     * {@code DataSource} yet (the JSON backend, until 02-05's snapshot-based manager lands).
+     * <p>
+     * 为一个插件容器构建并注册 {@code @Transactional} 通知器；若配置的后端还不能提供
+     * {@code DataSource}（JSON 后端，直到 02-05 的快照式管理器落地为止），则将该注解声明为
+     * 不可用。
+     *
+     * @param context  the plugin container, before refresh <br> 插件容器，尚未 refresh
+     * @param scope    the identity token used to resolve the plugin's {@code DataSource}
+     *                 <br> 用于解析插件 {@code DataSource} 的身份令牌
+     * @param resolver the resolver {@code wireAop} is assembling <br> {@code wireAop} 正在组装的解析器
+     */
+    private static void wireTransactional(SimpleContainer context, DataScope scope, AopProxyResolver resolver) {
+        DataStore dataStore = UltiTools.getInstance().getDataStore();
+        DataSource dataSource;
+        try {
+            dataSource = dataStore.getDataSource(scope);
+        } catch (UnsupportedOperationException e) {
+            resolver.addUnavailableAnnotation(Transactional.class,
+                    "@Transactional needs a TransactionManager bound to a DataSource. The "
+                            + "configured datasource.type (" + dataStore.getStoreType() + ") does "
+                            + "not expose one yet. Until then use "
+                            + "DataOperator.transaction(Callable) explicitly.");
+            return;
+        }
+
+        // Same reasoning as the shared exceptionCatchCache above (D-38): one AnnotationLookupCache
+        // instance per plugin container, constructor-injected into the interceptor, never static.
+        AnnotationLookupCache<Transactional> transactionalCache =
+                new AnnotationLookupCache<>(Transactional.class);
+
+        // One DataSourceTransactionManager per plugin container (D-01/D-02, FOUND-04): built here,
+        // from this plugin's own DataSource, so two plugin containers can never share transaction
+        // state. Registered into the container so DataOperator/service beans that need to join the
+        // active transaction (e.g. via setTransactionManager) can resolve it by type.
+        TransactionManager transactionManager = new DataSourceTransactionManager(dataSource);
+        context.registerType(TransactionManager.class, transactionManager);
+
+        TransactionInterceptor transactionInterceptor = new TransactionInterceptor(transactionManager);
+        // Order 100: below ExceptionCatch's 200 (lower value = higher priority, applied outermost),
+        // matching the documented interceptor order Transaction -> Exception -> target, and the
+        // "Transaction advisors typically use order 100" convention AopAdvisor#getOrder already
+        // documents.
+        resolver.addAdvisor(AopAdvisor.forAnnotation(
+                Transactional.class, transactionInterceptor, 100, transactionalCache));
     }
 
     /**
@@ -784,7 +843,7 @@ public class PluginManager {
             // can call Xxx.getInstance().getDataOperator() etc.
             setPluginStaticInstance(pluginClass, plugin);
 
-            wireAop(pluginContext);
+            wireAop(pluginContext, DataScope.forPlugin(plugin));
             pluginContext.refresh();
             plugin.setContext(pluginContext);
             return plugin;
@@ -976,7 +1035,8 @@ public class PluginManager {
         }
 
         // 3. Refresh container to instantiate beans
-        wireAop(context);
+        wireAop(context, DataScope.forExternal(adapter.getPluginName(), adapter.getDataFolder(),
+                Collections.emptySet()));
         context.refresh();
         adapter.setContext(context);
 

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -219,7 +219,7 @@ public class PluginManager {
             pluginContext.registerShutdownHook();
             pluginContext.setClassLoader(classLoader);
             pluginContext.getBeanFactory().registerSingleton(plugin.getClass().getSimpleName(), plugin);
-            wireAop(pluginContext, DataScope.forPlugin(plugin));
+            wireAop(pluginContext, DataScope.forPlugin(plugin, scanPluginEntities(plugin)));
             pluginContext.refresh();
             if (plugin.getClass().isAnnotationPresent(ContextEntry.class)) {
                 ContextEntry contextEntry = plugin.getClass().getAnnotation(ContextEntry.class);
@@ -413,6 +413,162 @@ public class PluginManager {
                 "[UltiTools-API] Failed to read jar file: " + pluginJar.getName(), e);
         }
         return null;
+    }
+
+    /**
+     * Scans a plugin's own JAR for classes carrying {@code @Table}, independently of {@link
+     * #loadPluginMainClass}'s scan (which returns as soon as it finds the module's main class and
+     * discards its own {@code scannedClasses} set). This pass visits every entry so a truncated
+     * result never makes a legitimate entity look unowned -- under D-15's fail-closed rule that
+     * would refuse a module that did nothing wrong. {@link #loadPluginMainClass}'s 1,000-class cap
+     * is reported here, not enforced: crossing it produces one WARNING naming the jar and the
+     * count, and the scan continues to the end of the jar regardless.
+     * <p>
+     * 独立于 {@link #loadPluginMainClass} 的扫描（后者一找到模块主类就 return，并丢弃自己的
+     * {@code scannedClasses} 集合），扫描 {@code pluginJar} 中所有携带 {@code @Table} 注解的类。
+     * 本次扫描会遍历每一个条目——截断的结果会让一个合法实体看起来「无主」，而 D-15 的
+     * fail-closed 规则会因此拒绝一个完全无辜的模块。给 {@link #loadPluginMainClass} 设置上限的
+     * 1000 这个数字，在这里只报告、不强制——超过时只产生一条 WARNING（点名 jar 和数量），
+     * 扫描仍会继续到 jar 结尾。
+     *
+     * @param pluginJar the module's own jar file <br> 模块自身的 jar 文件
+     * @return every {@code @Table}-annotated class found, never null <br> 找到的每一个携带
+     *         {@code @Table} 的类，不会为 null
+     */
+    private Set<Class<?>> scanEntitiesInJar(File pluginJar) {
+        Set<Class<?>> entities = new HashSet<>();
+        if (pluginJar == null || !pluginJar.isFile()) {
+            return entities;
+        }
+        try (JarFile jarFile = new JarFile(pluginJar)) {
+            Enumeration<JarEntry> entryEnumeration = jarFile.entries();
+            Set<String> scannedClasses = new HashSet<>();
+            boolean warnedOverCap = false;
+
+            while (entryEnumeration.hasMoreElements()) {
+                JarEntry entry = entryEnumeration.nextElement();
+                if (!entry.getName().endsWith(".class") || entry.getName().contains("META-INF")) {
+                    continue;
+                }
+
+                String className = entry
+                        .getName()
+                        .replace('/', '.')
+                        .replace(".class", "");
+
+                if (!scannedClasses.add(className)) {
+                    continue;
+                }
+
+                if (!warnedOverCap && scannedClasses.size() > 1000) {
+                    warnedOverCap = true;
+                    Bukkit.getLogger().log(Level.WARNING,
+                        "[UltiTools-API] Entity scan of " + pluginJar.getName() + " has passed 1000 "
+                            + "classes -- the scan continues to completion (the cap is reported here, "
+                            + "not enforced, so no entity is silently dropped).");
+                }
+
+                try {
+                    Class<?> aClass = ClassLoaderUtils.loadClass(className);
+                    if (aClass.isAnnotationPresent(com.ultikits.ultitools.annotations.Table.class)) {
+                        entities.add(aClass);
+                    }
+                } catch (ClassNotFoundException | LinkageError e) {
+                    Bukkit.getLogger().log(Level.FINE,
+                        "[UltiTools-API] Could not load class during entity scan: " + className + " - " + e.getMessage());
+                } catch (SecurityException e) {
+                    Bukkit.getLogger().log(Level.WARNING,
+                        "[UltiTools-API] Security violation during entity scan: " + className + " - " + e.getMessage());
+                }
+            }
+        } catch (IOException | LinkageError | RuntimeException e) {
+            Bukkit.getLogger().log(Level.SEVERE,
+                "[UltiTools-API] Failed to scan jar for entities: " + pluginJar.getName(), e);
+        }
+        return entities;
+    }
+
+    /**
+     * Best-effort resolution of the jar file {@code aClass} was loaded from, via its {@link
+     * java.security.CodeSource}. Never throws; returns {@code null} when the code source is
+     * unavailable or does not point at a real jar (e.g. exploded test classes) -- the same
+     * "best effort, class-name fallback" posture {@link UltiToolsPlugin#resolveJarFileNameForError()}
+     * already uses for the same lookup.
+     * <p>
+     * 通过 {@link java.security.CodeSource} 尽力解析 {@code aClass} 的加载来源 jar 文件。永不抛出
+     * 异常；代码源不可用，或并未指向真实 jar 文件时（例如测试中未打包的 class），返回
+     * {@code null}，与 {@link UltiToolsPlugin#resolveJarFileNameForError()} 对同一查找的既有
+     * "尽力而为、回退类名" 做法一致。
+     *
+     * @param aClass the class whose jar should be resolved <br> 待解析所属 jar 的类
+     * @return the jar file, or null if it cannot be resolved <br> jar 文件，无法解析时为 null
+     */
+    private static File resolveOwnJarFile(Class<?> aClass) {
+        try {
+            java.security.CodeSource src = aClass.getProtectionDomain().getCodeSource();
+            if (src == null || src.getLocation() == null) {
+                return null;
+            }
+            File file = new File(src.getLocation().toURI());
+            return file.isFile() && file.getName().endsWith(".jar") ? file : null;
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * Builds the entity set a {@link DataScope} for {@code plugin} should carry (D-19): every
+     * {@code @Table} class found by scanning the module's own jar, plus anything declared via
+     * {@code @UltiToolsModule#additionalEntities()} for entities that legitimately live elsewhere.
+     * Never throws -- a plugin whose jar cannot be resolved (e.g. a directly-constructed test
+     * instance with no real jar) simply gets an entity set built from its declared
+     * {@code additionalEntities()} alone, which is empty by default.
+     * <p>
+     * 为 {@code plugin} 的 {@link DataScope} 构建实体集合（D-19）：扫描模块自身 jar 得到的每一个
+     * {@code @Table} 类，加上模块通过 {@code @UltiToolsModule#additionalEntities()} 声明的、
+     * 合法存放在别处的实体。永不抛出异常——jar 无法解析时（例如直接构造、没有真实 jar 的测试
+     * 实例），实体集合仅由其声明的 {@code additionalEntities()} 构成，默认为空。
+     *
+     * @param plugin the plugin whose scope is being minted <br> 正在铸造 scope 的插件
+     * @return the entity set for that plugin's scope <br> 该插件 scope 的实体集合
+     */
+    private Set<Class<?>> scanPluginEntities(UltiToolsPlugin plugin) {
+        Set<Class<?>> entities = new HashSet<>();
+        File jarFile = resolveOwnJarFile(plugin.getClass());
+        if (jarFile != null) {
+            entities.addAll(scanEntitiesInJar(jarFile));
+        }
+        UltiToolsModule module = plugin.getClass().getAnnotation(UltiToolsModule.class);
+        if (module != null) {
+            Collections.addAll(entities, module.additionalEntities());
+        }
+        return entities;
+    }
+
+    /**
+     * Builds the entity set a {@link DataScope} for an external plugin should carry (D-19): every
+     * {@code @Table} class found by scanning the plugin's own jar, plus whatever it declared via
+     * {@code UltiToolsAPI.connect(plugin, additionalEntities)}.
+     * <p>
+     * 为外部插件的 {@link DataScope} 构建实体集合（D-19）：扫描插件自身 jar 得到的每一个
+     * {@code @Table} 类，加上通过 {@code UltiToolsAPI.connect(plugin, additionalEntities)} 声明的
+     * 实体。
+     *
+     * @param adapter            the external plugin adapter <br> 外部插件适配器
+     * @param additionalEntities entity classes declared via {@code connect(...)} <br> 通过
+     *                           {@code connect(...)} 声明的实体类
+     * @return the entity set for that external plugin's scope <br> 该外部插件 scope 的实体集合
+     */
+    private Set<Class<?>> scanExternalEntities(ExternalPluginAdapter adapter, Class<?>[] additionalEntities) {
+        Set<Class<?>> entities = new HashSet<>();
+        File jarFile = resolveOwnJarFile(adapter.getJavaPlugin().getClass());
+        if (jarFile != null) {
+            entities.addAll(scanEntitiesInJar(jarFile));
+        }
+        if (additionalEntities != null) {
+            Collections.addAll(entities, additionalEntities);
+        }
+        return entities;
     }
     
     /**
@@ -907,7 +1063,7 @@ public class PluginManager {
             // can call Xxx.getInstance().getDataOperator() etc.
             setPluginStaticInstance(pluginClass, plugin);
 
-            wireAop(pluginContext, DataScope.forPlugin(plugin));
+            wireAop(pluginContext, DataScope.forPlugin(plugin, scanPluginEntities(plugin)));
             pluginContext.refresh();
             plugin.setContext(pluginContext);
             return plugin;
@@ -1087,6 +1243,23 @@ public class PluginManager {
      * @since 6.2.2
      */
     public void registerExternal(ExternalPluginAdapter adapter) {
+        registerExternal(adapter, new Class<?>[0]);
+    }
+
+    /**
+     * Register an external Bukkit plugin adapter with the framework, declaring entity classes
+     * that legitimately live outside the plugin's own JAR (D-19), in addition to the entities
+     * found by scanning the plugin's own JAR for {@code @Table} classes.
+     * <p>
+     * 注册外部 Bukkit 插件适配器到框架中，并声明合法存放在插件自身 JAR 之外的实体类（D-19），
+     * 作为对扫描插件自身 JAR 得到的 {@code @Table} 实体集合的补充。
+     *
+     * @param adapter            the external plugin adapter <br> 外部插件适配器
+     * @param additionalEntities entity classes owned by this plugin that live outside its own JAR
+     *                           <br> 该插件拥有、但存放在自身 JAR 之外的实体类
+     * @since 6.3.0
+     */
+    public void registerExternal(ExternalPluginAdapter adapter, Class<?>[] additionalEntities) {
         // 1. Create child IoC container
         SimpleContainer context = new SimpleContainer();
         context.setParent(UltiTools.getInstance().getDependenceManagers().getContext());
@@ -1099,8 +1272,9 @@ public class PluginManager {
         }
 
         // 3. Refresh container to instantiate beans
-        wireAop(context, DataScope.forExternal(adapter.getPluginName(), adapter.getDataFolder(),
-                Collections.emptySet()));
+        DataScope scope = DataScope.forExternal(adapter.getPluginName(), adapter.getDataFolder(),
+                scanExternalEntities(adapter, additionalEntities));
+        wireAop(context, scope);
         context.refresh();
         adapter.setContext(context);
 

--- a/src/test/java/com/ultikits/ultitools/abstracts/UltiToolsPluginNameFallbackTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/UltiToolsPluginNameFallbackTest.java
@@ -1,0 +1,53 @@
+package com.ultikits.ultitools.abstracts;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ultikits.ultitools.exceptions.PluginModuleException;
+import com.ultikits.ultitools.utils.TestHelper;
+
+/**
+ * Pins D-16: a module whose plugin.yml carries no {@code name:} key is refused at load, rather
+ * than silently collapsing into the shared {@code "unknown"} identity that used to route its data
+ * into {@code sqliteDB/unknown.db} alongside every other name-less module.
+ * <p>
+ * This fixture class has no {@code plugin.yml} resource of its own on the test classpath at all
+ * (a {@code getInputStream()} lookup for one against a directory-based CodeSource, as Surefire
+ * runs test classes from {@code target/test-classes/}, fails the same way "no name: key" does),
+ * which is exactly the scenario this refusal exists to catch: a module JAR that cannot supply a
+ * name.
+ */
+@DisplayName("UltiToolsPlugin name: 缺失时拒绝加载测试 (D-16)")
+class UltiToolsPluginNameFallbackTest {
+
+    @BeforeEach
+    void setUp() {
+        // getLogger() is exercised on the loadPluginConfiguration() IOException path this test
+        // deliberately hits (see class javadoc), so it needs a real java.util.logging.Logger, not
+        // Mockito's default null return.
+        TestHelper.mockUltiToolsInstance(
+                ultiTools -> when(ultiTools.getLogger()).thenReturn(Logger.getLogger("test")));
+    }
+
+    @Test
+    @DisplayName("plugin.yml 缺少 name: 时构造函数应该抛出 PluginModuleException")
+    void shouldRefuseToLoadWhenNameKeyMissing() {
+        assertThatThrownBy(FixturePlugin::new)
+                .isInstanceOf(PluginModuleException.class)
+                .hasMessageContaining("name");
+    }
+
+    /** Minimal concrete UltiToolsPlugin subclass - only registerSelf() is abstract. */
+    static class FixturePlugin extends UltiToolsPlugin {
+        @Override
+        public boolean registerSelf() {
+            return true;
+        }
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/abstracts/data/DataEntityTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/data/DataEntityTest.java
@@ -2,26 +2,51 @@ package com.ultikits.ultitools.abstracts.data;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scheduler.BukkitTask;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.stubbing.Answer;
 
+import com.ultikits.ultitools.UltiTools;
+import com.ultikits.ultitools.abstracts.command.BaseCommandExecutor;
 import com.ultikits.ultitools.annotations.Column;
 import com.ultikits.ultitools.annotations.Table;
+import com.ultikits.ultitools.annotations.command.AsyncCommand;
+import com.ultikits.ultitools.annotations.command.CmdExecutor;
+import com.ultikits.ultitools.annotations.command.CmdMapping;
+import com.ultikits.ultitools.annotations.command.CmdTarget;
+import com.ultikits.ultitools.annotations.command.RunAsync;
 
 /**
  * Unit tests for BaseDataEntity and AuditableDataEntity.
@@ -394,6 +419,254 @@ public class DataEntityTest {
         }
     }
 
+    /**
+     * 02-08 Task 3 (T-02-REP-1 / T-02-EOP-4 / T-02-REP-4): pins
+     * {@code BaseCommandExecutor}'s current-user wrapper contract by dispatching real
+     * {@code onCommand(...)} calls through a mocked {@link BukkitScheduler} that runs the
+     * scheduled {@link Runnable} on a thread distinct from the calling thread -- joined before
+     * returning. This deliberately defeats a wrapper placed around the *scheduling* call: a
+     * {@code ThreadLocal} write made on the calling thread is invisible from a genuinely
+     * different thread, so only a wrapper placed inside the handler's own {@code run()} can pass
+     * these tests. See the plan's read_first note on this exact trap and 02-08-PLAN.md's
+     * cross-phase notice about {@code BaseCommandExecutor.java} being Phase 5's file.
+     */
+    @Nested
+    @DisplayName("BaseCommandExecutor current-user wrapper tests")
+    class CurrentUserCommandWrapperTests {
+
+        private Command mockCommand;
+        private final UUID[] postRunState = new UUID[1];
+
+        @org.junit.jupiter.api.BeforeEach
+        void setUpCommand() {
+            mockCommand = mock(Command.class);
+            when(mockCommand.getName()).thenReturn("probe");
+        }
+
+        private UltiTools stubUltiTools() {
+            UltiTools mockUltiTools = mock(UltiTools.class);
+            when(mockUltiTools.i18n(anyString())).thenAnswer(inv -> inv.getArgument(0));
+            return mockUltiTools;
+        }
+
+        /**
+         * Runs {@code r} on a brand-new thread (joined before returning), capturing
+         * {@link AuditableDataEntity#getCurrentUser()} into {@link #postRunState} on that same
+         * thread immediately after {@code r} finishes -- whether it returned normally or
+         * {@code BaseCommandExecutor}'s internal catch swallowed an exception from it. Opens its
+         * own {@code UltiTools} static mock scope on the new thread, since Mockito's static
+         * mocking is thread-scoped and the error-report path in {@code run()} calls
+         * {@code UltiTools.getInstance()} from whatever thread the handler runs on.
+         */
+        private BukkitTask runOnNewThreadCapturingPostState(Runnable r) {
+            Thread t = new Thread(() -> {
+                try (MockedStatic<UltiTools> inner = mockStatic(UltiTools.class)) {
+                    UltiTools mockUltiToolsForThread = stubUltiTools();
+                    inner.when(UltiTools::getInstance).thenReturn(mockUltiToolsForThread);
+                    r.run();
+                } finally {
+                    postRunState[0] = AuditableDataEntity.getCurrentUser();
+                }
+            }, "gsd-02-08-dispatch-thread");
+            t.start();
+            try {
+                t.join(5000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return mock(BukkitTask.class);
+        }
+
+        private void dispatch(BaseCommandExecutor executor, CommandSender sender, String[] args) {
+            BukkitScheduler mockScheduler = mock(BukkitScheduler.class);
+            when(mockScheduler.runTask(any(), any(Runnable.class)))
+                    .thenAnswer(inv -> runOnNewThreadCapturingPostState(inv.getArgument(1)));
+            when(mockScheduler.runTaskAsynchronously(any(), any(Runnable.class)))
+                    .thenAnswer(inv -> runOnNewThreadCapturingPostState(inv.getArgument(1)));
+
+            try (MockedStatic<Bukkit> bukkitMock = mockStatic(Bukkit.class);
+                 MockedStatic<UltiTools> ultiToolsMock = mockStatic(UltiTools.class)) {
+                bukkitMock.when(Bukkit::getScheduler).thenReturn(mockScheduler);
+                UltiTools mockUltiTools = stubUltiTools();
+                ultiToolsMock.when(UltiTools::getInstance).thenReturn(mockUltiTools);
+                executor.onCommand(sender, mockCommand, "probe", args);
+            }
+        }
+
+        @Test
+        @DisplayName("Player-sourced sync command observes the player's UUID, on a thread distinct from the caller")
+        void playerSyncCommandObservesUuidOnHandlerThread() {
+            CurrentUserProbeExecutor executor = new CurrentUserProbeExecutor();
+            Player player = mock(Player.class);
+            UUID uuid = UUID.randomUUID();
+            when(player.getUniqueId()).thenReturn(uuid);
+
+            dispatch(executor, player, new String[]{});
+
+            assertTrue(executor.invoked, "the probe handler should have run");
+            assertEquals(uuid, executor.observedDuringHandler);
+            assertNotEquals(Thread.currentThread(), executor.executionThread,
+                    "the handler must run on the thread the scheduler actually invokes it on, not the calling thread");
+        }
+
+        @Test
+        @DisplayName("Console-sourced sync command leaves the current user unset (SQL NULL, not a placeholder)")
+        void consoleSyncCommandLeavesUserUnset() {
+            CurrentUserProbeExecutor executor = new CurrentUserProbeExecutor();
+            CommandSender console = mock(CommandSender.class);
+
+            dispatch(executor, console, new String[]{});
+
+            assertTrue(executor.invoked);
+            assertNull(executor.observedDuringHandler);
+        }
+
+        @Test
+        @DisplayName("@AsyncCommand handler observes the player's UUID on its own dedicated thread")
+        void asyncCommandObservesUuidOnHandlerThread() {
+            CurrentUserProbeExecutor executor = new CurrentUserProbeExecutor();
+            Player player = mock(Player.class);
+            UUID uuid = UUID.randomUUID();
+            when(player.getUniqueId()).thenReturn(uuid);
+
+            dispatch(executor, player, new String[]{"async"});
+
+            assertTrue(executor.invoked);
+            assertEquals(uuid, executor.observedDuringHandler);
+        }
+
+        @Test
+        @DisplayName("@RunAsync handler observes the player's UUID on its own dedicated thread")
+        void runAsyncCommandObservesUuidOnHandlerThread() {
+            CurrentUserProbeExecutor executor = new CurrentUserProbeExecutor();
+            Player player = mock(Player.class);
+            UUID uuid = UUID.randomUUID();
+            when(player.getUniqueId()).thenReturn(uuid);
+
+            dispatch(executor, player, new String[]{"runasync"});
+
+            assertTrue(executor.invoked);
+            assertEquals(uuid, executor.observedDuringHandler);
+        }
+
+        @Test
+        @DisplayName("ThreadLocal holds no value on the handler's own thread after it returns normally")
+        void threadLocalClearedAfterNormalReturn() {
+            CurrentUserProbeExecutor executor = new CurrentUserProbeExecutor();
+            Player player = mock(Player.class);
+            when(player.getUniqueId()).thenReturn(UUID.randomUUID());
+
+            dispatch(executor, player, new String[]{});
+
+            assertTrue(executor.invoked);
+            assertNull(postRunState[0],
+                    "clearCurrentUser() must run on the handler's own thread before it finishes");
+        }
+
+        @Test
+        @DisplayName("ThreadLocal holds no value on the handler's own thread even when the handler throws")
+        void threadLocalClearedAfterHandlerThrows() {
+            CurrentUserProbeExecutor executor = new CurrentUserProbeExecutor();
+            executor.throwOnInvoke = true;
+            Player player = mock(Player.class);
+            UUID uuid = UUID.randomUUID();
+            when(player.getUniqueId()).thenReturn(uuid);
+
+            dispatch(executor, player, new String[]{});
+
+            assertTrue(executor.invoked, "the handler ran (and observed its user) before throwing");
+            assertEquals(uuid, executor.observedDuringHandler);
+            assertNull(postRunState[0],
+                    "clearCurrentUser() must still run in a finally even though the handler threw");
+        }
+
+        @Test
+        @DisplayName("A thread reused for a second dispatch does not retain the first dispatch's user")
+        void reusedThreadDoesNotLeakBetweenDispatches() throws Exception {
+            ExecutorService pooledWorker =
+                    Executors.newSingleThreadExecutor(r -> new Thread(r, "gsd-02-08-pooled-worker"));
+            try {
+                CurrentUserProbeExecutor executorA = new CurrentUserProbeExecutor();
+                Player playerA = mock(Player.class);
+                UUID uuidA = UUID.randomUUID();
+                when(playerA.getUniqueId()).thenReturn(uuidA);
+                dispatchOnPool(pooledWorker, executorA, playerA, new String[]{});
+                assertEquals(uuidA, executorA.observedDuringHandler);
+
+                CurrentUserProbeExecutor executorB = new CurrentUserProbeExecutor();
+                CommandSender console = mock(CommandSender.class);
+                dispatchOnPool(pooledWorker, executorB, console, new String[]{});
+
+                assertTrue(executorB.invoked);
+                assertNull(executorB.observedDuringHandler,
+                        "the pooled thread must not carry executorA's user into executorB's dispatch");
+            } finally {
+                pooledWorker.shutdownNow();
+            }
+        }
+
+        private void dispatchOnPool(ExecutorService pool, BaseCommandExecutor executor, CommandSender sender,
+                                     String[] args) throws Exception {
+            BukkitScheduler mockScheduler = mock(BukkitScheduler.class);
+            Answer<BukkitTask> submit = inv -> {
+                Runnable r = inv.getArgument(1);
+                pool.submit(() -> {
+                    try (MockedStatic<UltiTools> inner = mockStatic(UltiTools.class)) {
+                        UltiTools mockUltiToolsForThread = stubUltiTools();
+                    inner.when(UltiTools::getInstance).thenReturn(mockUltiToolsForThread);
+                        r.run();
+                    }
+                }).get(5, TimeUnit.SECONDS);
+                return mock(BukkitTask.class);
+            };
+            when(mockScheduler.runTask(any(), any(Runnable.class))).thenAnswer(submit);
+            when(mockScheduler.runTaskAsynchronously(any(), any(Runnable.class))).thenAnswer(submit);
+
+            try (MockedStatic<Bukkit> bukkitMock = mockStatic(Bukkit.class);
+                 MockedStatic<UltiTools> ultiToolsMock = mockStatic(UltiTools.class)) {
+                bukkitMock.when(Bukkit::getScheduler).thenReturn(mockScheduler);
+                UltiTools mockUltiTools = stubUltiTools();
+                ultiToolsMock.when(UltiTools::getInstance).thenReturn(mockUltiTools);
+                executor.onCommand(sender, mockCommand, "probe", args);
+            }
+        }
+
+        @Test
+        @DisplayName("Two concurrent command dispatches on different threads do not observe each other's user")
+        void concurrentDispatchesDoNotObserveEachOthersUser() throws InterruptedException {
+            CurrentUserProbeExecutor executorA = new CurrentUserProbeExecutor();
+            executorA.useLatches = true;
+            CurrentUserProbeExecutor executorB = new CurrentUserProbeExecutor();
+            executorB.useLatches = true;
+
+            Player playerA = mock(Player.class);
+            UUID uuidA = UUID.randomUUID();
+            when(playerA.getUniqueId()).thenReturn(uuidA);
+            Player playerB = mock(Player.class);
+            UUID uuidB = UUID.randomUUID();
+            when(playerB.getUniqueId()).thenReturn(uuidB);
+
+            Thread t1 = new Thread(() -> dispatch(executorA, playerA, new String[]{}));
+            Thread t2 = new Thread(() -> dispatch(executorB, playerB, new String[]{}));
+            t1.start();
+            t2.start();
+
+            assertTrue(executorA.entered.await(5, TimeUnit.SECONDS), "executor A should have entered its handler");
+            assertTrue(executorB.entered.await(5, TimeUnit.SECONDS), "executor B should have entered its handler");
+
+            // Both handlers are now inside their bodies concurrently -- release them together.
+            executorA.release.countDown();
+            executorB.release.countDown();
+
+            t1.join(5000);
+            t2.join(5000);
+
+            assertEquals(uuidA, executorA.observedDuringHandler);
+            assertEquals(uuidB, executorB.observedDuringHandler);
+            assertNotEquals(executorA.observedDuringHandler, executorB.observedDuringHandler);
+        }
+    }
+
     // Test implementations
     
     static class TestEntity extends BaseDataEntity<UUID> implements Cloneable {
@@ -618,6 +891,64 @@ public class DataEntityTest {
             super.onLoad();
             ON_LOAD_COUNT.incrementAndGet();
             ON_LOAD_ORDER.add(getId());
+        }
+    }
+
+    /**
+     * 02-08 Task 3 fixture: a minimal {@code BaseCommandExecutor} whose handler records
+     * {@link AuditableDataEntity#getCurrentUser()} as observed from inside the invocation, plus
+     * the thread it ran on. {@code useLatches} lets a test force two concurrent dispatches to be
+     * inside their handler bodies at the same instant, proving isolation rather than accidental
+     * serialization.
+     */
+    @CmdTarget(CmdTarget.CmdTargetType.BOTH)
+    @CmdExecutor(alias = {"probe"})
+    public static class CurrentUserProbeExecutor extends BaseCommandExecutor {
+        volatile UUID observedDuringHandler;
+        volatile boolean invoked;
+        volatile Thread executionThread;
+        volatile boolean throwOnInvoke;
+        boolean useLatches;
+        final CountDownLatch entered = new CountDownLatch(1);
+        final CountDownLatch release = new CountDownLatch(1);
+
+        @Override
+        protected void handleHelp(CommandSender sender) {
+            // Not exercised by these tests.
+        }
+
+        private void probeBody() {
+            observedDuringHandler = AuditableDataEntity.getCurrentUser();
+            invoked = true;
+            executionThread = Thread.currentThread();
+            if (useLatches) {
+                entered.countDown();
+                try {
+                    release.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            if (throwOnInvoke) {
+                throw new RuntimeException("boom - 02-08 current-user wrapper test");
+            }
+        }
+
+        @CmdMapping(format = "")
+        public void probe(CommandSender sender) {
+            probeBody();
+        }
+
+        @CmdMapping(format = "async")
+        @AsyncCommand(showProcessing = false, timeout = 0)
+        public void probeAsync(CommandSender sender) {
+            probeBody();
+        }
+
+        @CmdMapping(format = "runasync")
+        @RunAsync
+        public void probeRunAsync(CommandSender sender) {
+            probeBody();
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/abstracts/data/DataEntityTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/data/DataEntityTest.java
@@ -10,24 +10,30 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import com.ultikits.ultitools.annotations.Column;
+import com.ultikits.ultitools.annotations.Table;
+
 /**
  * Unit tests for BaseDataEntity and AuditableDataEntity.
  */
 @DisplayName("Data Entity Tests")
-class DataEntityTest {
+public class DataEntityTest {
 
     @AfterEach
     void tearDown() {
         // Always clear current user after each test
         AuditableDataEntity.clearCurrentUser();
+        CountingAuditableEntity.resetCounters();
     }
 
     @Nested
@@ -382,7 +388,7 @@ class DataEntityTest {
             UUID testUserId = UUID.randomUUID();
             AuditableDataEntity.setCurrentUser(testUserId);
             AuditableDataEntity.clearCurrentUser();
-            
+
             TestAuditableEntity entity = new TestAuditableEntity();
             assertNull(entity.getCurrentUserForTest());
         }
@@ -501,6 +507,117 @@ class DataEntityTest {
         @Override
         protected Object clone() throws CloneNotSupportedException {
             throw new CloneNotSupportedException("Cloning not supported");
+        }
+    }
+
+    /**
+     * Counting fixture shared by {@code SQLiteDataOperatorTest} and
+     * {@code SimpleJsonDataOperatorTest} (02-08 Task 1) so both backends assert the same
+     * hook-firing counts and order against the same entity shape.
+     * <p>
+     * Counters and order lists are {@code static} rather than per-instance: the relational
+     * backend deserializes every returned row into a brand-new instance via Gson
+     * ({@code AbstractRelationalDataOperator#getListHandler()}), which never runs a
+     * constructor parameter through the object -- only its no-arg constructor and field
+     * initializers -- so a shared list reference handed in via a constructor would be null on
+     * every entity Gson produces. Static state is safe here because this project's Surefire
+     * configuration has no {@code <parallel>} element (sequential test-class execution is the
+     * default), and every consuming test calls {@link #resetCounters()} in its own
+     * {@code @BeforeEach}/{@code @AfterEach}.
+     */
+    @Table("counting_auditable_entity")
+    public static class CountingAuditableEntity extends AuditableDataEntity<String> {
+
+        @Column(value = "label", type = "VARCHAR(255)")
+        private String label;
+
+        private static final AtomicInteger ON_CREATE_COUNT = new AtomicInteger();
+        private static final AtomicInteger ON_UPDATE_COUNT = new AtomicInteger();
+        private static final AtomicInteger ON_DELETE_COUNT = new AtomicInteger();
+        private static final AtomicInteger ON_LOAD_COUNT = new AtomicInteger();
+
+        private static final List<String> ON_CREATE_ORDER = Collections.synchronizedList(new ArrayList<>());
+        private static final List<String> ON_UPDATE_ORDER = Collections.synchronizedList(new ArrayList<>());
+        private static final List<String> ON_DELETE_ORDER = Collections.synchronizedList(new ArrayList<>());
+        private static final List<String> ON_LOAD_ORDER = Collections.synchronizedList(new ArrayList<>());
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(String label) {
+            this.label = label;
+        }
+
+        public static void resetCounters() {
+            ON_CREATE_COUNT.set(0);
+            ON_UPDATE_COUNT.set(0);
+            ON_DELETE_COUNT.set(0);
+            ON_LOAD_COUNT.set(0);
+            ON_CREATE_ORDER.clear();
+            ON_UPDATE_ORDER.clear();
+            ON_DELETE_ORDER.clear();
+            ON_LOAD_ORDER.clear();
+        }
+
+        public static int onCreateCount() {
+            return ON_CREATE_COUNT.get();
+        }
+
+        public static int onUpdateCount() {
+            return ON_UPDATE_COUNT.get();
+        }
+
+        public static int onDeleteCount() {
+            return ON_DELETE_COUNT.get();
+        }
+
+        public static int onLoadCount() {
+            return ON_LOAD_COUNT.get();
+        }
+
+        public static List<String> onCreateOrder() {
+            return new ArrayList<>(ON_CREATE_ORDER);
+        }
+
+        public static List<String> onUpdateOrder() {
+            return new ArrayList<>(ON_UPDATE_ORDER);
+        }
+
+        public static List<String> onDeleteOrder() {
+            return new ArrayList<>(ON_DELETE_ORDER);
+        }
+
+        public static List<String> onLoadOrder() {
+            return new ArrayList<>(ON_LOAD_ORDER);
+        }
+
+        @Override
+        public void onCreate() {
+            super.onCreate();
+            ON_CREATE_COUNT.incrementAndGet();
+            ON_CREATE_ORDER.add(getId());
+        }
+
+        @Override
+        public void onUpdate() {
+            super.onUpdate();
+            ON_UPDATE_COUNT.incrementAndGet();
+            ON_UPDATE_ORDER.add(getId());
+        }
+
+        @Override
+        public void onDelete() {
+            super.onDelete();
+            ON_DELETE_COUNT.incrementAndGet();
+            ON_DELETE_ORDER.add(getId());
+        }
+
+        @Override
+        public void onLoad() {
+            super.onLoad();
+            ON_LOAD_COUNT.incrementAndGet();
+            ON_LOAD_ORDER.add(getId());
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/aop/AopActivationTest.java
+++ b/src/test/java/com/ultikits/ultitools/aop/AopActivationTest.java
@@ -6,10 +6,17 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
+import java.io.File;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import lombok.Data;
@@ -19,7 +26,9 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
+import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.annotations.Autowired;
 import com.ultikits.ultitools.annotations.EventListener;
 import com.ultikits.ultitools.annotations.ExceptionCatch;
@@ -31,6 +40,9 @@ import com.ultikits.ultitools.annotations.Transactional;
 import com.ultikits.ultitools.context.SimpleContainer;
 import com.ultikits.ultitools.events.ModuleEvent;
 import com.ultikits.ultitools.exceptions.ContainerException;
+import com.ultikits.ultitools.interfaces.DataStore;
+import com.ultikits.ultitools.interfaces.impl.data.json.JsonStore;
+import com.ultikits.ultitools.manager.DataScope;
 import com.ultikits.ultitools.manager.PlayerCacheManager;
 import com.ultikits.ultitools.manager.PluginManager;
 
@@ -44,7 +56,7 @@ import com.ultikits.ultitools.manager.PluginManager;
  * {@code ExternalPluginIntegrationTest}, which assert that the real {@code register(plugin)} /
  * {@code registerExternal(adapter)} entry points call {@code wireAop(...)} at all (a non-null
  * {@code getAopProxyResolver()}). This file assumes wiring happened - it calls
- * {@link PluginManager#wireAop(SimpleContainer)} directly to isolate proxy behaviour from plugin
+ * {@link PluginManager#wireAop(SimpleContainer, DataScope)} directly to isolate proxy behaviour from plugin
  * bootstrap - and instead asserts that proxying does not break anything else on the resulting
  * bean: interception actually runs, injection lands on the right instance, and every scanner that
  * reads annotations off {@code getMethods()}/{@code getClass()} still finds them.
@@ -196,21 +208,44 @@ class AopActivationTest {
     }
 
     /**
-     * {@link PluginManager#wireAop(SimpleContainer)} is package-private in
+     * {@link PluginManager#wireAop(SimpleContainer, DataScope)} is package-private in
      * {@code com.ultikits.ultitools.manager} - a different package than this test - by deliberate
      * choice of the task that introduced it. Reflection reaches the exact production method
      * instead of duplicating its logic here, so this test still exercises the real wiring code and
      * still goes red under the negative control in the task brief (commenting out
      * {@code context.setAopProxyResolver(resolver)} inside {@code wireAop}), rather than a
      * stand-in that would pass regardless of whether wireAop itself is broken.
+     * <p>
+     * {@link DataScope} is also package-private-constructed in {@code manager}; reflection builds
+     * one here too. {@code UltiTools.getInstance().getDataStore()} is stubbed to a {@link JsonStore}
+     * for the duration of the call only (this file is about {@code @ExceptionCatch}, not the
+     * {@code @Transactional} JDBC path added in 02-01) - a {@link JsonStore} does not override
+     * {@code getDataSource(DataScope)}, so it throws {@link UnsupportedOperationException} and
+     * {@code wireAop} falls back to declaring {@code @Transactional} unavailable, exactly the
+     * pre-6.3.0 behavior {@link #shouldRefuseInheritedTransactional()} still asserts.
      */
     private static void invokeWireAop(SimpleContainer context) {
-        try {
-            Method wireAop = PluginManager.class.getDeclaredMethod("wireAop", SimpleContainer.class);
+        try (MockedStatic<UltiTools> ultiToolsMock = mockStatic(UltiTools.class)) {
+            UltiTools mockUltiTools = mock(UltiTools.class);
+            DataStore jsonStore = new JsonStore("build/test-aop-activation-json");
+            when(mockUltiTools.getDataStore()).thenReturn(jsonStore);
+            ultiToolsMock.when(UltiTools::getInstance).thenReturn(mockUltiTools);
+
+            Method wireAop = PluginManager.class.getDeclaredMethod("wireAop", SimpleContainer.class, DataScope.class);
             wireAop.setAccessible(true);
-            wireAop.invoke(null, context);
+            wireAop.invoke(null, context, newDataScope());
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException("Failed to invoke PluginManager.wireAop via reflection", e);
+        }
+    }
+
+    private static DataScope newDataScope() {
+        try {
+            Constructor<DataScope> ctor = DataScope.class.getDeclaredConstructor(String.class, File.class, Set.class);
+            ctor.setAccessible(true);
+            return ctor.newInstance("aop-activation-test", new File("."), Collections.emptySet());
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to construct DataScope via reflection", e);
         }
     }
 

--- a/src/test/java/com/ultikits/ultitools/aop/AopActivationTest.java
+++ b/src/test/java/com/ultikits/ultitools/aop/AopActivationTest.java
@@ -1,5 +1,6 @@
 package com.ultikits.ultitools.aop;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -39,7 +40,6 @@ import com.ultikits.ultitools.annotations.Service;
 import com.ultikits.ultitools.annotations.Transactional;
 import com.ultikits.ultitools.context.SimpleContainer;
 import com.ultikits.ultitools.events.ModuleEvent;
-import com.ultikits.ultitools.exceptions.ContainerException;
 import com.ultikits.ultitools.interfaces.DataStore;
 import com.ultikits.ultitools.interfaces.impl.data.json.JsonStore;
 import com.ultikits.ultitools.manager.DataScope;
@@ -219,10 +219,10 @@ class AopActivationTest {
      * {@link DataScope} is also package-private-constructed in {@code manager}; reflection builds
      * one here too. {@code UltiTools.getInstance().getDataStore()} is stubbed to a {@link JsonStore}
      * for the duration of the call only (this file is about {@code @ExceptionCatch}, not the
-     * {@code @Transactional} JDBC path added in 02-01) - a {@link JsonStore} does not override
-     * {@code getDataSource(DataScope)}, so it throws {@link UnsupportedOperationException} and
-     * {@code wireAop} falls back to declaring {@code @Transactional} unavailable, exactly the
-     * pre-6.3.0 behavior {@link #shouldRefuseInheritedTransactional()} still asserts.
+     * {@code @Transactional} JDBC path added in 02-01) - since 02-05 (D-03) a {@link JsonStore}
+     * gets a real snapshot-based {@code TransactionManager} from {@code wireAop}'s JSON branch, so
+     * {@code @Transactional} is genuinely wired here too, not merely declared unavailable. See
+     * {@link #shouldInterceptInheritedTransactionalMethod()}.
      */
     private static void invokeWireAop(SimpleContainer context) {
         try (MockedStatic<UltiTools> ultiToolsMock = mockStatic(UltiTools.class)) {
@@ -451,32 +451,18 @@ class AopActivationTest {
     }
 
     @Test
-    @DisplayName("@Transactional on a superclass method must trigger the load-time refusal")
-    void shouldRefuseInheritedTransactional() {
-        SimpleContainer context = new SimpleContainer();
-        invokeWireAop(context);
-        context.registerBean(InheritsTransactionalBean.class);
+    @DisplayName("A method-level @Transactional declared on a superclass must be intercepted "
+            + "(flipped from a pre-02-05 refusal case, D-03: JSON now wires @Transactional "
+            + "instead of declaring it unavailable, exactly like @ExceptionCatch's sibling case "
+            + "above)")
+    void shouldInterceptInheritedTransactionalMethod() {
+        SimpleContainer context = wiredContainer(InheritsTransactionalBean.class);
 
-        // SimpleContainer.createBean catches Exception and rewraps it, and ContainerException is
-        // itself a RuntimeException, so the refusal arrives wrapped and its text is no longer the
-        // top-level message. The chain is searched rather than the assertion being loosened to
-        // RuntimeException, which any unrelated container failure would also satisfy.
-        RuntimeException thrown = assertThrows(RuntimeException.class, context::refresh);
-        ContainerException refusal = null;
-        Throwable cursor = thrown;
-        for (int depth = 0; cursor != null && depth < 16; depth++) {
-            if (cursor instanceof ContainerException) {
-                refusal = (ContainerException) cursor;
-                break;
-            }
-            cursor = cursor.getCause();
-        }
-
-        assertNotNull(refusal, "the cause chain must contain the refusal, but was: " + thrown);
-        assertTrue(refusal.getMessage().contains("Transactional"),
-                "the refusal must name the annotation: " + refusal.getMessage());
-        assertTrue(refusal.getMessage().contains("transactionalOnBase"),
-                "the refusal must name the inherited method, not just the bean: "
-                        + refusal.getMessage());
+        InheritsTransactionalBean bean = context.getBean(InheritsTransactionalBean.class);
+        assertTrue(ProxyFactory.isProxyClass(bean.getClass()),
+                "neither @ExceptionCatch nor @Transactional is @Inherited, so this only proxies "
+                        + "if the scan walks the hierarchy itself");
+        assertDoesNotThrow(bean::transactionalOnBase,
+                "the inherited @Transactional method must actually be reachable through the proxy");
     }
 }

--- a/src/test/java/com/ultikits/ultitools/aop/ExceptionHandlerRethrowTest.java
+++ b/src/test/java/com/ultikits/ultitools/aop/ExceptionHandlerRethrowTest.java
@@ -2,15 +2,27 @@ package com.ultikits.ultitools.aop;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
+import java.io.File;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
+import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.annotations.ExceptionCatch;
 import com.ultikits.ultitools.annotations.Service;
 import com.ultikits.ultitools.context.SimpleContainer;
+import com.ultikits.ultitools.interfaces.DataStore;
+import com.ultikits.ultitools.interfaces.impl.data.json.JsonStore;
+import com.ultikits.ultitools.manager.DataScope;
 import com.ultikits.ultitools.manager.PluginManager;
 
 /**
@@ -147,18 +159,36 @@ class ExceptionHandlerRethrowTest {
     }
 
     /**
-     * {@link PluginManager#wireAop(SimpleContainer)} is package-private in a different package by
-     * deliberate design (see {@code AopActivationTest}'s identical helper, which this mirrors
-     * rather than duplicates logic for) - reflection reaches the exact production wiring code
-     * instead of a stand-in that would pass regardless of whether {@code wireAop} itself is broken.
+     * {@link PluginManager#wireAop(SimpleContainer, DataScope)} is package-private in a different
+     * package by deliberate design (see {@code AopActivationTest}'s identical helper, which this
+     * mirrors rather than duplicates logic for) - reflection reaches the exact production wiring
+     * code instead of a stand-in that would pass regardless of whether {@code wireAop} itself is
+     * broken. {@code UltiTools.getInstance().getDataStore()} is stubbed to a {@link JsonStore} for
+     * the duration of the call: this file is about {@code @ExceptionCatch}'s custom-handler
+     * rethrow semantics, not the {@code @Transactional} JDBC path 02-01 added.
      */
     private static void invokeWireAop(SimpleContainer context) {
-        try {
-            Method wireAop = PluginManager.class.getDeclaredMethod("wireAop", SimpleContainer.class);
+        try (MockedStatic<UltiTools> ultiToolsMock = mockStatic(UltiTools.class)) {
+            UltiTools mockUltiTools = mock(UltiTools.class);
+            DataStore jsonStore = new JsonStore("build/test-exception-rethrow-json");
+            when(mockUltiTools.getDataStore()).thenReturn(jsonStore);
+            ultiToolsMock.when(UltiTools::getInstance).thenReturn(mockUltiTools);
+
+            Method wireAop = PluginManager.class.getDeclaredMethod("wireAop", SimpleContainer.class, DataScope.class);
             wireAop.setAccessible(true);
-            wireAop.invoke(null, context);
+            wireAop.invoke(null, context, newDataScope());
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException("Failed to invoke PluginManager.wireAop via reflection", e);
+        }
+    }
+
+    private static DataScope newDataScope() {
+        try {
+            Constructor<DataScope> ctor = DataScope.class.getDeclaredConstructor(String.class, File.class, Set.class);
+            ctor.setAccessible(true);
+            return ctor.newInstance("exception-handler-rethrow-test", new File("."), Collections.emptySet());
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to construct DataScope via reflection", e);
         }
     }
 

--- a/src/test/java/com/ultikits/ultitools/aop/TransactionInterceptorTest.java
+++ b/src/test/java/com/ultikits/ultitools/aop/TransactionInterceptorTest.java
@@ -210,6 +210,129 @@ class TransactionInterceptorTest {
         }
     }
 
+    /**
+     * Marker exception standing in for {@code Transactional.java}'s own
+     * {@code rollbackFor = {BusinessException.class}} javadoc example (D-06).
+     */
+    public static class BusinessException extends Exception {
+        public BusinessException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * Fixture for {@link RollbackRuleCombinationTests} (D-06/D-07): additive {@code rollbackFor}
+     * plus the shallowest-inheritance-depth tiebreak against {@code noRollbackFor}, each case
+     * proven through both an external call and a self-invocation call (WIRE-13). Declared at the
+     * top level for the same Java 8 / JUnit 5 {@code @Nested} reason documented on
+     * {@link SelfInvocationBean}.
+     */
+    public static class RollbackRuleBean {
+        private final TransactionManager txManager;
+
+        public RollbackRuleBean(TransactionManager txManager) {
+            this.txManager = txManager;
+        }
+
+        // --- D-06: an unmatched rollbackFor no longer commits; it falls through to the default. ---
+
+        @Transactional(rollbackFor = BusinessException.class)
+        public void unmatchedRollbackForExternal() {
+            write(101);
+            throw new NullPointerException("boom - unmatched rollbackFor, external");
+        }
+
+        public void outerCallsUnmatchedRollbackFor() {
+            unmatchedRollbackForSelf();
+        }
+
+        @Transactional(rollbackFor = BusinessException.class)
+        public void unmatchedRollbackForSelf() {
+            write(102);
+            throw new NullPointerException("boom - unmatched rollbackFor, self-invocation");
+        }
+
+        // --- D-07: a narrower rollbackFor rule wins over a broader noRollbackFor rule. ---
+
+        @Transactional(noRollbackFor = Exception.class, rollbackFor = IllegalStateException.class)
+        public void narrowerRollbackForWinsExternal() {
+            write(103);
+            throw new IllegalStateException("boom - narrower rollbackFor wins, external");
+        }
+
+        public void outerCallsNarrowerRollbackForWins() {
+            narrowerRollbackForWinsSelf();
+        }
+
+        @Transactional(noRollbackFor = Exception.class, rollbackFor = IllegalStateException.class)
+        public void narrowerRollbackForWinsSelf() {
+            write(104);
+            throw new IllegalStateException("boom - narrower rollbackFor wins, self-invocation");
+        }
+
+        // --- D-07 mirror: a narrower noRollbackFor rule wins over a broader rollbackFor rule. ---
+
+        @Transactional(rollbackFor = Exception.class, noRollbackFor = IllegalStateException.class)
+        public void narrowerNoRollbackForWinsExternal() {
+            write(109);
+            throw new IllegalStateException("boom - narrower noRollbackFor wins, external");
+        }
+
+        public void outerCallsNarrowerNoRollbackForWins() {
+            narrowerNoRollbackForWinsSelf();
+        }
+
+        @Transactional(rollbackFor = Exception.class, noRollbackFor = IllegalStateException.class)
+        public void narrowerNoRollbackForWinsSelf() {
+            write(110);
+            throw new IllegalStateException("boom - narrower noRollbackFor wins, self-invocation");
+        }
+
+        // --- Sole noRollbackFor rule (no rollbackFor configured) still commits, unaffected. ---
+
+        @Transactional(noRollbackFor = IllegalStateException.class)
+        public void soleNoRollbackForCommitsExternal() {
+            write(105);
+            throw new IllegalStateException("boom - sole noRollbackFor commits, external");
+        }
+
+        public void outerCallsSoleNoRollbackForCommits() {
+            soleNoRollbackForCommitsSelf();
+        }
+
+        @Transactional(noRollbackFor = IllegalStateException.class)
+        public void soleNoRollbackForCommitsSelf() {
+            write(106);
+            throw new IllegalStateException("boom - sole noRollbackFor commits, self-invocation");
+        }
+
+        // --- D-07: an exact-depth tie (same class in both arrays) favors rollback. ---
+
+        @Transactional(rollbackFor = IllegalStateException.class, noRollbackFor = IllegalStateException.class)
+        public void exactTieRollsBackExternal() {
+            write(107);
+            throw new IllegalStateException("boom - exact-depth tie rolls back, external");
+        }
+
+        public void outerCallsExactTieRollsBack() {
+            exactTieRollsBackSelf();
+        }
+
+        @Transactional(rollbackFor = IllegalStateException.class, noRollbackFor = IllegalStateException.class)
+        public void exactTieRollsBackSelf() {
+            write(108);
+            throw new IllegalStateException("boom - exact-depth tie rolls back, self-invocation");
+        }
+
+        private void write(int id) {
+            try (Statement st = txManager.getConnection().createStatement()) {
+                st.execute("INSERT INTO tx_test (id) VALUES (" + id + ")");
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
     @BeforeEach
     void setUp() {
         interceptor = new TransactionInterceptor(transactionManager);
@@ -637,8 +760,9 @@ class TransactionInterceptorTest {
         }
 
         @Test
-        @DisplayName("Should commit for non-matching rollbackFor exception")
-        void shouldCommitForNonMatchingRollbackForException() throws Throwable {
+        @DisplayName("D-06: an unmatched rollbackFor now falls through to the RuntimeException/Error "
+                + "default and rolls back, instead of committing")
+        void shouldRollbackForNonMatchingRollbackForExceptionViaDefaultFallthrough() throws Throwable {
             Method method = RollbackService.class.getMethod("rollbackFor");
             Object target = new RollbackService();
 
@@ -648,7 +772,8 @@ class TransactionInterceptorTest {
 
             assertThrows(NullPointerException.class, () -> interceptor.invoke(mockInvocation));
 
-            verify(transactionManager).commit();
+            verify(transactionManager).rollback();
+            verify(transactionManager, never()).commit();
         }
 
         @Test
@@ -873,6 +998,166 @@ class TransactionInterceptorTest {
             assertThrows(RuntimeException.class, bean::plainWriteThenThrow);
 
             assertThat(countRows()).isEqualTo(1);
+        }
+    }
+
+    /**
+     * D-06/D-07: additive {@code rollbackFor} plus the shallowest-inheritance-depth tiebreak
+     * against {@code noRollbackFor}, each case proven through both an external call and a
+     * self-invocation call (WIRE-13). Same real-proxy-plus-real-JDBC rationale as
+     * {@link SelfInvocationAndExternalCallTests} - a mocked {@link TransactionManager} cannot
+     * distinguish self-invocation from an external call.
+     */
+    @Nested
+    @DisplayName("D-06/D-07: additive rollbackFor with shallowest-depth tiebreak（WIRE-13）")
+    class RollbackRuleCombinationTests {
+
+        private DataSource h2DataSource;
+        private DataSourceTransactionManager realManager;
+        private AopProxyResolver resolver;
+
+        @BeforeEach
+        void setUp() throws Exception {
+            HikariConfig config = new HikariConfig();
+            config.setJdbcUrl("jdbc:h2:mem:txinterceptorrollbackrule" + System.nanoTime()
+                    + ";DB_CLOSE_DELAY=-1;MODE=MySQL");
+            config.setUsername("sa");
+            // Deliberately no setPassword(): see TransactionalRollbackEndToEndTest's identical
+            // comment - the in-memory DB has no credential to hardcode.
+            h2DataSource = new HikariDataSource(config);
+            try (Connection conn = h2DataSource.getConnection();
+                    Statement st = conn.createStatement()) {
+                st.execute("CREATE TABLE tx_test (id INT PRIMARY KEY)");
+            }
+
+            realManager = new DataSourceTransactionManager(h2DataSource);
+            TransactionInterceptor realInterceptor = new TransactionInterceptor(realManager);
+            resolver = new AopProxyResolver();
+            resolver.addAdvisor(AopAdvisor.forAnnotation(Transactional.class, realInterceptor, 100));
+        }
+
+        @AfterEach
+        void tearDown() {
+            if (h2DataSource instanceof HikariDataSource) {
+                ((HikariDataSource) h2DataSource).close();
+            }
+        }
+
+        private int countRows() throws SQLException {
+            try (Connection conn = h2DataSource.getConnection();
+                    Statement st = conn.createStatement();
+                    ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM tx_test")) {
+                rs.next();
+                return rs.getInt(1);
+            }
+        }
+
+        private RollbackRuleBean newProxiedBean() throws ReflectiveOperationException {
+            Class<?> proxyClass = resolver.resolve(RollbackRuleBean.class);
+            return (RollbackRuleBean) proxyClass
+                    .getDeclaredConstructor(TransactionManager.class)
+                    .newInstance(realManager);
+        }
+
+        @Test
+        @DisplayName("D-06: unmatched rollbackFor rolls back on the RuntimeException default (external)")
+        void unmatchedRollbackForRollsBackExternal() throws Exception {
+            RollbackRuleBean bean = newProxiedBean();
+
+            assertThrows(NullPointerException.class, bean::unmatchedRollbackForExternal);
+
+            assertThat(countRows()).isZero();
+        }
+
+        @Test
+        @DisplayName("D-06: unmatched rollbackFor rolls back on the RuntimeException default (self-invocation)")
+        void unmatchedRollbackForRollsBackSelfInvocation() throws Exception {
+            RollbackRuleBean bean = newProxiedBean();
+
+            assertThrows(NullPointerException.class, bean::outerCallsUnmatchedRollbackFor);
+
+            assertThat(countRows()).isZero();
+        }
+
+        @Test
+        @DisplayName("D-07: a narrower rollbackFor wins over a broader noRollbackFor (external)")
+        void narrowerRollbackForWinsExternal() throws Exception {
+            RollbackRuleBean bean = newProxiedBean();
+
+            assertThrows(IllegalStateException.class, bean::narrowerRollbackForWinsExternal);
+
+            assertThat(countRows()).isZero();
+        }
+
+        @Test
+        @DisplayName("D-07: a narrower rollbackFor wins over a broader noRollbackFor (self-invocation)")
+        void narrowerRollbackForWinsSelfInvocation() throws Exception {
+            RollbackRuleBean bean = newProxiedBean();
+
+            assertThrows(IllegalStateException.class, bean::outerCallsNarrowerRollbackForWins);
+
+            assertThat(countRows()).isZero();
+        }
+
+        @Test
+        @DisplayName("D-07 mirror: a narrower noRollbackFor wins over a broader rollbackFor (external)")
+        void narrowerNoRollbackForWinsExternal() throws Exception {
+            RollbackRuleBean bean = newProxiedBean();
+
+            assertThrows(IllegalStateException.class, bean::narrowerNoRollbackForWinsExternal);
+
+            assertThat(countRows()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("D-07 mirror: a narrower noRollbackFor wins over a broader rollbackFor (self-invocation)")
+        void narrowerNoRollbackForWinsSelfInvocation() throws Exception {
+            RollbackRuleBean bean = newProxiedBean();
+
+            assertThrows(IllegalStateException.class, bean::outerCallsNarrowerNoRollbackForWins);
+
+            assertThat(countRows()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("A sole noRollbackFor rule still commits, unaffected by D-06 (external)")
+        void soleNoRollbackForStillCommitsExternal() throws Exception {
+            RollbackRuleBean bean = newProxiedBean();
+
+            assertThrows(IllegalStateException.class, bean::soleNoRollbackForCommitsExternal);
+
+            assertThat(countRows()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("A sole noRollbackFor rule still commits, unaffected by D-06 (self-invocation)")
+        void soleNoRollbackForStillCommitsSelfInvocation() throws Exception {
+            RollbackRuleBean bean = newProxiedBean();
+
+            assertThrows(IllegalStateException.class, bean::outerCallsSoleNoRollbackForCommits);
+
+            assertThat(countRows()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("D-07: an exact-depth tie between rollbackFor and noRollbackFor favors rollback (external)")
+        void exactDepthTieFavorsRollbackExternal() throws Exception {
+            RollbackRuleBean bean = newProxiedBean();
+
+            assertThrows(IllegalStateException.class, bean::exactTieRollsBackExternal);
+
+            assertThat(countRows()).isZero();
+        }
+
+        @Test
+        @DisplayName("D-07: an exact-depth tie between rollbackFor and noRollbackFor favors rollback "
+                + "(self-invocation)")
+        void exactDepthTieFavorsRollbackSelfInvocation() throws Exception {
+            RollbackRuleBean bean = newProxiedBean();
+
+            assertThrows(IllegalStateException.class, bean::outerCallsExactTieRollsBack);
+
+            assertThat(countRows()).isZero();
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/aop/TransactionInterceptorTest.java
+++ b/src/test/java/com/ultikits/ultitools/aop/TransactionInterceptorTest.java
@@ -374,6 +374,25 @@ class TransactionInterceptorTest {
             throw new RuntimeException("boom - inner REQUIRES_NEW, self-invocation");
         }
 
+        /**
+         * Outer REQUIRED transaction that self-invokes a REQUIRES_NEW method that succeeds -
+         * the self-invocation counterpart of {@link #requiresNewExternalSucceeds()}, pairing with
+         * it so connection-identity preservation is proven both ways even on the non-throwing path.
+         */
+        @Transactional
+        public void outerRequiredThenSelfInvokesRequiresNewThatSucceeds() {
+            capturedOuterConnectionBeforeInner = txManager.getConnection();
+            write(5);
+            innerRequiresNewSucceedsSelf();
+            capturedOuterConnectionAfterInner = txManager.getConnection();
+            write(6);
+        }
+
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void innerRequiresNewSucceedsSelf() {
+            write(98);
+        }
+
         /** Externally-called REQUIRES_NEW method that writes and returns normally. */
         @Transactional(propagation = Propagation.REQUIRES_NEW)
         public void requiresNewExternalSucceeds() {
@@ -1355,6 +1374,27 @@ class TransactionInterceptorTest {
             assertThat(rowExists(99)).isFalse();
 
             // No suspended frame left behind: a fresh begin() on this thread reports depth 1.
+            realManager.begin();
+            assertThat(realManager.getTransactionDepth()).isEqualTo(1);
+            realManager.rollback();
+        }
+
+        @Test
+        @DisplayName("REQUIRES_NEW (self-invocation): a successful inner transaction still "
+                + "preserves outer Connection identity")
+        void requiresNewSelfInvocationSuccessPreservesConnectionIdentity() throws Exception {
+            PropagationBean bean = newProxiedBean();
+
+            bean.outerRequiredThenSelfInvokesRequiresNewThatSucceeds();
+
+            assertThat(bean.capturedOuterConnectionAfterInner)
+                    .isSameAs(bean.capturedOuterConnectionBeforeInner);
+            // Outer's writes (5, 6) and the inner's own write (98) all committed independently.
+            assertThat(countRows()).isEqualTo(3);
+            assertThat(rowExists(5)).isTrue();
+            assertThat(rowExists(6)).isTrue();
+            assertThat(rowExists(98)).isTrue();
+
             realManager.begin();
             assertThat(realManager.getTransactionDepth()).isEqualTo(1);
             realManager.rollback();

--- a/src/test/java/com/ultikits/ultitools/aop/TransactionInterceptorTest.java
+++ b/src/test/java/com/ultikits/ultitools/aop/TransactionInterceptorTest.java
@@ -1,6 +1,7 @@
 package com.ultikits.ultitools.aop;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -100,11 +101,6 @@ class TransactionInterceptorTest {
         @Transactional(propagation = Propagation.NEVER)
         public String never() {
             return "never";
-        }
-
-        @Transactional(propagation = Propagation.NESTED)
-        public String nested() {
-            return "nested";
         }
     }
 
@@ -333,6 +329,95 @@ class TransactionInterceptorTest {
         }
     }
 
+    /**
+     * Fixture for {@link PropagationSuspendResumeTests} (D-09): real suspend/resume around
+     * {@code REQUIRES_NEW} and {@code NOT_SUPPORTED}, each proven through both an external call
+     * and a self-invocation call. Declared at the top level for the same Java 8 / JUnit 5
+     * {@code @Nested} reason documented on {@link SelfInvocationBean}. Exposes the raw
+     * {@link DataSourceTransactionManager} (rather than the {@link TransactionManager} interface,
+     * like the other fixtures in this file) because the tests need {@link
+     * DataSourceTransactionManager#getConnection()} and {@link
+     * DataSourceTransactionManager#getTransactionDepth()} directly.
+     */
+    public static class PropagationBean {
+        private final DataSourceTransactionManager txManager;
+
+        volatile Connection capturedOuterConnectionBeforeInner;
+        volatile Connection capturedOuterConnectionAfterInner;
+
+        public PropagationBean(DataSourceTransactionManager txManager) {
+            this.txManager = txManager;
+        }
+
+        /**
+         * Outer REQUIRED transaction that self-invokes a REQUIRES_NEW method whose body throws.
+         * The inner failure must not strand the suspended outer frame, nor mark it rollback-only -
+         * the outer keeps writing and commits normally afterwards.
+         */
+        @Transactional
+        public void outerRequiredThenSelfInvokesRequiresNewThatFails() {
+            capturedOuterConnectionBeforeInner = txManager.getConnection();
+            write(1);
+            try {
+                innerRequiresNewFailsSelf();
+            } catch (RuntimeException ignored) {
+                // The inner REQUIRES_NEW transaction's own failure and rollback must not
+                // propagate into the outer transaction's state.
+            }
+            capturedOuterConnectionAfterInner = txManager.getConnection();
+            write(2);
+        }
+
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void innerRequiresNewFailsSelf() {
+            write(99);
+            throw new RuntimeException("boom - inner REQUIRES_NEW, self-invocation");
+        }
+
+        /** Externally-called REQUIRES_NEW method that writes and returns normally. */
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void requiresNewExternalSucceeds() {
+            write(100);
+        }
+
+        /** Externally-called REQUIRES_NEW method whose body throws. */
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void requiresNewExternalFails() {
+            write(101);
+            throw new RuntimeException("boom - external REQUIRES_NEW");
+        }
+
+        /**
+         * Outer REQUIRED transaction that self-invokes a NOT_SUPPORTED write, then itself throws
+         * so the outer rolls back. The NOT_SUPPORTED write must survive the outer's rollback.
+         */
+        @Transactional
+        public void outerRequiredThenSelfInvokesNotSupportedThenFails() {
+            write(4);
+            innerNotSupportedWriteSelf();
+            throw new RuntimeException("boom - outer rolls back after NOT_SUPPORTED write, self-invocation");
+        }
+
+        @Transactional(propagation = Propagation.NOT_SUPPORTED)
+        public void innerNotSupportedWriteSelf() {
+            write(102);
+        }
+
+        /** Externally-called NOT_SUPPORTED write. */
+        @Transactional(propagation = Propagation.NOT_SUPPORTED)
+        public void notSupportedExternalWrite() {
+            write(103);
+        }
+
+        private void write(int id) {
+            try (Statement st = txManager.getConnection().createStatement()) {
+                st.execute("INSERT INTO tx_test (id) VALUES (" + id + ")");
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
     @BeforeEach
     void setUp() {
         interceptor = new TransactionInterceptor(transactionManager);
@@ -415,7 +500,7 @@ class TransactionInterceptorTest {
     class RequiresNewPropagationTests {
 
         @Test
-        @DisplayName("Should always create new transaction")
+        @DisplayName("Should always create new transaction, suspending and resuming around it (D-09)")
         void shouldAlwaysCreateNewTransaction() throws Throwable {
             Method method = PropagationService.class.getMethod("requiresNew");
             Object target = new PropagationService();
@@ -426,24 +511,49 @@ class TransactionInterceptorTest {
             Object result = interceptor.invoke(mockInvocation);
 
             assertEquals("requires_new", result);
+            verify(transactionManager).suspend();
             verify(transactionManager).begin();
             verify(transactionManager).commit();
+            verify(transactionManager).resume(null);
         }
 
         @Test
-        @DisplayName("Should create new transaction even when one exists")
+        @DisplayName("Should suspend the existing transaction, create a genuinely new one, and resume "
+                + "the suspended handle (D-09)")
         void shouldCreateNewTransactionEvenWhenOneExists() throws Throwable {
             Method method = PropagationService.class.getMethod("requiresNew");
             Object target = new PropagationService();
+            Object suspendedHandle = new Object();
 
             when(mockInvocation.getMethod()).thenReturn(method);
             when(mockInvocation.proceed()).thenReturn("requires_new");
             when(transactionManager.hasActiveTransaction()).thenReturn(true);
+            when(transactionManager.suspend()).thenReturn(suspendedHandle);
 
-            Object result = interceptor.invoke(mockInvocation);
+            interceptor.invoke(mockInvocation);
 
+            verify(transactionManager).suspend();
             verify(transactionManager).begin();
             verify(transactionManager).commit();
+            verify(transactionManager).resume(suspendedHandle);
+        }
+
+        @Test
+        @DisplayName("D-09: an inner REQUIRES_NEW failure still resumes the suspended handle, via a "
+                + "finally, so no frame is stranded")
+        void shouldResumeSuspendedTransactionWhenInnerThrows() throws Throwable {
+            Method method = PropagationService.class.getMethod("requiresNew");
+            Object target = new PropagationService();
+            Object suspendedHandle = new Object();
+
+            when(mockInvocation.getMethod()).thenReturn(method);
+            when(mockInvocation.proceed()).thenThrow(new RuntimeException("inner boom"));
+            when(transactionManager.suspend()).thenReturn(suspendedHandle);
+
+            assertThrows(RuntimeException.class, () -> interceptor.invoke(mockInvocation));
+
+            verify(transactionManager).rollback();
+            verify(transactionManager).resume(suspendedHandle);
         }
     }
 
@@ -523,19 +633,40 @@ class TransactionInterceptorTest {
     class NotSupportedPropagationTests {
 
         @Test
-        @DisplayName("Should proceed without transaction")
+        @DisplayName("Should proceed without transaction, suspending and resuming around it (D-09)")
         void shouldProceedWithoutTransaction() throws Throwable {
             Method method = PropagationService.class.getMethod("notSupported");
             Object target = new PropagationService();
 
             when(mockInvocation.getMethod()).thenReturn(method);
             when(mockInvocation.proceed()).thenReturn("not_supported");
-            when(transactionManager.hasActiveTransaction()).thenReturn(false);
 
             Object result = interceptor.invoke(mockInvocation);
 
             assertEquals("not_supported", result);
             verify(transactionManager, never()).begin();
+            verify(transactionManager).suspend();
+            verify(transactionManager).resume(null);
+        }
+
+        @Test
+        @DisplayName("Should suspend an existing transaction and resume the suspended handle "
+                + "afterwards (D-09)")
+        void shouldSuspendAndResumeExistingTransaction() throws Throwable {
+            Method method = PropagationService.class.getMethod("notSupported");
+            Object target = new PropagationService();
+            Object suspendedHandle = new Object();
+
+            when(mockInvocation.getMethod()).thenReturn(method);
+            when(mockInvocation.proceed()).thenReturn("not_supported");
+            when(transactionManager.hasActiveTransaction()).thenReturn(true);
+            when(transactionManager.suspend()).thenReturn(suspendedHandle);
+
+            interceptor.invoke(mockInvocation);
+
+            verify(transactionManager, never()).begin();
+            verify(transactionManager).suspend();
+            verify(transactionManager).resume(suspendedHandle);
         }
     }
 
@@ -574,40 +705,17 @@ class TransactionInterceptorTest {
     }
 
     @Nested
-    @DisplayName("NESTED Propagation Tests")
-    class NestedPropagationTests {
+    @DisplayName("Propagation enum tests (D-09)")
+    class PropagationEnumTests {
 
         @Test
-        @DisplayName("Should start new transaction when none exists")
-        void shouldStartNewTransactionWhenNoneExists() throws Throwable {
-            Method method = PropagationService.class.getMethod("nested");
-            Object target = new PropagationService();
-
-            when(mockInvocation.getMethod()).thenReturn(method);
-            when(mockInvocation.proceed()).thenReturn("nested");
-            when(transactionManager.hasActiveTransaction()).thenReturn(false);
-
-            Object result = interceptor.invoke(mockInvocation);
-
-            assertEquals("nested", result);
-            verify(transactionManager).begin();
-            verify(transactionManager).commit();
-        }
-
-        @Test
-        @DisplayName("Should join existing transaction")
-        void shouldJoinExistingTransaction() throws Throwable {
-            Method method = PropagationService.class.getMethod("nested");
-            Object target = new PropagationService();
-
-            when(mockInvocation.getMethod()).thenReturn(method);
-            when(mockInvocation.proceed()).thenReturn("nested");
-            when(transactionManager.hasActiveTransaction()).thenReturn(true);
-
-            Object result = interceptor.invoke(mockInvocation);
-
-            assertEquals("nested", result);
-            verify(transactionManager, never()).begin();
+        @DisplayName("Propagation has exactly six constants, matching Jakarta Transactions 2.0's "
+                + "TxType - NESTED is removed")
+        void hasExactlySixConstants() {
+            assertThat(Propagation.values()).hasSize(6);
+            assertThat(Propagation.values()).containsExactlyInAnyOrder(
+                    Propagation.REQUIRED, Propagation.REQUIRES_NEW, Propagation.SUPPORTS,
+                    Propagation.NOT_SUPPORTED, Propagation.MANDATORY, Propagation.NEVER);
         }
     }
 
@@ -1158,6 +1266,186 @@ class TransactionInterceptorTest {
             assertThrows(IllegalStateException.class, bean::outerCallsExactTieRollsBack);
 
             assertThat(countRows()).isZero();
+        }
+    }
+
+    /**
+     * D-09: real suspend/resume around {@code REQUIRES_NEW} and {@code NOT_SUPPORTED}, each proven
+     * through both an external call and a self-invocation call. "External call" here means the
+     * call site is outside {@link PropagationBean} entirely - the test itself, standing in for a
+     * caller on a thread that already has a transaction active from elsewhere - dispatched
+     * directly onto the proxy, exactly the same distinction {@link SelfInvocationAndExternalCallTests}
+     * draws between {@code external()} and {@code outerCallsInner()}.
+     */
+    @Nested
+    @DisplayName("D-09: real suspend/resume for REQUIRES_NEW and NOT_SUPPORTED")
+    class PropagationSuspendResumeTests {
+
+        private DataSource h2DataSource;
+        private DataSourceTransactionManager realManager;
+        private AopProxyResolver resolver;
+
+        @BeforeEach
+        void setUp() throws Exception {
+            HikariConfig config = new HikariConfig();
+            config.setJdbcUrl("jdbc:h2:mem:txinterceptorpropagation" + System.nanoTime()
+                    + ";DB_CLOSE_DELAY=-1;MODE=MySQL");
+            config.setUsername("sa");
+            // Deliberately no setPassword(): see TransactionalRollbackEndToEndTest's identical
+            // comment - the in-memory DB has no credential to hardcode.
+            h2DataSource = new HikariDataSource(config);
+            try (Connection conn = h2DataSource.getConnection();
+                    Statement st = conn.createStatement()) {
+                st.execute("CREATE TABLE tx_test (id INT PRIMARY KEY)");
+            }
+
+            realManager = new DataSourceTransactionManager(h2DataSource);
+            TransactionInterceptor realInterceptor = new TransactionInterceptor(realManager);
+            resolver = new AopProxyResolver();
+            resolver.addAdvisor(AopAdvisor.forAnnotation(Transactional.class, realInterceptor, 100));
+        }
+
+        @AfterEach
+        void tearDown() {
+            if (h2DataSource instanceof HikariDataSource) {
+                ((HikariDataSource) h2DataSource).close();
+            }
+        }
+
+        private int countRows() throws SQLException {
+            try (Connection conn = h2DataSource.getConnection();
+                    Statement st = conn.createStatement();
+                    ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM tx_test")) {
+                rs.next();
+                return rs.getInt(1);
+            }
+        }
+
+        private boolean rowExists(int id) throws SQLException {
+            try (Connection conn = h2DataSource.getConnection();
+                    Statement st = conn.createStatement();
+                    ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM tx_test WHERE id = " + id)) {
+                rs.next();
+                return rs.getInt(1) > 0;
+            }
+        }
+
+        private PropagationBean newProxiedBean() throws ReflectiveOperationException {
+            Class<?> proxyClass = resolver.resolve(PropagationBean.class);
+            return (PropagationBean) proxyClass
+                    .getDeclaredConstructor(DataSourceTransactionManager.class)
+                    .newInstance(realManager);
+        }
+
+        @Test
+        @DisplayName("REQUIRES_NEW (self-invocation): suspends the outer transaction, restores the "
+                + "same Connection afterwards, and an inner failure does not mark the outer "
+                + "rollback-only")
+        void requiresNewSelfInvocationSuspendsAndRestoresConnectionIdentity() throws Exception {
+            PropagationBean bean = newProxiedBean();
+
+            bean.outerRequiredThenSelfInvokesRequiresNewThatFails();
+
+            assertThat(bean.capturedOuterConnectionAfterInner)
+                    .isSameAs(bean.capturedOuterConnectionBeforeInner);
+            // Outer's own writes (1, 2) committed; inner's write (99) rolled back independently.
+            assertThat(countRows()).isEqualTo(2);
+            assertThat(rowExists(1)).isTrue();
+            assertThat(rowExists(2)).isTrue();
+            assertThat(rowExists(99)).isFalse();
+
+            // No suspended frame left behind: a fresh begin() on this thread reports depth 1.
+            realManager.begin();
+            assertThat(realManager.getTransactionDepth()).isEqualTo(1);
+            realManager.rollback();
+        }
+
+        @Test
+        @DisplayName("REQUIRES_NEW (external call): suspends and restores the outer transaction, "
+                + "preserving Connection identity")
+        void requiresNewExternalCallSuspendsAndRestoresConnectionIdentity() throws Exception {
+            PropagationBean bean = newProxiedBean();
+
+            realManager.begin(); // simulates a transaction already active from an external caller
+            Connection before = realManager.getConnection();
+
+            bean.requiresNewExternalSucceeds(); // external call: outside PropagationBean entirely
+
+            Connection after = realManager.getConnection();
+            assertThat(after).isSameAs(before);
+            assertThat(realManager.getTransactionDepth()).isEqualTo(1);
+
+            realManager.commit();
+            // Only the REQUIRES_NEW transaction's own write (100), already committed independently.
+            assertThat(countRows()).isEqualTo(1);
+            assertThat(rowExists(100)).isTrue();
+        }
+
+        @Test
+        @DisplayName("REQUIRES_NEW (external call): an inner failure does not strand the suspended "
+                + "outer frame or mark it rollback-only")
+        void requiresNewExternalCallFailureDoesNotStrandOrMarkOuterRollbackOnly() throws Exception {
+            PropagationBean bean = newProxiedBean();
+
+            realManager.begin();
+            Connection before = realManager.getConnection();
+
+            assertThrows(RuntimeException.class, bean::requiresNewExternalFails);
+
+            Connection after = realManager.getConnection();
+            assertThat(after).isSameAs(before);
+            assertThat(realManager.getTransactionDepth()).isEqualTo(1);
+
+            // The outer must still be committable - the inner failure must not have marked it
+            // rollback-only.
+            assertThatCode(realManager::commit).doesNotThrowAnyException();
+            // Row 101 was written inside the failed inner REQUIRES_NEW and rolled back with it.
+            assertThat(countRows()).isZero();
+
+            realManager.begin();
+            assertThat(realManager.getTransactionDepth()).isEqualTo(1);
+            realManager.rollback();
+        }
+
+        @Test
+        @DisplayName("NOT_SUPPORTED (self-invocation): a write made with no active transaction "
+                + "survives the outer transaction's rollback")
+        void notSupportedSelfInvocationWriteSurvivesOuterRollback() throws Exception {
+            PropagationBean bean = newProxiedBean();
+
+            assertThrows(RuntimeException.class,
+                    bean::outerRequiredThenSelfInvokesNotSupportedThenFails);
+
+            // Row 4 (outer's own write) rolled back with the outer transaction; row 102
+            // (NOT_SUPPORTED write) executed with no active transaction and survives.
+            assertThat(countRows()).isEqualTo(1);
+            assertThat(rowExists(102)).isTrue();
+            assertThat(rowExists(4)).isFalse();
+        }
+
+        @Test
+        @DisplayName("NOT_SUPPORTED (external call): a write made with no active transaction "
+                + "survives a separately-active outer transaction's rollback")
+        void notSupportedExternalCallWriteSurvivesOuterRollback() throws Exception {
+            PropagationBean bean = newProxiedBean();
+
+            realManager.begin();
+            try (Statement st = realManager.getConnection().createStatement()) {
+                st.execute("INSERT INTO tx_test (id) VALUES (5)");
+            }
+
+            bean.notSupportedExternalWrite(); // external call: outside PropagationBean entirely
+
+            assertThat(realManager.getTransactionDepth()).isEqualTo(1);
+            realManager.rollback();
+
+            assertThat(countRows()).isEqualTo(1);
+            assertThat(rowExists(103)).isTrue();
+            assertThat(rowExists(5)).isFalse();
+
+            realManager.begin();
+            assertThat(realManager.getTransactionDepth()).isEqualTo(1);
+            realManager.rollback();
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/aop/TransactionInterceptorTest.java
+++ b/src/test/java/com/ultikits/ultitools/aop/TransactionInterceptorTest.java
@@ -1,5 +1,6 @@
 package com.ultikits.ultitools.aop;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -12,7 +13,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -25,6 +33,9 @@ import com.ultikits.ultitools.annotations.Isolation;
 import com.ultikits.ultitools.annotations.Propagation;
 import com.ultikits.ultitools.annotations.Transactional;
 import com.ultikits.ultitools.interfaces.TransactionManager;
+import com.ultikits.ultitools.manager.DataSourceTransactionManager;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 
 /**
  * Unit tests for TransactionInterceptor.
@@ -149,6 +160,53 @@ class TransactionInterceptorTest {
 
         public String method2() {
             return "method2";
+        }
+    }
+
+    /**
+     * Fixture for {@link SelfInvocationAndExternalCallTests}. Un-annotated {@code outerCallsInner()}
+     * self-invokes annotated {@code inner()}, mirroring {@link AopSelfInvocationFixture}'s shape:
+     * the caller method is never overridden by the proxy, so its call to {@code this.inner()} is a
+     * plain virtual dispatch that must still resolve to the proxy's override. Declared at the
+     * top level (not inside the {@code @Nested} class) because JUnit 5 {@code @Nested} classes are
+     * non-static inner classes, and a {@code static} member class cannot be declared inside one on
+     * this project's Java 8 target.
+     */
+    public static class SelfInvocationBean {
+        private final TransactionManager txManager;
+
+        public SelfInvocationBean(TransactionManager txManager) {
+            this.txManager = txManager;
+        }
+
+        public void outerCallsInner() {
+            inner();
+        }
+
+        @Transactional
+        public void inner() {
+            write(1);
+            throw new RuntimeException("boom - self-invocation");
+        }
+
+        @Transactional
+        public void external() {
+            write(2);
+            throw new RuntimeException("boom - external call");
+        }
+
+        /** Negative control: not @Transactional, so its write must survive the throw. */
+        public void plainWriteThenThrow() {
+            write(3);
+            throw new RuntimeException("boom - not transactional");
+        }
+
+        private void write(int id) {
+            try (Statement st = txManager.getConnection().createStatement()) {
+                st.execute("INSERT INTO tx_test (id) VALUES (" + id + ")");
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 
@@ -718,6 +776,103 @@ class TransactionInterceptorTest {
 
             assertSame(original, thrown);
             verify(transactionManager).rollback();
+        }
+    }
+
+    /**
+     * WIRE-15: the same rollback must be observed whether a {@code @Transactional} method is
+     * reached by an external caller or by self-invocation from another method on the same bean.
+     * Self-invocation <b>is</b> intercepted in this codebase - the ByteBuddy subclass proxy is
+     * the bean, not a delegate wrapper - re-verified in Phase 1 against the four pre-existing
+     * {@code shouldInterceptSelfInvocation} tests ({@link AopActivationTest},
+     * {@link ProxyFactoryTest}, {@link AopProxyResolverTest}, {@code SimpleContainerAopTest}).
+     * <p>
+     * Unlike the rest of this file, these cases build a real {@link AopProxyResolver}-generated
+     * proxy over a real {@link DataSourceTransactionManager} bound to an in-memory H2
+     * {@link DataSource} - a mocked {@link TransactionManager} cannot distinguish self-invocation
+     * from an external call (the interceptor's own {@code invoke()} body is identical either way;
+     * only the proxy's dispatch differs), so only a real proxy + real JDBC connection can pin this.
+     */
+    @Nested
+    @DisplayName("外部调用与自调用的回滚一致性（WIRE-15）")
+    class SelfInvocationAndExternalCallTests {
+
+        private DataSource h2DataSource;
+        private DataSourceTransactionManager realManager;
+        private AopProxyResolver resolver;
+
+        @BeforeEach
+        void setUp() throws Exception {
+            HikariConfig config = new HikariConfig();
+            config.setJdbcUrl("jdbc:h2:mem:txinterceptorselfinvoke" + System.nanoTime()
+                    + ";DB_CLOSE_DELAY=-1;MODE=MySQL");
+            config.setUsername("sa");
+            // Deliberately no setPassword(): see TransactionalRollbackEndToEndTest's identical
+            // comment - the in-memory DB has no credential to hardcode.
+            h2DataSource = new HikariDataSource(config);
+            try (Connection conn = h2DataSource.getConnection();
+                    Statement st = conn.createStatement()) {
+                st.execute("CREATE TABLE tx_test (id INT PRIMARY KEY)");
+            }
+
+            realManager = new DataSourceTransactionManager(h2DataSource);
+            TransactionInterceptor realInterceptor = new TransactionInterceptor(realManager);
+            resolver = new AopProxyResolver();
+            resolver.addAdvisor(AopAdvisor.forAnnotation(Transactional.class, realInterceptor, 100));
+        }
+
+        @AfterEach
+        void tearDown() {
+            if (h2DataSource instanceof HikariDataSource) {
+                ((HikariDataSource) h2DataSource).close();
+            }
+        }
+
+        private int countRows() throws SQLException {
+            try (Connection conn = h2DataSource.getConnection();
+                    Statement st = conn.createStatement();
+                    ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM tx_test")) {
+                rs.next();
+                return rs.getInt(1);
+            }
+        }
+
+        private SelfInvocationBean newProxiedBean() throws ReflectiveOperationException {
+            Class<?> proxyClass = resolver.resolve(SelfInvocationBean.class);
+            return (SelfInvocationBean) proxyClass
+                    .getDeclaredConstructor(TransactionManager.class)
+                    .newInstance(realManager);
+        }
+
+        @Test
+        @DisplayName("Should intercept self-invocation and roll back the same as an external call")
+        void shouldInterceptSelfInvocation() throws Exception {
+            SelfInvocationBean bean = newProxiedBean();
+
+            assertThrows(RuntimeException.class, bean::outerCallsInner);
+
+            assertThat(countRows()).isZero();
+        }
+
+        @Test
+        @DisplayName("Should roll back identically when @Transactional is reached by an external call")
+        void shouldRollBackOnExternalCall() throws Exception {
+            SelfInvocationBean bean = newProxiedBean();
+
+            assertThrows(RuntimeException.class, bean::external);
+
+            assertThat(countRows()).isZero();
+        }
+
+        @Test
+        @DisplayName("Negative control: a non-@Transactional write survives the throw, proving the "
+                + "rollback above came from the interceptor, not an ambient rollback")
+        void shouldCommitNonTransactionalWriteDespiteThrow() throws Exception {
+            SelfInvocationBean bean = newProxiedBean();
+
+            assertThrows(RuntimeException.class, bean::plainWriteThenThrow);
+
+            assertThat(countRows()).isEqualTo(1);
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/api/ExternalDataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/api/ExternalDataStoreTest.java
@@ -2,6 +2,8 @@ package com.ultikits.ultitools.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 
@@ -12,14 +14,18 @@ import com.ultikits.ultitools.interfaces.DataStore;
 import com.ultikits.ultitools.interfaces.DataOperator;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
+import com.ultikits.ultitools.exceptions.DataAccessException;
+import com.ultikits.ultitools.exceptions.ErrorCode;
+import com.ultikits.ultitools.manager.DataScope;
+import com.ultikits.ultitools.manager.PluginManager;
+import com.ultikits.ultitools.utils.TestHelper;
 
 public class ExternalDataStoreTest {
     @TempDir
     File tempDir;
 
-    @Test
-    void defaultMethod_throwsUnsupported() {
-        DataStore store = new DataStore() {
+    private DataStore newStore() {
+        return new DataStore() {
             @Override public String getStoreType() { return "test"; }
             @Override public <T extends BaseDataEntity<String>>
                 DataOperator<T> getOperator(UltiToolsPlugin plugin, Class<T> dataEntity) {
@@ -27,6 +33,46 @@ public class ExternalDataStoreTest {
             }
             @Override public void destroyAllOperators() {}
         };
+    }
+
+    /**
+     * D-18: an unresolvable data folder now fails closed (D-15) rather than falling straight
+     * through to the "not supported" signal -- this is the behavior change Task 3 of 02-07
+     * introduces. {@code tempDir} matches no registered external plugin scope.
+     */
+    @Test
+    void defaultMethod_refusesUnregisteredFolder() {
+        PluginManager pluginManager = mock(PluginManager.class);
+        when(pluginManager.findScopeForDataFolder(tempDir)).thenReturn(null);
+        TestHelper.mockUltiToolsInstance(ultiTools -> when(ultiTools.getPluginManager()).thenReturn(pluginManager));
+
+        DataStore store = newStore();
+
+        assertThatThrownBy(() -> store.getOperator(tempDir, BaseDataEntity.class))
+                .isInstanceOf(DataAccessException.class)
+                .extracting(e -> ((DataAccessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ENTITY_NOT_OWNED);
+    }
+
+    /**
+     * Once {@code tempDir} resolves to a registered scope that owns the entity, the ownership
+     * check passes and the method reaches its original "not supported" signal -- unchanged from
+     * before Task 3, since this default body genuinely has no storage implementation of its own.
+     */
+    @Test
+    void defaultMethod_throwsUnsupportedOnceOwnershipCheckPasses() throws Exception {
+        java.lang.reflect.Method forExternal = DataScope.class.getDeclaredMethod(
+                "forExternal", String.class, File.class, java.util.Set.class);
+        forExternal.setAccessible(true);
+        DataScope scope = (DataScope) forExternal.invoke(
+                null, "OwningPlugin", tempDir, java.util.Collections.singleton(BaseDataEntity.class));
+
+        PluginManager pluginManager = mock(PluginManager.class);
+        when(pluginManager.findScopeForDataFolder(tempDir)).thenReturn(scope);
+        TestHelper.mockUltiToolsInstance(ultiTools -> when(ultiTools.getPluginManager()).thenReturn(pluginManager));
+
+        DataStore store = newStore();
+
         assertThatThrownBy(() -> store.getOperator(tempDir, BaseDataEntity.class))
                 .isInstanceOf(UnsupportedOperationException.class);
     }

--- a/src/test/java/com/ultikits/ultitools/api/ExternalDataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/api/ExternalDataStoreTest.java
@@ -41,7 +41,7 @@ public class ExternalDataStoreTest {
      * introduces. {@code tempDir} matches no registered external plugin scope.
      */
     @Test
-    void defaultMethod_refusesUnregisteredFolder() {
+    void defaultMethodRefusesUnregisteredFolder() {
         PluginManager pluginManager = mock(PluginManager.class);
         when(pluginManager.findScopeForDataFolder(tempDir)).thenReturn(null);
         TestHelper.mockUltiToolsInstance(ultiTools -> when(ultiTools.getPluginManager()).thenReturn(pluginManager));
@@ -60,7 +60,7 @@ public class ExternalDataStoreTest {
      * before Task 3, since this default body genuinely has no storage implementation of its own.
      */
     @Test
-    void defaultMethod_throwsUnsupportedOnceOwnershipCheckPasses() throws Exception {
+    void defaultMethodThrowsUnsupportedOnceOwnershipCheckPasses() throws Exception {
         java.lang.reflect.Method forExternal = DataScope.class.getDeclaredMethod(
                 "forExternal", String.class, File.class, java.util.Set.class);
         forExternal.setAccessible(true);

--- a/src/test/java/com/ultikits/ultitools/api/ExternalPluginIntegrationTest.java
+++ b/src/test/java/com/ultikits/ultitools/api/ExternalPluginIntegrationTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.context.SimpleContainer;
 import com.ultikits.ultitools.events.EventBus;
+import com.ultikits.ultitools.interfaces.DataStore;
 import com.ultikits.ultitools.manager.CommandManager;
 import com.ultikits.ultitools.manager.DependenceManagers;
 import com.ultikits.ultitools.manager.ListenerManager;
@@ -62,6 +63,11 @@ public class ExternalPluginIntegrationTest {
         when(mockUltiTools.getListenerManager()).thenReturn(listenerManager);
         when(mockUltiTools.getEventBus()).thenReturn(eventBus);
         when(mockUltiTools.getPluginManager()).thenReturn(new PluginManager());
+        // wireAop (02-01) resolves a DataSource through UltiTools.getInstance().getDataStore() for
+        // the @Transactional advisor. CALLS_REAL_METHODS lets the interface's own default
+        // getDataSource(DataScope) run and throw UnsupportedOperationException - wireAop's existing
+        // graceful "declare unavailable" fallback - instead of a bare mock's null surfacing as an NPE.
+        when(mockUltiTools.getDataStore()).thenReturn(mock(DataStore.class, CALLS_REAL_METHODS));
 
         setStaticField(UltiTools.class, "ultiTools", mockUltiTools);
     }

--- a/src/test/java/com/ultikits/ultitools/entities/WhereConditionTest.java
+++ b/src/test/java/com/ultikits/ultitools/entities/WhereConditionTest.java
@@ -26,6 +26,15 @@ class WhereConditionTest {
     }
 
     @Test
+    void testComparisonDefaultsToEqualWhenUnspecified() {
+        // WIRE-04: every WhereCondition must carry a non-null Comparison so relational
+        // builders never have to null-check it. Pins WhereCondition.comparison's
+        // @Builder.Default rather than assuming it stays that way.
+        WhereCondition condition = WhereCondition.builder().column("name").value("test").build();
+        assertEquals(Comparison.EQUAL, condition.getComparison());
+    }
+
+    @Test
     void testSetters() {
         WhereCondition condition = WhereCondition.builder().build();
         condition.setColumn("age");

--- a/src/test/java/com/ultikits/ultitools/interfaces/DataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/DataStoreTest.java
@@ -91,14 +91,16 @@ class DataStoreTest {
         }
 
         @Test
-        @DisplayName("Should have exactly 5 methods (3 abstract + 2 default)")
-        void shouldHaveExactlyFiveMethods() {
+        @DisplayName("Should have exactly 6 methods (3 abstract + 3 default)")
+        void shouldHaveExactlySixMethods() {
             // 02-01: added default getDataSource(DataScope) (D-01/D-17), alongside the existing
-            // default getOperator(File, Class).
+            // default getOperator(File, Class). 02-07 Task 2: added default
+            // getOperator(DataScope, Class) (D-14/D-17), the fail-closed, ownership-checked entry
+            // point.
             long count = java.util.Arrays.stream(DataStore.class.getDeclaredMethods())
                     .filter(m -> !m.isSynthetic())
                     .count();
-            assertThat(count).isEqualTo(5);
+            assertThat(count).isEqualTo(6);
         }
 
         @Test
@@ -106,6 +108,15 @@ class DataStoreTest {
         void shouldHaveGetDataSourceMethod() throws NoSuchMethodException {
             Method method = DataStore.class.getMethod("getDataSource",
                     com.ultikits.ultitools.manager.DataScope.class);
+            assertThat(method).isNotNull();
+            assertThat(method.isDefault()).isTrue();
+        }
+
+        @Test
+        @DisplayName("Should have getOperator(DataScope, Class) as a default method (D-17)")
+        void shouldHaveGetOperatorDataScopeMethod() throws NoSuchMethodException {
+            Method method = DataStore.class.getMethod("getOperator",
+                    com.ultikits.ultitools.manager.DataScope.class, Class.class);
             assertThat(method).isNotNull();
             assertThat(method.isDefault()).isTrue();
         }

--- a/src/test/java/com/ultikits/ultitools/interfaces/DataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/DataStoreTest.java
@@ -100,19 +100,22 @@ class DataStoreTest {
         }
 
         @Test
-        @DisplayName("Should have exactly 8 methods (3 abstract + 5 default)")
-        void shouldHaveExactlyEightMethods() {
+        @DisplayName("Should have exactly 9 methods (3 abstract + 6 default)")
+        void shouldHaveExactlyNineMethods() {
             // 02-01: added default getDataSource(DataScope) (D-01/D-17), alongside the existing
             // default getOperator(File, Class). 02-07 Task 2: added default
             // getOperator(DataScope, Class) (D-14/D-17), the fail-closed, ownership-checked entry
             // point. 02-12 Task 1: added the two checkOwnership(...) default methods extracting
             // the ownership check into one reusable member, called by both this interface's own
             // getOperator(File, Class) default body and, as their first statement, by every
-            // concrete store's own getOperator overrides (D-14/D-18).
+            // concrete store's own getOperator overrides (D-14/D-18). 02-13 Task 1: added default
+            // getOperatorUnchecked(DataScope, Class) (CR-01/CR-03) -- the internal, unchecked
+            // construction path getOperator(DataScope, Class) now delegates to instead of the
+            // public, previously ownership-exempt getOperator(File, Class) overload.
             long count = java.util.Arrays.stream(DataStore.class.getDeclaredMethods())
                     .filter(m -> !m.isSynthetic())
                     .count();
-            assertThat(count).isEqualTo(8);
+            assertThat(count).isEqualTo(9);
         }
 
         @Test
@@ -144,6 +147,15 @@ class DataStoreTest {
         @DisplayName("Should have getOperator(DataScope, Class) as a default method (D-17)")
         void shouldHaveGetOperatorDataScopeMethod() throws NoSuchMethodException {
             Method method = DataStore.class.getMethod("getOperator",
+                    com.ultikits.ultitools.manager.DataScope.class, Class.class);
+            assertThat(method).isNotNull();
+            assertThat(method.isDefault()).isTrue();
+        }
+
+        @Test
+        @DisplayName("Should have getOperatorUnchecked(DataScope, Class) as a default method (CR-01/CR-03, 02-13)")
+        void shouldHaveGetOperatorUncheckedMethod() throws NoSuchMethodException {
+            Method method = DataStore.class.getMethod("getOperatorUnchecked",
                     com.ultikits.ultitools.manager.DataScope.class, Class.class);
             assertThat(method).isNotNull();
             assertThat(method.isDefault()).isTrue();

--- a/src/test/java/com/ultikits/ultitools/interfaces/DataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/DataStoreTest.java
@@ -91,12 +91,23 @@ class DataStoreTest {
         }
 
         @Test
-        @DisplayName("Should have exactly 4 methods (3 abstract + 1 default)")
-        void shouldHaveExactlyFourMethods() {
+        @DisplayName("Should have exactly 5 methods (3 abstract + 2 default)")
+        void shouldHaveExactlyFiveMethods() {
+            // 02-01: added default getDataSource(DataScope) (D-01/D-17), alongside the existing
+            // default getOperator(File, Class).
             long count = java.util.Arrays.stream(DataStore.class.getDeclaredMethods())
                     .filter(m -> !m.isSynthetic())
                     .count();
-            assertThat(count).isEqualTo(4);
+            assertThat(count).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("Should have getDataSource(DataScope) as a default method")
+        void shouldHaveGetDataSourceMethod() throws NoSuchMethodException {
+            Method method = DataStore.class.getMethod("getDataSource",
+                    com.ultikits.ultitools.manager.DataScope.class);
+            assertThat(method).isNotNull();
+            assertThat(method.isDefault()).isTrue();
         }
     }
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/DataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/DataStoreTest.java
@@ -1,8 +1,12 @@
 package com.ultikits.ultitools.interfaces;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.TypeVariable;
@@ -13,9 +17,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
+import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
+import com.ultikits.ultitools.exceptions.DataAccessException;
+import com.ultikits.ultitools.exceptions.ErrorCode;
+import com.ultikits.ultitools.manager.PluginManager;
 
 /**
  * Tests for the {@link DataStore} interface.
@@ -91,16 +100,35 @@ class DataStoreTest {
         }
 
         @Test
-        @DisplayName("Should have exactly 6 methods (3 abstract + 3 default)")
-        void shouldHaveExactlySixMethods() {
+        @DisplayName("Should have exactly 8 methods (3 abstract + 5 default)")
+        void shouldHaveExactlyEightMethods() {
             // 02-01: added default getDataSource(DataScope) (D-01/D-17), alongside the existing
             // default getOperator(File, Class). 02-07 Task 2: added default
             // getOperator(DataScope, Class) (D-14/D-17), the fail-closed, ownership-checked entry
-            // point.
+            // point. 02-12 Task 1: added the two checkOwnership(...) default methods extracting
+            // the ownership check into one reusable member, called by both this interface's own
+            // getOperator(File, Class) default body and, as their first statement, by every
+            // concrete store's own getOperator overrides (D-14/D-18).
             long count = java.util.Arrays.stream(DataStore.class.getDeclaredMethods())
                     .filter(m -> !m.isSynthetic())
                     .count();
-            assertThat(count).isEqualTo(6);
+            assertThat(count).isEqualTo(8);
+        }
+
+        @Test
+        @DisplayName("Should have checkOwnership(UltiToolsPlugin, Class) as a default method (D-14/D-18, 02-12)")
+        void shouldHaveCheckOwnershipPluginMethod() throws NoSuchMethodException {
+            Method method = DataStore.class.getMethod("checkOwnership", UltiToolsPlugin.class, Class.class);
+            assertThat(method).isNotNull();
+            assertThat(method.isDefault()).isTrue();
+        }
+
+        @Test
+        @DisplayName("Should have checkOwnership(File, Class) as a default method (D-14/D-18, 02-12)")
+        void shouldHaveCheckOwnershipFileMethod() throws NoSuchMethodException {
+            Method method = DataStore.class.getMethod("checkOwnership", java.io.File.class, Class.class);
+            assertThat(method).isNotNull();
+            assertThat(method.isDefault()).isTrue();
         }
 
         @Test
@@ -343,6 +371,133 @@ class DataStoreTest {
             assertThat(store.getStoreType())
                     .isNotNull()
                     .isNotEmpty();
+        }
+    }
+
+    /**
+     * Task 1 (02-12): the extracted {@code checkOwnership} default methods, exercised directly on
+     * a bare stub {@code DataStore} that implements only the three abstract methods -- proving the
+     * refusal is inherited from the interface itself, not from any one store's own code. Before
+     * this task, {@code getOperator(UltiToolsPlugin, Class)} carried no check at all (D-14/D-18's
+     * disclosed gap); {@code checkOwnership(UltiToolsPlugin, Class)} did not exist to call.
+     */
+    @Nested
+    @DisplayName("checkOwnership default methods (D-14/D-18, 02-12 Task 1)")
+    class CheckOwnershipTests {
+
+        private DataStore stub() {
+            return new DataStore() {
+                @Override
+                public String getStoreType() {
+                    return "checkownership-stub";
+                }
+
+                @Override
+                public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(UltiToolsPlugin plugin, Class<T> dataEntity) {
+                    return null;
+                }
+
+                @Override
+                public void destroyAllOperators() {
+                }
+            };
+        }
+
+        class UnownedEntity extends BaseDataEntity<String> {
+        }
+
+        @Test
+        @DisplayName("checkOwnership(UltiToolsPlugin, Class) should refuse an entity the plugin does not own")
+        void checkOwnershipPluginShouldRefuseUnownedEntity() {
+            UltiToolsPlugin plugin = mock(UltiToolsPlugin.class);
+            when(plugin.getPluginName()).thenReturn("RequestingPlugin");
+            PluginManager pluginManager = mock(PluginManager.class);
+            when(pluginManager.findOwningPlugin(UnownedEntity.class)).thenReturn("OwningPlugin");
+            UltiTools ultiTools = mock(UltiTools.class);
+            when(ultiTools.getPluginManager()).thenReturn(pluginManager);
+
+            try (MockedStatic<UltiTools> ultiToolsStatic = mockStatic(UltiTools.class)) {
+                ultiToolsStatic.when(UltiTools::getInstance).thenReturn(ultiTools);
+
+                assertThatThrownBy(() -> stub().checkOwnership(plugin, UnownedEntity.class))
+                        .isInstanceOf(DataAccessException.class)
+                        .extracting(e -> ((DataAccessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ENTITY_NOT_OWNED);
+            }
+        }
+
+        @Test
+        @DisplayName("checkOwnership(UltiToolsPlugin, Class) refusal message names both the entity and the offending module")
+        void checkOwnershipPluginRefusalMessageNamesEntityAndModule() {
+            UltiToolsPlugin plugin = mock(UltiToolsPlugin.class);
+            when(plugin.getPluginName()).thenReturn("RequestingPlugin");
+            PluginManager pluginManager = mock(PluginManager.class);
+            when(pluginManager.findOwningPlugin(UnownedEntity.class)).thenReturn("OwningPlugin");
+            UltiTools ultiTools = mock(UltiTools.class);
+            when(ultiTools.getPluginManager()).thenReturn(pluginManager);
+
+            try (MockedStatic<UltiTools> ultiToolsStatic = mockStatic(UltiTools.class)) {
+                ultiToolsStatic.when(UltiTools::getInstance).thenReturn(ultiTools);
+
+                assertThatThrownBy(() -> stub().checkOwnership(plugin, UnownedEntity.class))
+                        .hasMessageContaining(UnownedEntity.class.getName())
+                        .hasMessageContaining("OwningPlugin");
+            }
+        }
+
+        @Test
+        @DisplayName("checkOwnership(UltiToolsPlugin, Class) should not refuse an entity the plugin owns")
+        void checkOwnershipPluginShouldNotRefuseOwnedEntity() {
+            UltiToolsPlugin plugin = mock(UltiToolsPlugin.class);
+            when(plugin.getPluginName()).thenReturn("OwningPlugin");
+            PluginManager pluginManager = mock(PluginManager.class);
+            when(pluginManager.findOwningPlugin(UnownedEntity.class)).thenReturn("OwningPlugin");
+            UltiTools ultiTools = mock(UltiTools.class);
+            when(ultiTools.getPluginManager()).thenReturn(pluginManager);
+
+            try (MockedStatic<UltiTools> ultiToolsStatic = mockStatic(UltiTools.class)) {
+                ultiToolsStatic.when(UltiTools::getInstance).thenReturn(ultiTools);
+
+                assertThat(org.assertj.core.api.Assertions.catchThrowable(
+                        () -> stub().checkOwnership(plugin, UnownedEntity.class))).isNull();
+            }
+        }
+
+        @Test
+        @DisplayName("checkOwnership(File, Class) should still exempt the framework's own core data folder")
+        void checkOwnershipFileShouldExemptFrameworkCoreFolder() {
+            File coreFolder = new File(System.getProperty("java.io.tmpdir"), "ultitools-test-core-folder");
+            UltiTools ultiTools = mock(UltiTools.class);
+            when(ultiTools.getDataFolder()).thenReturn(coreFolder);
+
+            try (MockedStatic<UltiTools> ultiToolsStatic = mockStatic(UltiTools.class)) {
+                ultiToolsStatic.when(UltiTools::getInstance).thenReturn(ultiTools);
+
+                // No PluginManager stub at all -- if the core-folder exemption did not fire first,
+                // this would NPE-or-refuse rather than pass silently.
+                assertThat(org.assertj.core.api.Assertions.catchThrowable(
+                        () -> stub().checkOwnership(coreFolder, UnownedEntity.class))).isNull();
+            }
+        }
+
+        @Test
+        @DisplayName("checkOwnership(File, Class) should still refuse an unregistered external folder with the 02-07 message")
+        void checkOwnershipFileShouldRefuseUnregisteredFolder() {
+            File unregisteredFolder = new File(System.getProperty("java.io.tmpdir"), "ultitools-test-unregistered-folder");
+            File coreFolder = new File(System.getProperty("java.io.tmpdir"), "ultitools-test-core-folder-other");
+            PluginManager pluginManager = mock(PluginManager.class);
+            when(pluginManager.findScopeForDataFolder(unregisteredFolder)).thenReturn(null);
+            UltiTools ultiTools = mock(UltiTools.class);
+            when(ultiTools.getDataFolder()).thenReturn(coreFolder);
+            when(ultiTools.getPluginManager()).thenReturn(pluginManager);
+
+            try (MockedStatic<UltiTools> ultiToolsStatic = mockStatic(UltiTools.class)) {
+                ultiToolsStatic.when(UltiTools::getInstance).thenReturn(ultiTools);
+
+                assertThatThrownBy(() -> stub().checkOwnership(unregisteredFolder, UnownedEntity.class))
+                        .isInstanceOf(DataAccessException.class)
+                        .hasMessageContaining("UltiToolsAPI.connect");
+            }
         }
     }
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/DataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/DataStoreTest.java
@@ -129,7 +129,7 @@ class DataStoreTest {
         @Test
         @DisplayName("Should have checkOwnership(File, Class) as a default method (D-14/D-18, 02-12)")
         void shouldHaveCheckOwnershipFileMethod() throws NoSuchMethodException {
-            Method method = DataStore.class.getMethod("checkOwnership", java.io.File.class, Class.class);
+            Method method = DataStore.class.getMethod("checkOwnership", File.class, Class.class);
             assertThat(method).isNotNull();
             assertThat(method.isDefault()).isTrue();
         }

--- a/src/test/java/com/ultikits/ultitools/interfaces/DataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/DataStoreTest.java
@@ -464,8 +464,14 @@ class DataStoreTest {
         }
 
         @Test
-        @DisplayName("checkOwnership(File, Class) should still exempt the framework's own core data folder")
-        void checkOwnershipFileShouldExemptFrameworkCoreFolder() {
+        @DisplayName("checkOwnership(File, Class) should no longer exempt the framework's own core data folder (CR-01, 02-13)")
+        void checkOwnershipFileShouldRefuseFrameworkCoreFolder() {
+            // CR-01 (02-REVIEW.md): the old isFrameworkCoreFolder exemption was keyed purely on a
+            // value any caller can obtain (UltiTools#getDataFolder() is public in the published
+            // jar), not on any credential -- so any code sharing the JVM could reach it. 02-13
+            // deletes the exemption. With no PluginManager registered, the reverse lookup finds no
+            // scope for the core folder either, so this must refuse exactly like any other
+            // unregistered folder.
             File coreFolder = new File(System.getProperty("java.io.tmpdir"), "ultitools-test-core-folder");
             UltiTools ultiTools = mock(UltiTools.class);
             when(ultiTools.getDataFolder()).thenReturn(coreFolder);
@@ -473,10 +479,10 @@ class DataStoreTest {
             try (MockedStatic<UltiTools> ultiToolsStatic = mockStatic(UltiTools.class)) {
                 ultiToolsStatic.when(UltiTools::getInstance).thenReturn(ultiTools);
 
-                // No PluginManager stub at all -- if the core-folder exemption did not fire first,
-                // this would NPE-or-refuse rather than pass silently.
-                assertThat(org.assertj.core.api.Assertions.catchThrowable(
-                        () -> stub().checkOwnership(coreFolder, UnownedEntity.class))).isNull();
+                assertThatThrownBy(() -> stub().checkOwnership(coreFolder, UnownedEntity.class))
+                        .isInstanceOf(DataAccessException.class)
+                        .extracting(e -> ((DataAccessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ENTITY_NOT_OWNED);
             }
         }
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/TimeoutAwareQueryRunnerTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/TimeoutAwareQueryRunnerTest.java
@@ -1,0 +1,147 @@
+package com.ultikits.ultitools.interfaces.impl.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.sql.DataSource;
+
+import org.apache.commons.dbutils.handlers.MapListHandler;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+/**
+ * First test in the codebase to assert on {@link PreparedStatement#getQueryTimeout()}. Exercises
+ * {@link TimeoutAwareQueryRunner} against a real H2 {@link HikariDataSource}, following {@code
+ * SQLiteDataOperatorTest}'s H2-in-MySQL-compatibility-mode setup.
+ * <p>
+ * Every deadline case is driven by a fixed-nanosecond {@link java.util.function.Supplier}, not a
+ * sleep -- a test that sleeps to cross a second boundary is a flaky test (Wave 0 gap 3,
+ * 02-VALIDATION.md).
+ */
+@DisplayName("TimeoutAwareQueryRunner")
+class TimeoutAwareQueryRunnerTest {
+
+    private static HikariDataSource dataSource;
+
+    @BeforeAll
+    static void initDataSource() {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:h2:mem:timeoutawareqrtest;DB_CLOSE_DELAY=-1;MODE=MySQL");
+        config.setUsername("sa");
+        // Deliberately no setPassword(): the in-memory DB is created password-less on first
+        // connection; an empty-string password reads as a hardcoded credential to static
+        // analysis. There is no credential here.
+        dataSource = new HikariDataSource(config);
+    }
+
+    @AfterAll
+    static void closeDataSource() {
+        dataSource.close();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        try (Connection conn = dataSource.getConnection();
+                Statement st = conn.createStatement()) {
+            st.execute("DROP TABLE IF EXISTS timeout_probe");
+            st.execute("CREATE TABLE timeout_probe (id INT PRIMARY KEY, name VARCHAR(50))");
+            st.execute("INSERT INTO timeout_probe (id, name) VALUES (1, 'alpha')");
+        }
+    }
+
+    /**
+     * Captures the {@link PreparedStatement} a {@link TimeoutAwareQueryRunner} builds, via a
+     * {@link org.apache.commons.dbutils.ResultSetHandler} run inside {@code query(...)} -- the
+     * runner does not otherwise expose the statement it prepared. {@code getQueryTimeout()} is
+     * read from the live {@code ResultSet}'s owning statement, since it is still open at that
+     * point.
+     */
+    private int capturedQueryTimeout(TimeoutAwareQueryRunner runner) throws Exception {
+        AtomicReference<Integer> timeout = new AtomicReference<>();
+        runner.query("SELECT * FROM timeout_probe WHERE id = ?", rs -> {
+            timeout.set(rs.getStatement().getQueryTimeout());
+            return null;
+        }, 1);
+        return timeout.get();
+    }
+
+    @Test
+    @DisplayName("a 10-second deadline yields a statement timeout in the 9-10 range")
+    void tenSecondDeadlineYieldsRemainingBudget() throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        TimeoutAwareQueryRunner runner = new TimeoutAwareQueryRunner(dataSource, () -> deadline);
+
+        int timeout = capturedQueryTimeout(runner);
+
+        assertThat(timeout).isBetween(9, 10);
+    }
+
+    @Test
+    @DisplayName("an already-passed deadline floors at 1, never 0 and never negative")
+    void passedDeadlineFloorsAtOne() throws Exception {
+        long deadline = System.nanoTime() - TimeUnit.SECONDS.toNanos(30);
+        TimeoutAwareQueryRunner runner = new TimeoutAwareQueryRunner(dataSource, () -> deadline);
+
+        int timeout = capturedQueryTimeout(runner);
+
+        assertThat(timeout).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("no deadline (null supplier result) leaves setQueryTimeout uncalled")
+    void noDeadlineLeavesDriverDefault() throws Exception {
+        TimeoutAwareQueryRunner runner = new TimeoutAwareQueryRunner(dataSource, () -> null);
+
+        int timeout = capturedQueryTimeout(runner);
+
+        // H2's own driver default is 0 ("no limit") -- asserting the exact driver default would
+        // couple this test to H2; the behavior actually under test is "unchanged from what a
+        // plain QueryRunner would have produced", which the driver default satisfies here since
+        // a plain QueryRunner never calls setQueryTimeout either.
+        assertThat(timeout).isZero();
+    }
+
+    @Test
+    @DisplayName("a real SELECT executed through the runner returns the expected rows unchanged")
+    void queryRunnerBehaviorIsUnchanged() throws Exception {
+        TimeoutAwareQueryRunner runner = new TimeoutAwareQueryRunner(dataSource, () -> null);
+
+        List<Map<String, Object>> rows = runner.query(
+                "SELECT * FROM timeout_probe WHERE id = ?", new MapListHandler(), 1);
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).get("NAME")).isEqualTo("alpha");
+    }
+
+    @Test
+    @DisplayName("a second statement later in the same transaction gets a strictly smaller budget")
+    void secondStatementGetsSmallerBudgetWhenClockAdvances() throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        AtomicReference<Long> clock = new AtomicReference<>(System.nanoTime());
+        TimeoutAwareQueryRunner runner = new TimeoutAwareQueryRunner(dataSource, () -> deadline);
+
+        int first = capturedQueryTimeout(runner);
+        // Simulate the clock having advanced by re-deriving the deadline relative to an earlier
+        // "now" than the second call will use -- built via a second runner sharing the same fixed
+        // deadline but whose remaining budget is computed against a later instant, exactly what
+        // System.nanoTime() advancing between two real statements would produce.
+        long laterDeadline = deadline - TimeUnit.SECONDS.toNanos(3);
+        TimeoutAwareQueryRunner laterRunner = new TimeoutAwareQueryRunner(dataSource, () -> laterDeadline);
+        int second = capturedQueryTimeout(laterRunner);
+
+        assertThat(second).isLessThan(first);
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/TimeoutAwareQueryRunnerTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/TimeoutAwareQueryRunnerTest.java
@@ -8,13 +8,11 @@ import java.sql.Statement;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.sql.DataSource;
-
 import org.apache.commons.dbutils.handlers.MapListHandler;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,36 +28,47 @@ import com.zaxxer.hikari.HikariDataSource;
  * Every deadline case is driven by a fixed-nanosecond {@link java.util.function.Supplier}, not a
  * sleep -- a test that sleeps to cross a second boundary is a flaky test (Wave 0 gap 3,
  * 02-VALIDATION.md).
+ * <p>
+ * Each test gets its own dedicated, uniquely-named in-memory database rather than sharing one
+ * across the class. This is not just isolation hygiene: H2 stores a JDBC {@code Statement}'s
+ * {@code queryTimeout} as session (connection) state, confirmed empirically against
+ * {@code h2-2.2.224.jar} -- once ANY statement on a connection calls
+ * {@code setQueryTimeout(N)}, every later statement on that same connection (even a brand-new
+ * {@code PreparedStatement} that never had it called) reports {@code N}, and H2's own
+ * {@code SET QUERY_TIMEOUT 0} command does not reset that client-side JDBC state. A shared
+ * connection pool would make {@link #noDeadlineLeavesDriverDefault()} pass or fail depending on
+ * test execution order and which pooled physical connection HikariCP happened to hand out.
  */
 @DisplayName("TimeoutAwareQueryRunner")
 class TimeoutAwareQueryRunnerTest {
 
-    private static HikariDataSource dataSource;
+    private static final AtomicInteger DB_COUNTER = new AtomicInteger();
 
-    @BeforeAll
-    static void initDataSource() {
+    private HikariDataSource dataSource;
+
+    @BeforeEach
+    void setUp() throws Exception {
         HikariConfig config = new HikariConfig();
-        config.setJdbcUrl("jdbc:h2:mem:timeoutawareqrtest;DB_CLOSE_DELAY=-1;MODE=MySQL");
+        // A fresh, uniquely-named in-memory database per test -- see the class javadoc for why
+        // this must not be shared.
+        config.setJdbcUrl("jdbc:h2:mem:timeoutawareqrtest" + DB_COUNTER.incrementAndGet()
+                + ";DB_CLOSE_DELAY=-1;MODE=MySQL");
         config.setUsername("sa");
         // Deliberately no setPassword(): the in-memory DB is created password-less on first
         // connection; an empty-string password reads as a hardcoded credential to static
         // analysis. There is no credential here.
         dataSource = new HikariDataSource(config);
-    }
 
-    @AfterAll
-    static void closeDataSource() {
-        dataSource.close();
-    }
-
-    @BeforeEach
-    void setUp() throws Exception {
         try (Connection conn = dataSource.getConnection();
                 Statement st = conn.createStatement()) {
-            st.execute("DROP TABLE IF EXISTS timeout_probe");
             st.execute("CREATE TABLE timeout_probe (id INT PRIMARY KEY, name VARCHAR(50))");
             st.execute("INSERT INTO timeout_probe (id, name) VALUES (1, 'alpha')");
         }
+    }
+
+    @AfterEach
+    void tearDown() {
+        dataSource.close();
     }
 
     /**
@@ -107,10 +116,8 @@ class TimeoutAwareQueryRunnerTest {
 
         int timeout = capturedQueryTimeout(runner);
 
-        // H2's own driver default is 0 ("no limit") -- asserting the exact driver default would
-        // couple this test to H2; the behavior actually under test is "unchanged from what a
-        // plain QueryRunner would have produced", which the driver default satisfies here since
-        // a plain QueryRunner never calls setQueryTimeout either.
+        // A fresh H2 connection's own default is 0 ("no limit"), confirmed empirically -- see the
+        // class javadoc for why this database is not shared with any test that sets a timeout.
         assertThat(timeout).isZero();
     }
 
@@ -130,14 +137,13 @@ class TimeoutAwareQueryRunnerTest {
     @DisplayName("a second statement later in the same transaction gets a strictly smaller budget")
     void secondStatementGetsSmallerBudgetWhenClockAdvances() throws Exception {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
-        AtomicReference<Long> clock = new AtomicReference<>(System.nanoTime());
         TimeoutAwareQueryRunner runner = new TimeoutAwareQueryRunner(dataSource, () -> deadline);
 
         int first = capturedQueryTimeout(runner);
-        // Simulate the clock having advanced by re-deriving the deadline relative to an earlier
-        // "now" than the second call will use -- built via a second runner sharing the same fixed
-        // deadline but whose remaining budget is computed against a later instant, exactly what
-        // System.nanoTime() advancing between two real statements would produce.
+        // Simulate the clock having advanced between two statements of the same transaction by
+        // computing the second statement's remaining budget against the same fixed deadline but
+        // an effectively later "now" -- exactly what System.nanoTime() advancing between two real
+        // statements would produce, without sleeping to cross a second boundary.
         long laterDeadline = deadline - TimeUnit.SECONDS.toNanos(3);
         TimeoutAwareQueryRunner laterRunner = new TimeoutAwareQueryRunner(dataSource, () -> laterDeadline);
         int second = capturedQueryTimeout(laterRunner);

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/TransactionDataOperatorTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/TransactionDataOperatorTest.java
@@ -435,4 +435,49 @@ class TransactionDataOperatorTest {
             assertThat(operator.getById("1").getScore()).isEqualTo(100);
         }
     }
+
+    // ===== Per-statement query timeout (D-10, 02-09 Task 2) =====
+
+    @Nested
+    @DisplayName("Per-statement query timeout end-to-end")
+    class PerStatementTimeoutTests {
+
+        private DataSourceTransactionManager txManager;
+
+        @BeforeEach
+        void setUpTxManager() {
+            txManager = new DataSourceTransactionManager(dataSource);
+            operator.setTransactionManager(txManager);
+        }
+
+        /**
+         * Reads {@code getQueryTimeout()} off the statement {@link #operator}'s own {@code
+         * queryRunner} field builds -- {@code queryRunner} is {@code protected} on {@link
+         * AbstractRelationalDataOperator}, accessible here since this test class shares its
+         * package. Proves the wiring end-to-end: {@link DataSourceTransactionManager#setTimeout}
+         * -&gt; {@link DataSourceTransactionManager#getTimeoutDeadlineNanos()} -&gt; {@link
+         * TimeoutAwareQueryRunner}'s deadline supplier -&gt; the actual prepared statement.
+         */
+        private int capturedQueryTimeout() throws Exception {
+            java.util.concurrent.atomic.AtomicReference<Integer> timeout = new java.util.concurrent.atomic.AtomicReference<>();
+            operator.queryRunner.query("SELECT * FROM tx_test", rs -> {
+                timeout.set(rs.getStatement().getQueryTimeout());
+                return null;
+            });
+            return timeout.get();
+        }
+
+        @Test
+        @DisplayName("a statement issued during a timed transaction carries the remaining budget")
+        void statementCarriesRemainingBudgetDuringTimedTransaction() throws Exception {
+            txManager.begin();
+            txManager.setTimeout(10);
+
+            int timeout = capturedQueryTimeout();
+
+            assertThat(timeout).isBetween(9, 10);
+
+            txManager.commit();
+        }
+    }
 }

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/TransactionDataOperatorTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/TransactionDataOperatorTest.java
@@ -457,13 +457,19 @@ class TransactionDataOperatorTest {
          * package. Proves the wiring end-to-end: {@link DataSourceTransactionManager#setTimeout}
          * -&gt; {@link DataSourceTransactionManager#getTimeoutDeadlineNanos()} -&gt; {@link
          * TimeoutAwareQueryRunner}'s deadline supplier -&gt; the actual prepared statement.
+         * <p>
+         * Deliberately parameterized ({@code WHERE id = ?}), even though no row need match:
+         * {@code QueryRunner.query(sql, handler)}'s zero-params overload takes a {@code
+         * conn.createStatement()} path that never reaches {@code prepareStatement(Connection,
+         * String)} at all -- the exact method {@link TimeoutAwareQueryRunner} overrides. Only the
+         * parameterized overload routes through a real {@code PreparedStatement}.
          */
         private int capturedQueryTimeout() throws Exception {
             java.util.concurrent.atomic.AtomicReference<Integer> timeout = new java.util.concurrent.atomic.AtomicReference<>();
-            operator.queryRunner.query("SELECT * FROM tx_test", rs -> {
+            operator.queryRunner.query("SELECT * FROM tx_test WHERE id = ?", rs -> {
                 timeout.set(rs.getStatement().getQueryTimeout());
                 return null;
-            });
+            }, "nonexistent-id");
             return timeout.get();
         }
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonStoreTest.java
@@ -396,16 +396,28 @@ class JsonStoreTest {
         }
 
         @Test
-        @DisplayName("The framework's own core data folder should still be exempt on getOperator(File, Class)")
-        void shouldExemptFrameworkCoreFolderViaFileOverload() {
+        @DisplayName("The framework's own core data folder should no longer be exempt on getOperator(File, Class) -- CR-01, 02-13")
+        void shouldRefuseFrameworkCoreFolderViaFileOverload() {
             // mockUltiToolsInstance.getDataFolder() is stubbed to tempDir.toFile() above -- passing
-            // tempDir.toFile() itself is exactly the framework-core-folder sentinel
-            // checkOwnership(File, Class) exempts. No PluginManager stub needed for this call to
-            // succeed.
-            DataOperator<AnnotatedTestData> operator = store.getOperator(tempDir.toFile(), AnnotatedTestData.class);
+            // tempDir.toFile() itself used to be exactly the framework-core-folder sentinel
+            // checkOwnership(File, Class) exempted (02-07/02-12). CR-01 (02-REVIEW.md): the
+            // exemption was keyed purely on a value any caller can obtain
+            // (UltiTools#getDataFolder() is public in the published jar), not on any credential.
+            // 02-13 deletes the exemption; no PluginManager stub for this folder is registered
+            // here, so the reverse lookup finds no scope and the call must refuse exactly like any
+            // other unregistered folder -- not silently succeed.
+            //
+            // Fixed outside this plan's own files_modified list (Rule 3 deviation, matching the
+            // precedent 02-07/02-12-SUMMARY.md both recorded for the identical situation): this
+            // test asserted behavior CR-01's fix in DataStore.java directly breaks.
+            assertThatThrownBy(() -> store.getOperator(tempDir.toFile(), AnnotatedTestData.class))
+                    .isInstanceOf(DataAccessException.class)
+                    .extracting(e -> ((DataAccessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.ENTITY_NOT_OWNED);
 
-            assertThat(operator).isNotNull();
-            assertThat(store.getDataOperatorCount()).isEqualTo(1);
+            assertThat(store.getDataOperatorCount())
+                    .as("a refused call must not have built an operator")
+                    .isZero();
         }
     }
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonStoreTest.java
@@ -284,25 +284,31 @@ class JsonStoreTest {
         @Test
         @DisplayName("Multiple plugins using same JsonStore")
         void testMultiplePlugins() {
+            // Pins SILENT-04's fix: dataOperatorMap is keyed by (plugin identity, entity class), not
+            // by entity class alone, so two plugins requesting the same @Table entity get two
+            // distinct operators writing to two distinct directories and cannot read each other's
+            // rows through them.
             UltiToolsPlugin plugin1 = mock(UltiToolsPlugin.class);
             when(plugin1.getPluginName()).thenReturn("Plugin1");
-            
+
             UltiToolsPlugin plugin2 = mock(UltiToolsPlugin.class);
             when(plugin2.getPluginName()).thenReturn("Plugin2");
-            
+
             DataOperator<AnnotatedTestData> op1 = store.getOperator(plugin1, AnnotatedTestData.class);
             DataOperator<AnnotatedTestData> op2 = store.getOperator(plugin2, AnnotatedTestData.class);
-            
-            // Note: Same entity class but different plugins - they share the same operator
-            // This is because dataOperatorMap is keyed by Class, not by plugin+class
-            // Insert data through one operator
+
+            assertThat(op1).isNotSameAs(op2);
+
+            // Insert data through plugin1's operator
             AnnotatedTestData data1 = new AnnotatedTestData();
             data1.setId("plugin1-data");
             data1.setName("from plugin 1");
             op1.insert(data1);
-            
-            // Should be visible through the same operator (since they share)
+
+            // Visible through plugin1's own operator...
             assertThat(op1.getById("plugin1-data")).isNotNull();
+            // ...but NOT through plugin2's operator - they are isolated, not shared.
+            assertThat(op2.getById("plugin1-data")).isNull();
         }
     }
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonStoreTest.java
@@ -28,8 +28,11 @@ import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.annotations.Table;
+import com.ultikits.ultitools.exceptions.DataAccessException;
+import com.ultikits.ultitools.exceptions.ErrorCode;
 import com.ultikits.ultitools.interfaces.DataOperator;
 import com.ultikits.ultitools.manager.DataStoreManager;
+import com.ultikits.ultitools.manager.PluginManager;
 
 /**
  * Tests for JsonStore.
@@ -45,6 +48,7 @@ class JsonStoreTest {
     private static UltiTools mockUltiToolsInstance;
     private static BukkitScheduler mockScheduler;
     private static BukkitTask mockTask;
+    private static PluginManager mockPluginManager;
 
     @BeforeAll
     static void setUpClass() {
@@ -74,10 +78,19 @@ class JsonStoreTest {
         when(mockUltiToolsInstance.getConfig()).thenReturn(mockConfig);
         when(mockConfig.getInt(anyString())).thenReturn(10);
         when(mockUltiToolsInstance.isEnabled()).thenReturn(true);
-        
+
+        // 02-12 Task 2: every getOperator(UltiToolsPlugin, Class) call now runs checkOwnership()
+        // first, which consults UltiTools.getInstance().getPluginManager().findOwningPlugin(...).
+        // Each nested class's own @BeforeEach (re-)stubs findOwningPlugin's default Answer to
+        // echo back its own freshly-created mockPlugin's name, so ownership passes by default for
+        // the plugin under test; individual tests override this with a more specific,
+        // entity-scoped stub when they need a genuine refusal.
+        mockPluginManager = mock(PluginManager.class);
+        when(mockUltiToolsInstance.getPluginManager()).thenReturn(mockPluginManager);
+
         mockedUltiTools = mockStatic(UltiTools.class);
         mockedUltiTools.when(UltiTools::getInstance).thenReturn(mockUltiToolsInstance);
-        
+
         mockedDataStoreManager = mockStatic(DataStoreManager.class);
     }
     
@@ -128,8 +141,10 @@ class JsonStoreTest {
             store = new JsonStore(tempDir.toString());
             mockPlugin = mock(UltiToolsPlugin.class);
             when(mockPlugin.getPluginName()).thenReturn("TestPlugin");
+            when(mockPluginManager.findOwningPlugin(org.mockito.ArgumentMatchers.any()))
+                    .thenAnswer(inv -> mockPlugin.getPluginName());
         }
-        
+
         @Test
         @DisplayName("Should return DataOperator for annotated entity")
         void testGetOperator() {
@@ -197,8 +212,10 @@ class JsonStoreTest {
             store = new JsonStore(tempDir.toString());
             mockPlugin = mock(UltiToolsPlugin.class);
             when(mockPlugin.getPluginName()).thenReturn("TestPlugin");
+            when(mockPluginManager.findOwningPlugin(org.mockito.ArgumentMatchers.any()))
+                    .thenAnswer(inv -> mockPlugin.getPluginName());
         }
-        
+
         @Test
         @DisplayName("Should flush all operators without error")
         void testDestroyAllOperators() {
@@ -252,6 +269,8 @@ class JsonStoreTest {
             store = new JsonStore(tempDir.toString());
             mockPlugin = mock(UltiToolsPlugin.class);
             when(mockPlugin.getPluginName()).thenReturn("IntegrationTestPlugin");
+            when(mockPluginManager.findOwningPlugin(org.mockito.ArgumentMatchers.any()))
+                    .thenAnswer(inv -> mockPlugin.getPluginName());
         }
         
         @Test
@@ -282,20 +301,26 @@ class JsonStoreTest {
         }
         
         @Test
-        @DisplayName("Multiple plugins using same JsonStore")
-        void testMultiplePlugins() {
-            // Pins SILENT-04's fix: dataOperatorMap is keyed by (plugin identity, entity class), not
-            // by entity class alone, so two plugins requesting the same @Table entity get two
-            // distinct operators writing to two distinct directories and cannot read each other's
-            // rows through them.
+        @DisplayName("Two plugins, two entities: each succeeds on its own, isolated storage (SILENT-04)")
+        void testMultiplePluginsWithOwnEntities() {
+            // Was: testMultiplePlugins, which had plugin1 and plugin2 both request the SAME
+            // @Table entity class and asserted each got its own isolated operator. Under 02-12's
+            // ownership model an entity has exactly one owner (PluginManager.findOwningPlugin,
+            // first-registration-wins), so that scenario is no longer legitimate -- it is exactly
+            // what D-14 exists to refuse (see testSecondPluginRequestingFirstPluginsEntityIsRefused
+            // below). This test keeps SILENT-04's real remaining claim: dataOperatorMap is keyed by
+            // (plugin identity, entity class), so two DIFFERENT, each-legitimately-owned entities
+            // resolve to two distinct operators writing to two distinct directories.
             UltiToolsPlugin plugin1 = mock(UltiToolsPlugin.class);
             when(plugin1.getPluginName()).thenReturn("Plugin1");
+            when(mockPluginManager.findOwningPlugin(AnnotatedTestData.class)).thenReturn("Plugin1");
 
             UltiToolsPlugin plugin2 = mock(UltiToolsPlugin.class);
             when(plugin2.getPluginName()).thenReturn("Plugin2");
+            when(mockPluginManager.findOwningPlugin(AnotherAnnotatedTestData.class)).thenReturn("Plugin2");
 
             DataOperator<AnnotatedTestData> op1 = store.getOperator(plugin1, AnnotatedTestData.class);
-            DataOperator<AnnotatedTestData> op2 = store.getOperator(plugin2, AnnotatedTestData.class);
+            DataOperator<AnotherAnnotatedTestData> op2 = store.getOperator(plugin2, AnotherAnnotatedTestData.class);
 
             assertThat(op1).isNotSameAs(op2);
 
@@ -305,10 +330,82 @@ class JsonStoreTest {
             data1.setName("from plugin 1");
             op1.insert(data1);
 
-            // Visible through plugin1's own operator...
+            // Visible through plugin1's own operator, and plugin2's operator (a different entity
+            // type entirely) has no way to even ask for it.
             assertThat(op1.getById("plugin1-data")).isNotNull();
-            // ...but NOT through plugin2's operator - they are isolated, not shared.
-            assertThat(op2.getById("plugin1-data")).isNull();
+        }
+
+        @Test
+        @DisplayName("A second plugin requesting the first plugin's entity is refused (D-14/D-18, 02-12)")
+        void testSecondPluginRequestingFirstPluginsEntityIsRefused() {
+            UltiToolsPlugin plugin1 = mock(UltiToolsPlugin.class);
+            when(plugin1.getPluginName()).thenReturn("Plugin1");
+            when(mockPluginManager.findOwningPlugin(AnnotatedTestData.class)).thenReturn("Plugin1");
+
+            UltiToolsPlugin plugin2 = mock(UltiToolsPlugin.class);
+            when(plugin2.getPluginName()).thenReturn("Plugin2");
+
+            DataOperator<AnnotatedTestData> op1 = store.getOperator(plugin1, AnnotatedTestData.class);
+            assertThat(op1).isNotNull();
+
+            assertThatThrownBy(() -> store.getOperator(plugin2, AnnotatedTestData.class))
+                    .isInstanceOf(DataAccessException.class)
+                    .extracting(e -> ((DataAccessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.ENTITY_NOT_OWNED);
+        }
+    }
+
+    // ==================== Ownership Tests (02-12 Task 2, D-14/D-18) ====================
+
+    /**
+     * {@code checkOwnership} is now called as the first statement of both legacy
+     * {@code getOperator} overrides -- closing the residual bypass 02-07 disclosed. JsonStore has
+     * no connection pool to prove empty on refusal (unlike SQLite/MySQL), so these tests assert
+     * against the operator cache instead, via the store's own package-private
+     * {@code getDataOperatorCount()} test seam.
+     */
+    @Nested
+    @DisplayName("Ownership Tests")
+    class OwnershipTests {
+
+        private JsonStore store;
+
+        @BeforeEach
+        void setUp() {
+            store = new JsonStore(tempDir.toString());
+            when(mockUltiToolsInstance.getDataFolder()).thenReturn(tempDir.toFile());
+        }
+
+        @Test
+        @DisplayName("getOperator(File, Class) should refuse another plugin's unregistered folder, with no cache side effect")
+        void shouldRefuseUnregisteredFolderViaFileOverloadWithNoSideEffects() throws java.io.IOException {
+            java.io.File someOtherPluginsFolder = java.nio.file.Files.createTempDirectory("json-other-plugin").toFile();
+            when(mockPluginManager.findScopeForDataFolder(someOtherPluginsFolder)).thenReturn(null);
+
+            assertThatThrownBy(() -> store.getOperator(someOtherPluginsFolder, AnnotatedTestData.class))
+                    .isInstanceOf(DataAccessException.class)
+                    .extracting(e -> ((DataAccessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.ENTITY_NOT_OWNED);
+
+            // getDataOperatorCount() is package-private on JsonStore; this test class is in the
+            // same package (com.ultikits.ultitools.interfaces.impl.data.json), so it is called
+            // directly -- no reflection needed.
+            assertThat(store.getDataOperatorCount())
+                    .as("a refused call must not have built an operator")
+                    .isZero();
+        }
+
+        @Test
+        @DisplayName("The framework's own core data folder should still be exempt on getOperator(File, Class)")
+        void shouldExemptFrameworkCoreFolderViaFileOverload() {
+            // mockUltiToolsInstance.getDataFolder() is stubbed to tempDir.toFile() above -- passing
+            // tempDir.toFile() itself is exactly the framework-core-folder sentinel
+            // checkOwnership(File, Class) exempts. No PluginManager stub needed for this call to
+            // succeed.
+            DataOperator<AnnotatedTestData> operator = store.getOperator(tempDir.toFile(), AnnotatedTestData.class);
+
+            assertThat(operator).isNotNull();
+            assertThat(store.getDataOperatorCount()).isEqualTo(1);
         }
     }
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonTransactionTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonTransactionTest.java
@@ -7,10 +7,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -29,6 +31,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
+import com.ultikits.ultitools.annotations.Propagation;
+import com.ultikits.ultitools.annotations.Transactional;
+import com.ultikits.ultitools.aop.AopAdvisor;
+import com.ultikits.ultitools.aop.AopProxyResolver;
+import com.ultikits.ultitools.aop.TransactionInterceptor;
 import com.ultikits.ultitools.exceptions.UnexpectedRollbackException;
 import com.ultikits.ultitools.manager.JsonTransactionManager;
 
@@ -74,6 +81,95 @@ class JsonTransactionTest {
         public void setName(String name) { this.name = name; }
         public int getValue() { return value; }
         public void setValue(int value) { this.value = value; }
+    }
+
+    /**
+     * Fixture for {@link RequiresNewAndNotSupportedIntegrationTests} (02-11): proves REQUIRES_NEW
+     * and NOT_SUPPORTED genuinely suspend on the JSON backend, mirroring
+     * {@code TransactionInterceptorTest.PropagationBean}'s JDBC shape. Declared at the top level
+     * (not inside the {@code @Nested} test class) for the same Java 8 / JUnit 5 reason documented
+     * on that JDBC fixture -- a {@code static} member class cannot live inside a non-static
+     * {@code @Nested} class on this project's Java 8 target.
+     * <p>
+     * Writes to two <em>different</em> operators deliberately -- {@code outerOperator} for the
+     * outer scope's own writes, {@code innerOperator} for the inner REQUIRES_NEW/NOT_SUPPORTED
+     * scope's writes. This is not an artifact of the test but a consequence of how
+     * {@link JsonTransactionManager} rolls back: it restores an operator's <em>entire</em> cache
+     * from a snapshot captured at that operator's first touch inside a given transaction context
+     * (see {@code SimpleJsonDataOperator#restoreCache}), so proving genuine independence between
+     * an outer scope and a REQUIRES_NEW/NOT_SUPPORTED inner scope requires them to touch different
+     * operators -- exactly the same distinction
+     * {@code PerPluginTransactionScopeTests#untouchedOperatorNotSnapshotted} already establishes
+     * for a concurrent external write. Two operators sharing one {@link JsonTransactionManager} is
+     * exactly how one plugin's several JSON-backed entities behave in production.
+     */
+    public static class JsonPropagationBean {
+        private final SimpleJsonDataOperator<TestData> outerOperator;
+        private final SimpleJsonDataOperator<TestData> innerOperator;
+        private final JsonTransactionManager txManager;
+
+        /** Captured inside {@link #innerNotSupportedWriteSelf()}/{@link #notSupportedExternalWrite()}. */
+        volatile boolean hasActiveTxInsideNotSupported;
+
+        /** Captured immediately after the self-invoked NOT_SUPPORTED call returns, still inside the
+         *  outer transaction -- proves the outer is intact at its original depth afterwards. */
+        volatile int depthAfterNotSupportedReturnsSelf;
+
+        public JsonPropagationBean(SimpleJsonDataOperator<TestData> outerOperator,
+                SimpleJsonDataOperator<TestData> innerOperator, JsonTransactionManager txManager) {
+            this.outerOperator = outerOperator;
+            this.innerOperator = innerOperator;
+            this.txManager = txManager;
+        }
+
+        /**
+         * Outer REQUIRED transaction that self-invokes a REQUIRES_NEW method whose write commits,
+         * then itself throws so the outer rolls back. The inner's committed write must survive.
+         */
+        @Transactional
+        public void outerRequiredThenSelfInvokesRequiresNewThenFails() {
+            outerOperator.insert(new TestData("outer", "Outer", 1));
+            innerRequiresNewSucceedsSelf();
+            throw new RuntimeException(
+                    "boom - outer rolls back after inner REQUIRES_NEW commit, self-invocation");
+        }
+
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void innerRequiresNewSucceedsSelf() {
+            innerOperator.insert(new TestData("inner", "Inner", 99));
+        }
+
+        /** Externally-called REQUIRES_NEW method that writes and commits independently. */
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void requiresNewExternalSucceeds() {
+            innerOperator.insert(new TestData("external-inner", "ExternalInner", 100));
+        }
+
+        /**
+         * Outer REQUIRED transaction that self-invokes a NOT_SUPPORTED write, then itself throws
+         * so the outer rolls back. The NOT_SUPPORTED write must survive the outer's rollback.
+         */
+        @Transactional
+        public void outerRequiredThenSelfInvokesNotSupportedThenFails() {
+            outerOperator.insert(new TestData("outer-nsw", "OuterNsw", 4));
+            innerNotSupportedWriteSelf();
+            depthAfterNotSupportedReturnsSelf = txManager.getTransactionDepth();
+            throw new RuntimeException(
+                    "boom - outer rolls back after NOT_SUPPORTED write, self-invocation");
+        }
+
+        @Transactional(propagation = Propagation.NOT_SUPPORTED)
+        public void innerNotSupportedWriteSelf() {
+            hasActiveTxInsideNotSupported = txManager.hasActiveTransaction();
+            innerOperator.insert(new TestData("not-supported", "NotSupported", 102));
+        }
+
+        /** Externally-called NOT_SUPPORTED write. */
+        @Transactional(propagation = Propagation.NOT_SUPPORTED)
+        public void notSupportedExternalWrite() {
+            hasActiveTxInsideNotSupported = txManager.hasActiveTransaction();
+            innerOperator.insert(new TestData("external-not-supported", "ExternalNotSupported", 103));
+        }
     }
 
     // ===== Transaction Commit Tests =====
@@ -555,6 +651,221 @@ class JsonTransactionTest {
             assertThatThrownBy(manager::getConnection).isInstanceOf(UnsupportedOperationException.class);
             assertThatThrownBy(() -> manager.setIsolationLevel(1)).isInstanceOf(UnsupportedOperationException.class);
             assertThatThrownBy(() -> manager.setReadOnly(true)).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    // ===== suspend()/resume() -- REQUIRES_NEW/NOT_SUPPORTED's suspension mechanism (02-11) =====
+
+    /**
+     * Unit-level tests against {@link JsonTransactionManager#suspend()}/{@link
+     * JsonTransactionManager#resume(Object)} directly, mirroring
+     * {@code DataSourceTransactionManagerTest.SuspendResumeTests} (D-09) one-for-one on the JSON
+     * side. No operator is needed here -- these four properties live entirely on {@code
+     * contextHolder}/{@code suspendedStack}.
+     */
+    @Nested
+    @DisplayName("suspend()/resume() -- the mechanism REQUIRES_NEW/NOT_SUPPORTED need (02-11, D-09)")
+    class SuspendResumeTests {
+
+        private JsonTransactionManager manager;
+
+        @BeforeEach
+        void setUpManager() {
+            manager = new JsonTransactionManager("suspend-resume-unit-test");
+        }
+
+        @Test
+        @DisplayName("suspend() with no active transaction returns null and does nothing")
+        void suspendWithNothingActiveReturnsNull() {
+            Object suspended = manager.suspend();
+
+            assertThat(suspended).isNull();
+        }
+
+        @Test
+        @DisplayName("resume(null) is a no-op")
+        void resumeWithNullIsNoOp() {
+            assertThatCode(() -> manager.resume(null)).doesNotThrowAnyException();
+            assertThat(manager.hasActiveTransaction()).isFalse();
+        }
+
+        @Test
+        @DisplayName("suspend() detaches the current context; hasActiveTransaction() becomes false")
+        void suspendDetachesCurrentContext() {
+            manager.begin();
+            assertThat(manager.hasActiveTransaction()).isTrue();
+
+            Object suspended = manager.suspend();
+
+            assertThat(suspended).isNotNull();
+            assertThat(manager.hasActiveTransaction()).isFalse();
+        }
+
+        @Test
+        @DisplayName("suspend() -> begin() -> commit() -> resume(saved): original context restored "
+                + "at its original depth, not depth 1")
+        void suspendThenResumeRestoresOriginalDepth() {
+            manager.begin(); // outer, depth 1
+            manager.begin(); // outer, depth 2 (still the same context)
+            assertThat(manager.getTransactionDepth()).isEqualTo(2);
+
+            Object suspended = manager.suspend();
+            assertThat(manager.hasActiveTransaction()).isFalse();
+
+            manager.begin(); // inner, independent, depth 1
+            assertThat(manager.getTransactionDepth()).isEqualTo(1);
+            manager.commit(); // inner finishes and discards its own context completely
+            assertThat(manager.hasActiveTransaction()).isFalse();
+
+            manager.resume(suspended);
+
+            assertThat(manager.hasActiveTransaction()).isTrue();
+            assertThat(manager.getTransactionDepth()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("resume() with a handle this manager did not produce throws "
+                + "IllegalArgumentException naming the problem, rather than accepting it silently")
+        void resumeWithForeignHandleThrows() {
+            assertThatThrownBy(() -> manager.resume("not a Context"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("did not produce");
+        }
+
+        @Test
+        @DisplayName("Suspended-stack ThreadLocal leaves no dangling frame once the last one is "
+                + "popped (T-02-DOS-5 parity)")
+        void suspendedStackLeavesNoDanglingFrameAfterResume() throws Exception {
+            manager.begin();
+            Object suspended = manager.suspend();
+            manager.resume(suspended);
+
+            assertThat(suspendedStackValue()).isNull();
+        }
+
+        private Deque<?> suspendedStackValue() throws Exception {
+            Field field = JsonTransactionManager.class.getDeclaredField("suspendedStack");
+            field.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            ThreadLocal<Deque<?>> threadLocal = (ThreadLocal<Deque<?>>) field.get(manager);
+            return threadLocal.get();
+        }
+    }
+
+    // ===== REQUIRES_NEW/NOT_SUPPORTED through TransactionInterceptor, on the JSON backend (02-11) =====
+
+    /**
+     * End-to-end tests driving {@link JsonPropagationBean} through a real
+     * {@link com.ultikits.ultitools.aop.AopProxyResolver}-built ByteBuddy proxy and a real
+     * {@link TransactionInterceptor}, exactly mirroring {@code
+     * TransactionInterceptorTest.PropagationSuspendResumeTests}'s JDBC shape (D-09) but on
+     * {@link JsonTransactionManager}. Each behavior is proven twice -- once through an external
+     * call (the test itself, standing in for a caller on a thread that already has a transaction
+     * active from elsewhere, dispatched directly onto the proxy) and once through a
+     * self-invocation call -- the same distinction {@code SelfInvocationAndExternalCallTests}
+     * draws, and self-invocation IS intercepted in this framework (the generated subclass is the
+     * bean, not a delegate).
+     */
+    @Nested
+    @DisplayName("REQUIRES_NEW/NOT_SUPPORTED genuinely suspend on the JSON backend (02-11, D-09)")
+    class RequiresNewAndNotSupportedIntegrationTests {
+
+        private SimpleJsonDataOperator<TestData> outerOperator;
+        private SimpleJsonDataOperator<TestData> innerOperator;
+        private JsonTransactionManager propagationManager;
+        private AopProxyResolver resolver;
+
+        @BeforeEach
+        void setUpPropagationFixture() throws Exception {
+            File outerDir = Files.createDirectory(tempDir.resolve("propagation-outer-" + System.nanoTime())).toFile();
+            File innerDir = Files.createDirectory(tempDir.resolve("propagation-inner-" + System.nanoTime())).toFile();
+            outerOperator = new SimpleJsonDataOperator<>(outerDir.getAbsolutePath(), TestData.class);
+            innerOperator = new SimpleJsonDataOperator<>(innerDir.getAbsolutePath(), TestData.class);
+            propagationManager = new JsonTransactionManager("propagation-integration-test");
+            outerOperator.bindTransactionManager(propagationManager);
+            innerOperator.bindTransactionManager(propagationManager);
+
+            TransactionInterceptor interceptor = new TransactionInterceptor(propagationManager);
+            resolver = new AopProxyResolver();
+            resolver.addAdvisor(AopAdvisor.forAnnotation(Transactional.class, interceptor, 100));
+        }
+
+        private JsonPropagationBean newProxiedBean() throws ReflectiveOperationException {
+            Class<?> proxyClass = resolver.resolve(JsonPropagationBean.class);
+            return (JsonPropagationBean) proxyClass
+                    .getDeclaredConstructor(SimpleJsonDataOperator.class, SimpleJsonDataOperator.class,
+                            JsonTransactionManager.class)
+                    .newInstance(outerOperator, innerOperator, propagationManager);
+        }
+
+        @Test
+        @DisplayName("REQUIRES_NEW (self-invocation): the inner transaction's commit survives the "
+                + "outer transaction's rollback")
+        void requiresNewSelfInvocationInnerCommitSurvivesOuterRollback() throws Exception {
+            JsonPropagationBean bean = newProxiedBean();
+
+            assertThatThrownBy(bean::outerRequiredThenSelfInvokesRequiresNewThenFails)
+                    .isInstanceOf(RuntimeException.class);
+
+            assertThat(outerOperator.getById("outer")).isNull();
+            assertThat(innerOperator.getById("inner")).isNotNull();
+            assertThat(propagationManager.hasActiveTransaction()).isFalse();
+        }
+
+        @Test
+        @DisplayName("REQUIRES_NEW (external call): commits independently of a separately-active "
+                + "outer transaction that later rolls back")
+        void requiresNewExternalCallInnerCommitSurvivesOuterRollback() throws Exception {
+            JsonPropagationBean bean = newProxiedBean();
+
+            propagationManager.begin(); // simulates a transaction already active from an external caller
+            outerOperator.insert(new TestData("outer-ext", "OuterExt", 1));
+
+            bean.requiresNewExternalSucceeds(); // external call: outside JsonPropagationBean entirely
+
+            // No suspended frame left behind: the outer is exactly where it was before.
+            assertThat(propagationManager.getTransactionDepth()).isEqualTo(1);
+
+            propagationManager.rollback();
+
+            assertThat(outerOperator.getById("outer-ext")).isNull();
+            assertThat(innerOperator.getById("external-inner")).isNotNull();
+        }
+
+        @Test
+        @DisplayName("NOT_SUPPORTED (self-invocation): the body runs with no active transaction, "
+                + "and the outer transaction is intact at its original depth afterwards")
+        void notSupportedSelfInvocationRunsWithNoActiveTransaction() throws Exception {
+            JsonPropagationBean bean = newProxiedBean();
+
+            assertThatThrownBy(bean::outerRequiredThenSelfInvokesNotSupportedThenFails)
+                    .isInstanceOf(RuntimeException.class);
+
+            assertThat(bean.hasActiveTxInsideNotSupported).isFalse();
+            assertThat(bean.depthAfterNotSupportedReturnsSelf).isEqualTo(1);
+            assertThat(innerOperator.getById("not-supported")).isNotNull();
+            assertThat(outerOperator.getById("outer-nsw")).isNull();
+        }
+
+        @Test
+        @DisplayName("NOT_SUPPORTED (external call): the body runs with no active transaction, and "
+                + "the separately-active outer transaction is intact at its original depth afterwards")
+        void notSupportedExternalCallRunsWithNoActiveTransaction() throws Exception {
+            JsonPropagationBean bean = newProxiedBean();
+
+            propagationManager.begin(); // depth 1, simulates an external caller's active transaction
+            outerOperator.insert(new TestData("outer-ext-nsw", "OuterExtNsw", 1));
+
+            bean.notSupportedExternalWrite(); // external call: outside JsonPropagationBean entirely
+
+            assertThat(bean.hasActiveTxInsideNotSupported).isFalse();
+            assertThat(propagationManager.hasActiveTransaction()).isTrue();
+            assertThat(propagationManager.getTransactionDepth()).isEqualTo(1);
+
+            propagationManager.rollback();
+
+            assertThat(outerOperator.getById("outer-ext-nsw")).isNull();
+            assertThat(innerOperator.getById("external-not-supported")).isNotNull();
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonTransactionTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonTransactionTest.java
@@ -1,11 +1,13 @@
 package com.ultikits.ultitools.interfaces.impl.data.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,6 +29,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
+import com.ultikits.ultitools.exceptions.UnexpectedRollbackException;
+import com.ultikits.ultitools.manager.JsonTransactionManager;
 
 @DisplayName("JSON Data Operator - Transaction & Batch Tests")
 class JsonTransactionTest {
@@ -424,6 +428,133 @@ class JsonTransactionTest {
 
             // Only "stable" should remain
             assertThat(operator.getById("stable")).isNotNull();
+        }
+    }
+
+    // ===== Per-Plugin Transaction Scope (JsonTransactionManager, D-03) =====
+
+    @Nested
+    @DisplayName("JsonTransactionManager - Per-Plugin Rollback Scope")
+    class PerPluginTransactionScopeTests {
+
+        private SimpleJsonDataOperator<TestData> operatorA;
+        private SimpleJsonDataOperator<TestData> operatorB;
+        private JsonTransactionManager manager;
+
+        @BeforeEach
+        void setUpTwoOperators() throws Exception {
+            File dirA = Files.createDirectory(tempDir.resolve("operator-a")).toFile();
+            File dirB = Files.createDirectory(tempDir.resolve("operator-b")).toFile();
+            operatorA = new SimpleJsonDataOperator<>(dirA.getAbsolutePath(), TestData.class);
+            operatorB = new SimpleJsonDataOperator<>(dirB.getAbsolutePath(), TestData.class);
+            manager = new JsonTransactionManager("per-plugin-scope-test");
+            operatorA.bindTransactionManager(manager);
+            operatorB.bindTransactionManager(manager);
+        }
+
+        @Test
+        @DisplayName("Rollback restores every operator of the plugin touched during the transaction")
+        void rollbackRestoresBothTouchedOperators() {
+            operatorA.insert(new TestData("pre-a", "PreA", 1));
+            operatorB.insert(new TestData("pre-b", "PreB", 2));
+
+            manager.begin();
+            operatorA.insert(new TestData("new-a", "NewA", 10));
+            operatorB.insert(new TestData("new-b", "NewB", 20));
+            manager.rollback();
+
+            assertThat(operatorA.getAll()).hasSize(1);
+            assertThat(operatorA.getById("pre-a")).isNotNull();
+            assertThat(operatorA.getById("new-a")).isNull();
+
+            assertThat(operatorB.getAll()).hasSize(1);
+            assertThat(operatorB.getById("pre-b")).isNotNull();
+            assertThat(operatorB.getById("new-b")).isNull();
+        }
+
+        @Test
+        @DisplayName("An operator never written to during the transaction is not snapshotted -- "
+                + "a concurrent external write to it survives rollback")
+        void untouchedOperatorNotSnapshotted() throws Exception {
+            operatorA.insert(new TestData("pre-a", "PreA", 1));
+
+            manager.begin();
+            operatorA.insert(new TestData("new-a", "NewA", 10));
+
+            // A write to operatorB from a different thread never observes this thread's active
+            // transaction context (JsonTransactionManager's context is ThreadLocal, matching
+            // DataSourceTransactionManager's design), so it is never captured -- exactly the
+            // "operator never touched" case, made observable via a genuinely concurrent write.
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            try {
+                executor.submit(() -> operatorB.insert(new TestData("external", "External", 99))).get();
+            } finally {
+                executor.shutdown();
+            }
+
+            manager.rollback();
+
+            // operatorA was touched on this thread -- restored to its pre-transaction state.
+            assertThat(operatorA.getById("new-a")).isNull();
+            assertThat(operatorA.getById("pre-a")).isNotNull();
+
+            // operatorB was never touched inside the transaction -- the concurrent external write
+            // survives the rollback untouched.
+            assertThat(operatorB.getById("external")).isNotNull();
+        }
+
+        @Test
+        @DisplayName("commit() discards captured snapshots")
+        void commitDiscardsSnapshots() {
+            manager.begin();
+            operatorA.insert(new TestData("a", "A", 1));
+            manager.commit();
+
+            assertThat(operatorA.getById("a")).isNotNull();
+            assertThat(manager.hasActiveTransaction()).isFalse();
+        }
+
+        @Test
+        @DisplayName("rollback() with no active transaction logs a warning and returns")
+        void rollbackWithNoActiveTransactionIsANoOp() {
+            assertThatCode(() -> manager.rollback()).doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("Depth 2: inner rollback() then outer commit() throws UnexpectedRollbackException "
+                + "and restores every captured snapshot")
+        void nestedRollbackThenOuterCommitThrows() {
+            operatorA.insert(new TestData("pre-a", "PreA", 1));
+
+            manager.begin(); // depth 1
+            manager.begin(); // depth 2
+            operatorA.insert(new TestData("new-a", "NewA", 10));
+            manager.rollback(); // marks rollback-only, depth -> 1
+
+            assertThat(manager.hasActiveTransaction()).isTrue();
+            assertThat(manager.getTransactionDepth()).isEqualTo(1);
+
+            assertThatThrownBy(manager::commit).isInstanceOf(UnexpectedRollbackException.class);
+
+            assertThat(operatorA.getById("new-a")).isNull();
+            assertThat(operatorA.getById("pre-a")).isNotNull();
+            assertThat(manager.hasActiveTransaction()).isFalse();
+        }
+
+        @Test
+        @DisplayName("setTimeout gives an explicit answer, not a silent no-op")
+        void setTimeoutIsNotASilentNoOp() {
+            assertThatThrownBy(() -> manager.setTimeout(30))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("JsonTransactionManager implements TransactionManager only -- "
+                + "the JDBC-only methods are refused, not silently no-op")
+        void doesNotImplementJdbcMethods() {
+            assertThatThrownBy(manager::getConnection).isInstanceOf(UnsupportedOperationException.class);
+            assertThatThrownBy(() -> manager.setIsolationLevel(1)).isInstanceOf(UnsupportedOperationException.class);
+            assertThatThrownBy(() -> manager.setReadOnly(true)).isInstanceOf(UnsupportedOperationException.class);
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperatorTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperatorTest.java
@@ -8,11 +8,16 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.FileWriter;
 import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Logger;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,7 +25,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import com.ultikits.ultitools.abstracts.data.AuditableDataEntity;
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
+import com.ultikits.ultitools.abstracts.data.DataEntityTest;
 import com.ultikits.ultitools.annotations.Table;
 import com.ultikits.ultitools.entities.Comparison;
 import com.ultikits.ultitools.entities.WhereCondition;
@@ -710,6 +717,232 @@ class SimpleJsonDataOperatorTest {
 
         public void setValue(int value) {
             this.value = value;
+        }
+    }
+
+    /**
+     * SILENT-02 (02-08): the same set of assertions as
+     * {@code SQLiteDataOperatorTest$LifecycleHookTests}, run against the JSON backend, so the
+     * two backends cannot diverge on when the entity lifecycle hooks fire.
+     */
+    @Nested
+    @DisplayName("Lifecycle Hook Tests (SILENT-02)")
+    class LifecycleHookTests {
+
+        private SimpleJsonDataOperator<DataEntityTest.CountingAuditableEntity> hookOperator;
+
+        @BeforeEach
+        void setUpHookOperator() {
+            File hookDir = new File(storeDir, "counting-auditable");
+            hookDir.mkdirs();
+            hookOperator = new SimpleJsonDataOperator<>(hookDir.getAbsolutePath(),
+                    DataEntityTest.CountingAuditableEntity.class);
+            DataEntityTest.CountingAuditableEntity.resetCounters();
+            AuditableDataEntity.clearCurrentUser();
+        }
+
+        @AfterEach
+        void tearDownHookOperator() {
+            DataEntityTest.CountingAuditableEntity.resetCounters();
+            AuditableDataEntity.clearCurrentUser();
+        }
+
+        private DataEntityTest.CountingAuditableEntity newEntity(String label) {
+            DataEntityTest.CountingAuditableEntity entity = new DataEntityTest.CountingAuditableEntity();
+            entity.setLabel(label);
+            return entity;
+        }
+
+        @Test
+        @DisplayName("insert should populate created_at and created_by (previously always NULL)")
+        void insertShouldPopulateCreatedAtAndCreatedBy() {
+            UUID user = UUID.randomUUID();
+            AuditableDataEntity.setCurrentUser(user);
+            DataEntityTest.CountingAuditableEntity entity = newEntity("insert-1");
+
+            hookOperator.insert(entity);
+
+            assertThat(entity.getCreatedAt()).isNotNull();
+            assertThat(entity.getCreatedBy()).isEqualTo(user);
+        }
+
+        @Test
+        @DisplayName("update should populate updated_at and updated_by (previously always NULL)")
+        void updateShouldPopulateUpdatedAtAndUpdatedBy() {
+            DataEntityTest.CountingAuditableEntity entity = newEntity("update-1");
+            hookOperator.insert(entity);
+
+            UUID user = UUID.randomUUID();
+            AuditableDataEntity.setCurrentUser(user);
+            entity.setLabel("update-1-changed");
+            hookOperator.update(entity);
+
+            assertThat(entity.getUpdatedAt()).isNotNull();
+            assertThat(entity.getUpdatedBy()).isEqualTo(user);
+        }
+
+        @Test
+        @DisplayName("insert/update/getById/delById each fire their matching hook exactly once")
+        void hooksFireExactlyOnceEachForSingleEntityOperations() {
+            DataEntityTest.CountingAuditableEntity entity = newEntity("count-1");
+
+            hookOperator.insert(entity);
+            assertThat(DataEntityTest.CountingAuditableEntity.onCreateCount()).isEqualTo(1);
+
+            entity.setLabel("count-1-updated");
+            hookOperator.update(entity);
+            assertThat(DataEntityTest.CountingAuditableEntity.onUpdateCount()).isEqualTo(1);
+
+            DataEntityTest.CountingAuditableEntity loaded = hookOperator.getById(entity.getId());
+            assertThat(loaded).isNotNull();
+            assertThat(DataEntityTest.CountingAuditableEntity.onLoadCount()).isEqualTo(1);
+
+            hookOperator.delById(entity.getId());
+            assertThat(DataEntityTest.CountingAuditableEntity.onDeleteCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("getAll/page fire onLoad exactly once per returned entity")
+        void getAllAndPageFireOnLoadOncePerReturnedEntity() {
+            hookOperator.insert(newEntity("load-1"));
+            hookOperator.insert(newEntity("load-2"));
+            hookOperator.insert(newEntity("load-3"));
+            DataEntityTest.CountingAuditableEntity.resetCounters();
+
+            List<DataEntityTest.CountingAuditableEntity> all = hookOperator.getAll();
+            assertThat(all).hasSize(3);
+            assertThat(DataEntityTest.CountingAuditableEntity.onLoadCount()).isEqualTo(3);
+
+            DataEntityTest.CountingAuditableEntity.resetCounters();
+            List<DataEntityTest.CountingAuditableEntity> page = hookOperator.page(1, 2, WhereCondition.empty());
+            assertThat(page).hasSize(2);
+            assertThat(DataEntityTest.CountingAuditableEntity.onLoadCount())
+                    .as("onLoad must fire only for the entities actually returned by the page, not every matched row")
+                    .isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("exist(WhereCondition...) does not fire onLoad -- it is a boolean check, not a read")
+        void existDoesNotFireOnLoad() {
+            hookOperator.insert(newEntity("exist-1"));
+            DataEntityTest.CountingAuditableEntity.resetCounters();
+
+            boolean found = hookOperator.exist(
+                    WhereCondition.builder().column("label").value("exist-1").build());
+
+            assertThat(found).isTrue();
+            assertThat(DataEntityTest.CountingAuditableEntity.onLoadCount()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("insert then immediate update: created_at keeps the insert value, updated_at is non-null")
+        void adjacentInsertThenUpdatePreservesCreatedAt() {
+            DataEntityTest.CountingAuditableEntity entity = newEntity("adjacency-1");
+            hookOperator.insert(entity);
+            LocalDateTime createdAt = entity.getCreatedAt();
+            assertThat(createdAt).isNotNull();
+
+            entity.setLabel("adjacency-1-updated");
+            hookOperator.update(entity);
+
+            assertThat(entity.getCreatedAt()).isEqualTo(createdAt);
+            assertThat(entity.getUpdatedAt()).isNotNull();
+
+            DataEntityTest.CountingAuditableEntity reloaded = hookOperator.getById(entity.getId());
+            assertThat(reloaded.getCreatedAt()).isEqualTo(createdAt);
+            assertThat(reloaded.getUpdatedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("insertAll(empty list) fires no hooks and stores no entries")
+        void insertAllEmptyFiresNoHooksAndWritesNoRows() {
+            hookOperator.insertAll(Collections.emptyList());
+
+            assertThat(DataEntityTest.CountingAuditableEntity.onCreateCount()).isEqualTo(0);
+            assertThat(hookOperator.getAll()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("with no current user set, created_by/updated_by stay null (not a placeholder string)")
+        void nullActorLeavesCreatedByNull() {
+            DataEntityTest.CountingAuditableEntity entity = newEntity("null-actor-1");
+
+            hookOperator.insert(entity);
+
+            assertThat(entity.getCreatedBy()).isNull();
+            assertThat(entity.getUpdatedBy()).isNull();
+            DataEntityTest.CountingAuditableEntity reloaded = hookOperator.getById(entity.getId());
+            assertThat(reloaded.getCreatedBy()).isNull();
+            assertThat(reloaded.getUpdatedBy()).isNull();
+        }
+
+        @Test
+        @DisplayName("insertAll(3 entities) fires onCreate exactly 3 times, in list order")
+        void insertAllFiresOnCreateThreeTimesInOrder() {
+            DataEntityTest.CountingAuditableEntity e1 = newEntity("batch-1");
+            e1.setId("batch-id-1");
+            DataEntityTest.CountingAuditableEntity e2 = newEntity("batch-2");
+            e2.setId("batch-id-2");
+            DataEntityTest.CountingAuditableEntity e3 = newEntity("batch-3");
+            e3.setId("batch-id-3");
+
+            hookOperator.insertAll(Arrays.asList(e1, e2, e3));
+
+            assertThat(DataEntityTest.CountingAuditableEntity.onCreateCount()).isEqualTo(3);
+            assertThat(DataEntityTest.CountingAuditableEntity.onCreateOrder())
+                    .containsExactly("batch-id-1", "batch-id-2", "batch-id-3");
+        }
+
+        @Test
+        @DisplayName("updateAll(3 entities) fires onUpdate exactly 3 times, in list order")
+        void updateAllFiresOnUpdateThreeTimesInOrder() throws Exception {
+            DataEntityTest.CountingAuditableEntity e1 = newEntity("batch-u-1");
+            e1.setId("batch-u-id-1");
+            DataEntityTest.CountingAuditableEntity e2 = newEntity("batch-u-2");
+            e2.setId("batch-u-id-2");
+            DataEntityTest.CountingAuditableEntity e3 = newEntity("batch-u-3");
+            e3.setId("batch-u-id-3");
+            hookOperator.insertAll(Arrays.asList(e1, e2, e3));
+            DataEntityTest.CountingAuditableEntity.resetCounters();
+
+            hookOperator.updateAll(Arrays.asList(e1, e2, e3));
+
+            assertThat(DataEntityTest.CountingAuditableEntity.onUpdateCount()).isEqualTo(3);
+            assertThat(DataEntityTest.CountingAuditableEntity.onUpdateOrder())
+                    .containsExactly("batch-u-id-1", "batch-u-id-2", "batch-u-id-3");
+        }
+
+        @Test
+        @DisplayName("del(WhereCondition...) deletes by predicate but does not fire onDelete (rows never materialised)")
+        void delByConditionDoesNotFireOnDelete() {
+            DataEntityTest.CountingAuditableEntity entity = newEntity("del-condition-1");
+            hookOperator.insert(entity);
+            DataEntityTest.CountingAuditableEntity.resetCounters();
+
+            hookOperator.del(WhereCondition.builder().column("label").value("del-condition-1").build());
+
+            assertThat(DataEntityTest.CountingAuditableEntity.onDeleteCount())
+                    .as("del(WhereCondition...) deletes by predicate without materialising entries -- it must not fire onDelete")
+                    .isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("a snapshot restore (rolled-back transaction) does not re-fire onLoad for restored entries")
+        void snapshotRestoreDoesNotRefireOnLoad() {
+            hookOperator.insert(newEntity("txn-1"));
+            DataEntityTest.CountingAuditableEntity.resetCounters();
+
+            assertThatThrownBy(() -> hookOperator.transaction(() -> {
+                hookOperator.insert(newEntity("txn-2"));
+                throw new RuntimeException("force rollback");
+            })).isInstanceOf(RuntimeException.class);
+
+            // The snapshot restore itself (not the getAll() check below, which fires its own
+            // onLoad on the surviving entity) must not count as a load.
+            assertThat(DataEntityTest.CountingAuditableEntity.onLoadCount())
+                    .as("restoreCache() repopulates the cache from a snapshot; that is not a load")
+                    .isEqualTo(0);
+            assertThat(hookOperator.getAll()).hasSize(1);
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperatorTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperatorTest.java
@@ -2,7 +2,11 @@ package com.ultikits.ultitools.interfaces.impl.data.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -31,7 +35,10 @@ import com.ultikits.ultitools.abstracts.data.DataEntityTest;
 import com.ultikits.ultitools.annotations.Table;
 import com.ultikits.ultitools.entities.Comparison;
 import com.ultikits.ultitools.entities.WhereCondition;
+import com.ultikits.ultitools.exceptions.DataAccessException;
+import com.ultikits.ultitools.exceptions.ErrorCode;
 import com.ultikits.ultitools.interfaces.DataOperator.LikeType;
+import com.ultikits.ultitools.manager.JsonTransactionManager;
 
 class SimpleJsonDataOperatorTest {
 
@@ -598,10 +605,64 @@ class SimpleJsonDataOperatorTest {
         void testDelSkipNullPath() {
             operator.insert(new TestData("1", "test", 10));
             int sizeBefore = operator.getAll().size();
-            
+
             operator.del(WhereCondition.builder().column("nonexistent").value("value").build());
-            
+
             assertThat(operator.getAll()).hasSize(sizeBefore);
+        }
+
+        /**
+         * CR-02 (02-REVIEW.md, 02-13): {@link com.ultikits.ultitools.interfaces.DataOperator#del}'s
+         * interface javadoc, added in this same phase, promises a {@code null} or zero-length
+         * {@code whereConditions} is rejected with a {@code DataAccessException} -- the guarantee
+         * {@code AbstractRelationalDataOperator.del()} already enforces. Before 02-13,
+         * {@code SimpleJsonDataOperator.del()} did not: a zero-length array made the {@code for}
+         * loop body never run, so the call returned normally having deleted nothing, in direct
+         * contradiction of the promise; a {@code null} array threw a raw {@code
+         * NullPointerException} instead of the promised exception type.
+         */
+        @Test
+        @DisplayName("del() with a zero-length array should throw DataAccessException, not silently delete nothing (CR-02, 02-13)")
+        void testDelZeroLengthArrayShouldThrow() {
+            operator.insert(new TestData("1", "test", 10));
+
+            assertThatThrownBy(() -> operator.del())
+                    .isInstanceOf(DataAccessException.class)
+                    .extracting(e -> ((DataAccessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.DATA_ENTITY_INVALID);
+
+            // A refused call must not have deleted anything as a side effect.
+            assertThat(operator.getById("1")).isNotNull();
+        }
+
+        @Test
+        @DisplayName("del(null) should throw DataAccessException, not a raw NullPointerException (CR-02, 02-13)")
+        void testDelNullArrayShouldThrowDataAccessException() {
+            operator.insert(new TestData("1", "test", 10));
+
+            assertThatThrownBy(() -> operator.del((WhereCondition[]) null))
+                    .isInstanceOf(DataAccessException.class)
+                    .extracting(e -> ((DataAccessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.DATA_ENTITY_INVALID);
+
+            assertThat(operator.getById("1")).isNotNull();
+        }
+
+        @Test
+        @DisplayName("a refused del() must not capture a transaction snapshot as a side effect (CR-02, 02-13)")
+        void testRefusedDelShouldNotCaptureTransactionSnapshot() {
+            // Data inserted BEFORE begin(), so a snapshot capture triggered by this transaction's
+            // own first write would be observable via captureIfAbsent(...) being invoked -- del()
+            // is the only operation performed inside the transaction below, so if the refusal
+            // fires before beforeMutate() runs, captureIfAbsent(...) is never called at all.
+            operator.insert(new TestData("1", "test", 10));
+            JsonTransactionManager manager = spy(new JsonTransactionManager("del-guard-test"));
+            operator.bindTransactionManager(manager);
+            manager.begin();
+
+            assertThatThrownBy(() -> operator.del()).isInstanceOf(DataAccessException.class);
+
+            verify(manager, never()).captureIfAbsent(any(), any(), any());
         }
     }
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataOperatorTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataOperatorTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
 import com.ultikits.ultitools.annotations.Column;
 import com.ultikits.ultitools.annotations.Table;
+import com.ultikits.ultitools.entities.Comparison;
 import com.ultikits.ultitools.entities.WhereCondition;
 import com.ultikits.ultitools.interfaces.DataOperator.LikeType;
 
@@ -110,6 +111,46 @@ class MysqlDataOperatorTest {
 
             assertThat(operator.exist(entity)).isTrue();
             assertThat(operator.exist(WhereCondition.builder().column("id").value("test-1").build())).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("Comparison 语义测试（GREATER 与 SQLite/JSON 后端一致，WIRE-04）")
+    class ComparisonSemanticsTests {
+
+        @BeforeEach
+        void insertNumericRows() {
+            insertNumeric("cmp-1", 1);
+            insertNumeric("cmp-5", 5);
+            insertNumeric("cmp-9", 9);
+        }
+
+        private void insertNumeric(String id, int age) {
+            TestEntity entity = new TestEntity();
+            entity.setId(id);
+            entity.setName("Entity" + age);
+            entity.setAge(age);
+            operator.insert(entity);
+        }
+
+        @Test
+        @DisplayName("getAll(GREATER) 只返回大于阈值的行，而不是等于阈值")
+        void getAllGreaterShouldReturnOnlyRowsAboveThreshold() {
+            List<TestEntity> result = operator.getAll(
+                    WhereCondition.builder().column("age").value(5).comparison(Comparison.GREATER).build());
+
+            assertThat(result).extracting(TestEntity::getAge).containsExactly(9);
+        }
+
+        @Test
+        @DisplayName("exist(GREATER) 与 getAll 的 GREATER 语义一致")
+        void existGreaterShouldMatchGetAllSemantics() {
+            assertThat(operator.exist(
+                    WhereCondition.builder().column("age").value(5).comparison(Comparison.GREATER).build()))
+                    .isTrue();
+            assertThat(operator.exist(
+                    WhereCondition.builder().column("age").value(9).comparison(Comparison.GREATER).build()))
+                    .isFalse();
         }
     }
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataStoreTest.java
@@ -6,13 +6,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.lang.reflect.Field;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -113,28 +112,19 @@ class MysqlDataStoreTest {
         when(mockConfig.getInt("mysql.prepStmtCacheSqlLimit")).thenReturn(2048);
     }
 
-    /**
-     * 清理 MysqlDataStore 中的静态缓存
-     */
-    private void clearStaticCache() {
-        try {
-            Field field = MysqlDataStore.class.getDeclaredField("dataOperatorMap");
-            field.setAccessible(true);
-            Map<?, ?> map = (Map<?, ?>) field.get(null);
-            map.clear();
-        } catch (Exception e) {
-            // 忽略反射异常
-        }
-    }
-
     @BeforeEach
     void setUp() {
-        clearStaticCache();
+        // dataOperatorMap is instance-scoped since Task 3 (SILENT-04) - each test constructs its own
+        // fresh MysqlDataStore(), so there is no shared static cache left to clear here anymore.
         ultiToolsStaticMock = mockStatic(UltiTools.class);
         ultiToolsStaticMock.when(UltiTools::getInstance).thenReturn(mockUltiTools);
         lenient().when(mockUltiTools.getConfig()).thenReturn(mockConfig);
         lenient().when(mockUltiTools.getLogger()).thenReturn(mockLogger);
         lenient().when(mockUltiTools.i18n(anyString())).thenAnswer(inv -> inv.getArgument(0));
+        // Used only by tests that call getOperator(); lenient() so tests that don't need it
+        // (constructor/getStoreType/getDataSource/destroyAllOperators tests) aren't flagged for an
+        // unused stub under Mockito's strict-stubs default.
+        lenient().when(mockPlugin.getPluginName()).thenReturn("test-plugin");
     }
 
     @AfterEach
@@ -142,7 +132,6 @@ class MysqlDataStoreTest {
         if (ultiToolsStaticMock != null) {
             ultiToolsStaticMock.close();
         }
-        clearStaticCache();
     }
 
     @Nested
@@ -329,6 +318,34 @@ class MysqlDataStoreTest {
         }
 
         @Test
+        @DisplayName("两个插件请求同一实体类应该得到互不相同的 operator (SILENT-04)")
+        void shouldCreateDifferentOperatorsForDifferentPluginsSameEntity() {
+            // Arrange - pins T-02-EOP-1's mitigation: the operator cache key now includes the
+            // requesting plugin's identity, not only the entity class, so two plugins asking for
+            // the same @Table entity no longer share one MysqlDataOperator (and, through it, one
+            // another's rows).
+            setupMysqlConfig();
+            UltiToolsPlugin otherPlugin = mock(UltiToolsPlugin.class);
+            when(otherPlugin.getPluginName()).thenReturn("other-plugin");
+
+            try (MockedConstruction<HikariDataSource> hikariMock =
+                    mockConstruction(HikariDataSource.class);
+                 MockedConstruction<MysqlDataOperator> operatorMock =
+                    mockConstruction(MysqlDataOperator.class)) {
+
+                MysqlDataStore store = new MysqlDataStore();
+
+                // Act
+                DataOperator<TestDataEntity> operatorForFirstPlugin = store.getOperator(mockPlugin, TestDataEntity.class);
+                DataOperator<TestDataEntity> operatorForOtherPlugin = store.getOperator(otherPlugin, TestDataEntity.class);
+
+                // Assert
+                assertThat(operatorForFirstPlugin).isNotSameAs(operatorForOtherPlugin);
+                assertThat(operatorMock.constructed()).hasSize(2);
+            }
+        }
+
+        @Test
         @DisplayName("应该正确传递 DataSource 给 MysqlDataOperator")
         void shouldPassDataSourceToMysqlDataOperator() {
             // Arrange
@@ -375,6 +392,31 @@ class MysqlDataStoreTest {
 
                 // Assert
                 verify(mockDataSource).close();
+            }
+        }
+
+        @Test
+        @DisplayName("应该清空 operator 缓存")
+        void shouldClearOperatorCache() {
+            // Arrange
+            setupMysqlConfig();
+
+            try (MockedConstruction<HikariDataSource> hikariMock =
+                    mockConstruction(HikariDataSource.class);
+                 MockedConstruction<MysqlDataOperator> operatorMock =
+                    mockConstruction(MysqlDataOperator.class)) {
+
+                MysqlDataStore store = new MysqlDataStore();
+                DataOperator<TestDataEntity> before = store.getOperator(mockPlugin, TestDataEntity.class);
+
+                // Act
+                store.destroyAllOperators();
+                DataOperator<TestDataEntity> after = store.getOperator(mockPlugin, TestDataEntity.class);
+
+                // Assert - a fresh operator is built, proving the cache was actually emptied rather
+                // than merely surviving destroyAllOperators() untouched.
+                assertThat(after).isNotSameAs(before);
+                assertThat(operatorMock.constructed()).hasSize(2);
             }
         }
 
@@ -477,20 +519,23 @@ class MysqlDataStoreTest {
     }
 
     @Nested
-    @DisplayName("静态缓存测试")
+    @DisplayName("实例级缓存测试 (SILENT-04 修复后)")
     class StaticCacheTests {
 
         @Test
-        @DisplayName("不同 MysqlDataStore 实例应该共享 operator 缓存")
-        void differentStoreInstancesShouldShareOperatorCache() {
-            // Arrange
+        @DisplayName("不同 MysqlDataStore 实例不应该共享 operator 缓存")
+        void differentStoreInstancesShouldNotShareOperatorCache() {
+            // Arrange - dataOperatorMap 从 Task 3 (SILENT-04) 起是实例字段，不再是 static，
+            // 所以两个独立的 store 实例各自持有自己的缓存。生产环境中 DataStoreManager 只会注册
+            // 一个 MysqlDataStore 实例，所以这个场景不会在真实运行时出现，但它记录了这个
+            // 有意为之的行为变化。
             setupMysqlConfig();
 
-            try (MockedConstruction<HikariDataSource> hikariMock = 
+            try (MockedConstruction<HikariDataSource> hikariMock =
                     mockConstruction(HikariDataSource.class);
-                 MockedConstruction<MysqlDataOperator> operatorMock = 
+                 MockedConstruction<MysqlDataOperator> operatorMock =
                     mockConstruction(MysqlDataOperator.class)) {
-                
+
                 MysqlDataStore store1 = new MysqlDataStore();
                 MysqlDataStore store2 = new MysqlDataStore();
 
@@ -498,10 +543,10 @@ class MysqlDataStoreTest {
                 DataOperator<TestDataEntity> operator1 = store1.getOperator(mockPlugin, TestDataEntity.class);
                 DataOperator<TestDataEntity> operator2 = store2.getOperator(mockPlugin, TestDataEntity.class);
 
-                // Assert - 由于静态缓存，两个 store 应该返回同一个 operator
-                assertThat(operator1).isSameAs(operator2);
-                // 只创建了一个 MysqlDataOperator
-                assertThat(operatorMock.constructed()).hasSize(1);
+                // Assert - each store instance has its own operator cache
+                assertThat(operator1).isNotSameAs(operator2);
+                // Two independent stores -> two MysqlDataOperator instances
+                assertThat(operatorMock.constructed()).hasSize(2);
             }
         }
     }

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataStoreTest.java
@@ -729,22 +729,31 @@ class MysqlDataStoreTest {
         }
 
         @Test
-        @DisplayName("框架自身的核心数据文件夹在 getOperator(File, Class) 上仍然豁免")
-        void shouldExemptFrameworkCoreFolderViaFileOverload() {
+        @DisplayName("框架自身的核心数据文件夹在 getOperator(File, Class) 上不再豁免 -- CR-01, 02-13")
+        void shouldRefuseFrameworkCoreFolderViaFileOverload() {
             setupMysqlConfig();
             // mockUltiTools.getDataFolder() is stubbed to tempDir in setUp() -- passing tempDir
-            // itself is exactly the framework-core-folder sentinel checkOwnership(File, Class)
-            // exempts. No PluginManager stub needed for this call to succeed.
-
+            // itself used to be exactly the framework-core-folder sentinel checkOwnership(File,
+            // Class) exempted (02-07/02-12). CR-01 (02-REVIEW.md): on MySQL this was a genuine,
+            // unauthenticated read/write bypass -- MysqlDataStore has exactly one global
+            // HikariDataSource for the whole server, so the operator this call used to receive
+            // read and wrote the same real @Table-named table the legitimate owning plugin uses,
+            // with zero ownership verification anywhere on the path. 02-13 deletes the exemption;
+            // no PluginManager stub is registered here, so the call must refuse exactly like any
+            // other unregistered folder.
             try (MockedConstruction<HikariDataSource> hikariMock = mockConstruction(HikariDataSource.class);
                  MockedConstruction<MysqlDataOperator> operatorMock = mockConstruction(MysqlDataOperator.class)) {
 
                 MysqlDataStore store = new MysqlDataStore();
 
-                DataOperator<TestDataEntity> operator = store.getOperator(tempDir, TestDataEntity.class);
+                assertThatThrownBy(() -> store.getOperator(tempDir, TestDataEntity.class))
+                        .isInstanceOf(DataAccessException.class)
+                        .extracting(e -> ((DataAccessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ENTITY_NOT_OWNED);
 
-                assertThat(operator).isNotNull();
-                assertThat(operatorMock.constructed()).hasSize(1);
+                assertThat(operatorMock.constructed())
+                        .as("a refused call must not have built an operator against the shared MySQL table")
+                        .isEmpty();
             }
         }
     }

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataStoreTest.java
@@ -2,6 +2,7 @@ package com.ultikits.ultitools.interfaces.impl.data.mysql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -22,6 +24,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
@@ -32,7 +35,10 @@ import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.annotations.Column;
 import com.ultikits.ultitools.annotations.Table;
+import com.ultikits.ultitools.exceptions.DataAccessException;
+import com.ultikits.ultitools.exceptions.ErrorCode;
 import com.ultikits.ultitools.interfaces.DataOperator;
+import com.ultikits.ultitools.manager.PluginManager;
 import com.zaxxer.hikari.HikariDataSource;
 
 import lombok.Data;
@@ -57,6 +63,12 @@ class MysqlDataStoreTest {
 
     @Mock
     private UltiToolsPlugin mockPlugin;
+
+    @Mock
+    private PluginManager mockPluginManager;
+
+    @TempDir
+    File tempDir;
 
     private MockedStatic<UltiTools> ultiToolsStaticMock;
 
@@ -125,6 +137,18 @@ class MysqlDataStoreTest {
         // (constructor/getStoreType/getDataSource/destroyAllOperators tests) aren't flagged for an
         // unused stub under Mockito's strict-stubs default.
         lenient().when(mockPlugin.getPluginName()).thenReturn("test-plugin");
+
+        // 02-12 Task 2: every getOperator(UltiToolsPlugin, Class) call now runs checkOwnership()
+        // first. Default every entity to "owned by whoever mockPlugin currently claims to be" --
+        // an Answer, not a fixed thenReturn, so it stays correct across the different plugin names
+        // individual tests stub onto mockPlugin. Tests exercising a genuine ownership refusal
+        // override this with a more specific, entity-scoped stub (Mockito: the more specific /
+        // later-registered stub wins for a matching call). lenient() for the same reason as above.
+        lenient().when(mockUltiTools.getPluginManager()).thenReturn(mockPluginManager);
+        lenient().when(mockPluginManager.findOwningPlugin(any())).thenAnswer(inv -> mockPlugin.getPluginName());
+        // Backs checkOwnership(File, Class)'s framework-core-folder exemption; lenient() since
+        // only the File-overload tests below actually reach that check.
+        lenient().when(mockUltiTools.getDataFolder()).thenReturn(tempDir);
     }
 
     @AfterEach
@@ -318,13 +342,18 @@ class MysqlDataStoreTest {
         }
 
         @Test
-        @DisplayName("两个插件请求同一实体类应该得到互不相同的 operator (SILENT-04)")
-        void shouldCreateDifferentOperatorsForDifferentPluginsSameEntity() {
-            // Arrange - pins T-02-EOP-1's mitigation: the operator cache key now includes the
-            // requesting plugin's identity, not only the entity class, so two plugins asking for
-            // the same @Table entity no longer share one MysqlDataOperator (and, through it, one
-            // another's rows).
+        @DisplayName("两个插件请求同一实体类：拥有它的插件成功，另一个插件被拒绝 (02-12 更新，取代 SILENT-04 旧断言)")
+        void secondPluginRequestingFirstPluginsEntityShouldBeRefused() {
+            // Was: shouldCreateDifferentOperatorsForDifferentPluginsSameEntity, which asserted that
+            // two DIFFERENT plugins both requesting the SAME @Table entity class each got their own
+            // operator. Under 02-12's ownership model an entity has exactly one owner (02-07's
+            // PluginManager.findOwningPlugin registry, first-registration-wins), so that scenario is
+            // no longer a legitimate one to keep silently working -- it is exactly the case D-14
+            // exists to refuse. The composite (identity, entity) cache key SILENT-04 introduced is
+            // still real and still exercised by shouldCreateDifferentOperatorsForDifferentEntityClasses
+            // above (one plugin, two entities).
             setupMysqlConfig();
+            when(mockPluginManager.findOwningPlugin(TestDataEntity.class)).thenReturn("test-plugin");
             UltiToolsPlugin otherPlugin = mock(UltiToolsPlugin.class);
             when(otherPlugin.getPluginName()).thenReturn("other-plugin");
 
@@ -335,13 +364,18 @@ class MysqlDataStoreTest {
 
                 MysqlDataStore store = new MysqlDataStore();
 
-                // Act
-                DataOperator<TestDataEntity> operatorForFirstPlugin = store.getOperator(mockPlugin, TestDataEntity.class);
-                DataOperator<TestDataEntity> operatorForOtherPlugin = store.getOperator(otherPlugin, TestDataEntity.class);
+                // Act - the owning plugin succeeds...
+                DataOperator<TestDataEntity> operatorForOwner = store.getOperator(mockPlugin, TestDataEntity.class);
 
-                // Assert
-                assertThat(operatorForFirstPlugin).isNotSameAs(operatorForOtherPlugin);
-                assertThat(operatorMock.constructed()).hasSize(2);
+                // ...but a different plugin requesting the same entity is refused, and the refusal
+                // has not created a second operator as a side effect.
+                assertThatThrownBy(() -> store.getOperator(otherPlugin, TestDataEntity.class))
+                        .isInstanceOf(DataAccessException.class)
+                        .extracting(e -> ((DataAccessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ENTITY_NOT_OWNED);
+
+                assertThat(operatorForOwner).isNotNull();
+                assertThat(operatorMock.constructed()).hasSize(1);
             }
         }
 
@@ -658,6 +692,59 @@ class MysqlDataStoreTest {
 
                 // Assert
                 assertThat(store).isNotNull();
+            }
+        }
+    }
+
+    /**
+     * 02-12 Task 2: {@code checkOwnership} is now called as the first statement of both legacy
+     * {@code getOperator} overrides -- closing the residual bypass 02-07 disclosed (D-14/D-18). A
+     * refused call must not have created an operator as a side effect.
+     */
+    @Nested
+    @DisplayName("所有权校验测试 (D-14/D-18, 02-12 Task 2)")
+    class OwnershipTests {
+
+        @Test
+        @DisplayName("getOperator(File, Class) 应该拒绝其他插件的未注册文件夹，且不产生任何 operator 缓存副作用")
+        void shouldRefuseUnregisteredFolderViaFileOverloadWithNoSideEffects() {
+            setupMysqlConfig();
+            File someOtherPluginsFolder = new File(tempDir, "some-other-plugin");
+            when(mockPluginManager.findScopeForDataFolder(someOtherPluginsFolder)).thenReturn(null);
+
+            try (MockedConstruction<HikariDataSource> hikariMock = mockConstruction(HikariDataSource.class);
+                 MockedConstruction<MysqlDataOperator> operatorMock = mockConstruction(MysqlDataOperator.class)) {
+
+                MysqlDataStore store = new MysqlDataStore();
+
+                assertThatThrownBy(() -> store.getOperator(someOtherPluginsFolder, TestDataEntity.class))
+                        .isInstanceOf(DataAccessException.class)
+                        .extracting(e -> ((DataAccessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ENTITY_NOT_OWNED);
+
+                assertThat(operatorMock.constructed())
+                        .as("a refused call must not have built an operator")
+                        .isEmpty();
+            }
+        }
+
+        @Test
+        @DisplayName("框架自身的核心数据文件夹在 getOperator(File, Class) 上仍然豁免")
+        void shouldExemptFrameworkCoreFolderViaFileOverload() {
+            setupMysqlConfig();
+            // mockUltiTools.getDataFolder() is stubbed to tempDir in setUp() -- passing tempDir
+            // itself is exactly the framework-core-folder sentinel checkOwnership(File, Class)
+            // exempts. No PluginManager stub needed for this call to succeed.
+
+            try (MockedConstruction<HikariDataSource> hikariMock = mockConstruction(HikariDataSource.class);
+                 MockedConstruction<MysqlDataOperator> operatorMock = mockConstruction(MysqlDataOperator.class)) {
+
+                MysqlDataStore store = new MysqlDataStore();
+
+                DataOperator<TestDataEntity> operator = store.getOperator(tempDir, TestDataEntity.class);
+
+                assertThat(operator).isNotNull();
+                assertThat(operatorMock.constructed()).hasSize(1);
             }
         }
     }

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataOperatorTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataOperatorTest.java
@@ -3,23 +3,34 @@ package com.ultikits.ultitools.interfaces.impl.data.sqlite;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.lang.reflect.Field;
+import java.nio.file.Path;
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.sql.DataSource;
 
+import org.apache.commons.dbutils.QueryRunner;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
 
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
 import com.ultikits.ultitools.annotations.Column;
 import com.ultikits.ultitools.annotations.Table;
+import com.ultikits.ultitools.entities.Comparison;
 import com.ultikits.ultitools.entities.WhereCondition;
+import com.ultikits.ultitools.exceptions.DataAccessException;
 import com.ultikits.ultitools.interfaces.DataOperator.LikeType;
+import com.ultikits.ultitools.interfaces.impl.data.AbstractRelationalDataOperator;
+import com.ultikits.ultitools.interfaces.impl.data.json.SimpleJsonDataOperator;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
@@ -289,6 +300,211 @@ class SQLiteDataOperatorTest {
             operator.delById("del-2");
 
             assertThat(operator.exist(entity)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("Comparison 语义测试（GREATER 等运算符跨后端一致，WIRE-04）")
+    class ComparisonSemanticsTests {
+
+        @BeforeEach
+        void insertNumericRows() {
+            insertNumeric("cmp-1", 1);
+            insertNumeric("cmp-5", 5);
+            insertNumeric("cmp-9", 9);
+        }
+
+        private void insertNumeric(String id, int age) {
+            TestEntity entity = new TestEntity();
+            entity.setId(id);
+            entity.setName("Entity" + age);
+            entity.setAge(age);
+            operator.insert(entity);
+        }
+
+        @Test
+        @DisplayName("Test A: getAll(GREATER) 只返回大于阈值的行，而不是等于阈值")
+        void getAllGreaterShouldReturnOnlyRowsAboveThreshold() {
+            List<TestEntity> result = operator.getAll(
+                    WhereCondition.builder().column("age").value(5).comparison(Comparison.GREATER).build());
+
+            assertThat(result).extracting(TestEntity::getAge).containsExactly(9);
+        }
+
+        @Test
+        @DisplayName("Test B: SQLite 与 SimpleJsonDataOperator 在同一个 GREATER 条件下返回同一行集")
+        void greaterShouldAgreeAcrossSqliteAndJson(@TempDir Path jsonDir) {
+            SimpleJsonDataOperator<TestEntity> json =
+                    new SimpleJsonDataOperator<>(jsonDir.toFile().getAbsolutePath(), TestEntity.class);
+            insertNumericInto(json, "json-cmp-1", 1);
+            insertNumericInto(json, "json-cmp-5", 5);
+            insertNumericInto(json, "json-cmp-9", 9);
+
+            WhereCondition condition =
+                    WhereCondition.builder().column("age").value(5).comparison(Comparison.GREATER).build();
+
+            List<Integer> sqliteAges = operator.getAll(condition).stream()
+                    .map(TestEntity::getAge).collect(Collectors.toList());
+            List<Integer> jsonAges = json.getAll(condition).stream()
+                    .map(TestEntity::getAge).collect(Collectors.toList());
+
+            assertThat(sqliteAges)
+                    .as("同一个 GREATER 条件，SQLite 与 JSON 后端必须返回同一批年龄值")
+                    .containsExactlyInAnyOrderElementsOf(jsonAges)
+                    .containsExactly(9);
+        }
+
+        private void insertNumericInto(SimpleJsonDataOperator<TestEntity> json, String id, int age) {
+            TestEntity entity = new TestEntity();
+            entity.setId(id);
+            entity.setName("Entity" + age);
+            entity.setAge(age);
+            json.insert(entity);
+        }
+
+        @Test
+        @DisplayName("Test C: exist(GREATER) 与 getAll 的 GREATER 语义一致")
+        void existGreaterShouldMatchGetAllSemantics() {
+            assertThat(operator.exist(
+                    WhereCondition.builder().column("age").value(5).comparison(Comparison.GREATER).build()))
+                    .as("存在一行 age=9 > 5")
+                    .isTrue();
+
+            assertThat(operator.exist(
+                    WhereCondition.builder().column("age").value(9).comparison(Comparison.GREATER).build()))
+                    .as("没有任何行 age > 9")
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("Test C: page(GREATER) 与 getAll 的 GREATER 语义一致")
+        void pageGreaterShouldMatchGetAllSemantics() {
+            List<TestEntity> result = operator.page(1, 10,
+                    WhereCondition.builder().column("age").value(5).comparison(Comparison.GREATER).build());
+
+            assertThat(result).extracting(TestEntity::getAge).containsExactly(9);
+        }
+    }
+
+    @Nested
+    @DisplayName("LIKE 语义测试（INCLUDE/STARTSWITH/ENDSWITH 与 JSON 后端一致，WIRE-04）")
+    class LikeComparisonTests {
+
+        @BeforeEach
+        void insertNameRows() {
+            insertNamed("like-cmp-1", "TestEntity");
+            insertNamed("like-cmp-2", "AnotherTest");
+        }
+
+        private void insertNamed(String id, String name) {
+            TestEntity entity = new TestEntity();
+            entity.setId(id);
+            entity.setName(name);
+            operator.insert(entity);
+        }
+
+        @Test
+        @DisplayName("Test D: INCLUDE 匹配子串出现在任意位置")
+        void includeShouldMatchSubstringAnywhere() {
+            List<TestEntity> result = operator.getAll(
+                    WhereCondition.builder().column("name").value("Test").comparison(Comparison.INCLUDE).build());
+
+            assertThat(result).extracting(TestEntity::getName)
+                    .containsExactlyInAnyOrder("TestEntity", "AnotherTest");
+        }
+
+        @Test
+        @DisplayName("Test D: STARTSWITH 只匹配以该值开头的行")
+        void startswithShouldMatchPrefixOnly() {
+            List<TestEntity> result = operator.getAll(WhereCondition.builder().column("name").value("Test")
+                    .comparison(Comparison.STARTSWITH).build());
+
+            assertThat(result).extracting(TestEntity::getName).containsExactly("TestEntity");
+        }
+
+        @Test
+        @DisplayName("Test D: ENDSWITH 只匹配以该值结尾的行")
+        void endswithShouldMatchSuffixOnly() {
+            List<TestEntity> result = operator.getAll(
+                    WhereCondition.builder().column("name").value("Test").comparison(Comparison.ENDSWITH).build());
+
+            assertThat(result).extracting(TestEntity::getName).containsExactly("AnotherTest");
+        }
+    }
+
+    @Nested
+    @DisplayName("del() 零条件防护测试（SILENT-01）")
+    class DeleteGuardTests {
+
+        @BeforeEach
+        void insertThreeRows() {
+            for (int i = 1; i <= 3; i++) {
+                TestEntity entity = new TestEntity();
+                entity.setId("guard-" + i);
+                entity.setName("Guard" + i);
+                entity.setAge(i);
+                operator.insert(entity);
+            }
+        }
+
+        private long countRows() throws Exception {
+            try (Connection conn = dataSource.getConnection();
+                 Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM test_entity")) {
+                rs.next();
+                return rs.getLong(1);
+            }
+        }
+
+        @Test
+        @DisplayName("Test E: del() 零条件（varargs 空数组）抛出 DataAccessException，行数不变")
+        void delWithNoConditionsShouldThrowAndLeaveRowsUnchanged() throws Exception {
+            assertThat(countRows()).isEqualTo(3);
+
+            assertThatThrownBy(operator::del).isInstanceOf(DataAccessException.class);
+
+            assertThat(countRows())
+                    .as("表未被清空——修复前这里会变成 0")
+                    .isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("Test E: del((WhereCondition[]) null) 与零长度数组行为一致")
+        void delWithNullConditionsShouldThrowAndLeaveRowsUnchanged() throws Exception {
+            assertThatThrownBy(() -> operator.del((WhereCondition[]) null))
+                    .isInstanceOf(DataAccessException.class);
+
+            assertThat(countRows()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("Test F: 连续两次调用 del() 零条件均抛出，行数不变（守卫不是一次性 latch）")
+        void delWithNoConditionsShouldThrowTwiceInARowAndStayIdempotent() throws Exception {
+            assertThatThrownBy(operator::del).isInstanceOf(DataAccessException.class);
+            assertThatThrownBy(operator::del).isInstanceOf(DataAccessException.class);
+
+            assertThat(countRows()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("Test G: 守卫在触及 QueryRunner 之前就已生效——update 从未被调用")
+        void delWithNoConditionsShouldNeverReachQueryRunner() throws Exception {
+            QueryRunner spyRunner = Mockito.spy(new QueryRunner(dataSource));
+            Field field = AbstractRelationalDataOperator.class.getDeclaredField("queryRunner");
+            field.setAccessible(true);
+            field.set(operator, spyRunner);
+
+            assertThatThrownBy(operator::del).isInstanceOf(DataAccessException.class);
+
+            Mockito.verifyNoInteractions(spyRunner);
+        }
+
+        @Test
+        @DisplayName("Test H（正对照）: del(单条件) 仍然只删除匹配的行")
+        void delWithOneConditionShouldStillDeleteOnlyMatchingRow() throws Exception {
+            operator.del(WhereCondition.builder().column("name").value("Guard1").build());
+
+            assertThat(countRows()).isEqualTo(2);
         }
     }
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataOperatorTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataOperatorTest.java
@@ -8,12 +8,17 @@ import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.sql.DataSource;
 
 import org.apache.commons.dbutils.QueryRunner;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,7 +27,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
+import com.ultikits.ultitools.abstracts.data.AuditableDataEntity;
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
+import com.ultikits.ultitools.abstracts.data.DataEntityTest;
 import com.ultikits.ultitools.annotations.Column;
 import com.ultikits.ultitools.annotations.Table;
 import com.ultikits.ultitools.entities.Comparison;
@@ -609,6 +616,221 @@ class SQLiteDataOperatorTest {
             
             assertThatThrownBy(() -> operator.insert(entity2))
                 .isInstanceOf(RuntimeException.class);
+        }
+    }
+
+    /**
+     * SILENT-02 (02-08): {@code onCreate}/{@code onUpdate}/{@code onDelete}/{@code onLoad} were
+     * declared on {@code BaseDataEntity} but nothing in this class ever called them, and
+     * {@code AuditableDataEntity#setCurrentUser} had zero call sites -- so {@code created_at}/
+     * {@code created_by}/{@code updated_at}/{@code updated_by} were always {@code NULL} on every
+     * persisted row. Both halves are pinned here against the relational backend; the identical
+     * set is pinned against {@code SimpleJsonDataOperatorTest} so the two backends cannot diverge.
+     */
+    @Nested
+    @DisplayName("生命周期钩子测试（SILENT-02）")
+    class LifecycleHookTests {
+
+        private AbstractRelationalDataOperator<DataEntityTest.CountingAuditableEntity> hookOperator;
+
+        @BeforeEach
+        void setUpHookOperator() {
+            try (Connection conn = dataSource.getConnection();
+                 Statement stmt = conn.createStatement()) {
+                stmt.execute("DROP TABLE IF EXISTS counting_auditable_entity");
+            } catch (Exception ignored) {
+            }
+            hookOperator = new SQLiteDataOperator<>(dataSource, DataEntityTest.CountingAuditableEntity.class);
+            DataEntityTest.CountingAuditableEntity.resetCounters();
+            AuditableDataEntity.clearCurrentUser();
+        }
+
+        @AfterEach
+        void tearDownHookOperator() {
+            DataEntityTest.CountingAuditableEntity.resetCounters();
+            AuditableDataEntity.clearCurrentUser();
+        }
+
+        private DataEntityTest.CountingAuditableEntity newEntity(String label) {
+            DataEntityTest.CountingAuditableEntity entity = new DataEntityTest.CountingAuditableEntity();
+            entity.setLabel(label);
+            return entity;
+        }
+
+        private long countRows() throws Exception {
+            try (Connection conn = dataSource.getConnection();
+                 Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM counting_auditable_entity")) {
+                rs.next();
+                return rs.getLong(1);
+            }
+        }
+
+        @Test
+        @DisplayName("insert 应填充 created_at 与 created_by（此前一直是 NULL）")
+        void insertShouldPopulateCreatedAtAndCreatedBy() {
+            UUID user = UUID.randomUUID();
+            AuditableDataEntity.setCurrentUser(user);
+            DataEntityTest.CountingAuditableEntity entity = newEntity("insert-1");
+
+            hookOperator.insert(entity);
+
+            assertThat(entity.getCreatedAt()).isNotNull();
+            assertThat(entity.getCreatedBy()).isEqualTo(user);
+        }
+
+        @Test
+        @DisplayName("update 应填充 updated_at 与 updated_by（此前一直是 NULL）")
+        void updateShouldPopulateUpdatedAtAndUpdatedBy() throws Exception {
+            DataEntityTest.CountingAuditableEntity entity = newEntity("update-1");
+            hookOperator.insert(entity);
+
+            UUID user = UUID.randomUUID();
+            AuditableDataEntity.setCurrentUser(user);
+            entity.setLabel("update-1-changed");
+            hookOperator.update(entity);
+
+            assertThat(entity.getUpdatedAt()).isNotNull();
+            assertThat(entity.getUpdatedBy()).isEqualTo(user);
+        }
+
+        @Test
+        @DisplayName("insert/update/getById/delById 各自恰好触发一次对应钩子")
+        void hooksFireExactlyOnceEachForSingleEntityOperations() throws Exception {
+            DataEntityTest.CountingAuditableEntity entity = newEntity("count-1");
+
+            hookOperator.insert(entity);
+            assertThat(DataEntityTest.CountingAuditableEntity.onCreateCount()).isEqualTo(1);
+
+            entity.setLabel("count-1-updated");
+            hookOperator.update(entity);
+            assertThat(DataEntityTest.CountingAuditableEntity.onUpdateCount()).isEqualTo(1);
+
+            DataEntityTest.CountingAuditableEntity loaded = hookOperator.getById(entity.getId());
+            assertThat(loaded).isNotNull();
+            assertThat(DataEntityTest.CountingAuditableEntity.onLoadCount()).isEqualTo(1);
+
+            hookOperator.delById(entity.getId());
+            assertThat(DataEntityTest.CountingAuditableEntity.onDeleteCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("getAll/page 对返回的每个实体恰好触发一次 onLoad")
+        void getAllAndPageFireOnLoadOncePerReturnedEntity() {
+            hookOperator.insert(newEntity("load-1"));
+            hookOperator.insert(newEntity("load-2"));
+            hookOperator.insert(newEntity("load-3"));
+            DataEntityTest.CountingAuditableEntity.resetCounters();
+
+            List<DataEntityTest.CountingAuditableEntity> all = hookOperator.getAll();
+            assertThat(all).hasSize(3);
+            assertThat(DataEntityTest.CountingAuditableEntity.onLoadCount()).isEqualTo(3);
+
+            DataEntityTest.CountingAuditableEntity.resetCounters();
+            List<DataEntityTest.CountingAuditableEntity> page = hookOperator.page(1, 2);
+            assertThat(page).hasSize(2);
+            assertThat(DataEntityTest.CountingAuditableEntity.onLoadCount())
+                    .as("onLoad must fire only for the entities actually returned by the page, not every matched row")
+                    .isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("插入后立即更新：created_at 保持插入时的值，updated_at 非空")
+        void adjacentInsertThenUpdatePreservesCreatedAt() throws Exception {
+            DataEntityTest.CountingAuditableEntity entity = newEntity("adjacency-1");
+            hookOperator.insert(entity);
+            LocalDateTime createdAt = entity.getCreatedAt();
+            assertThat(createdAt).isNotNull();
+
+            entity.setLabel("adjacency-1-updated");
+            hookOperator.update(entity);
+
+            assertThat(entity.getCreatedAt()).isEqualTo(createdAt);
+            assertThat(entity.getUpdatedAt()).isNotNull();
+
+            DataEntityTest.CountingAuditableEntity reloaded = hookOperator.getById(entity.getId());
+            assertThat(reloaded.getCreatedAt()).isEqualTo(createdAt);
+            assertThat(reloaded.getUpdatedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("insertAll(空列表) 不触发任何钩子，也不写入任何行")
+        void insertAllEmptyFiresNoHooksAndWritesNoRows() throws Exception {
+            hookOperator.insertAll(Collections.emptyList());
+
+            assertThat(DataEntityTest.CountingAuditableEntity.onCreateCount()).isEqualTo(0);
+            assertThat(countRows()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("未设置当前用户时，created_by/updated_by 写入 SQL NULL 而非占位字符串")
+        void nullActorWritesSqlNullNotPlaceholderString() throws Exception {
+            DataEntityTest.CountingAuditableEntity entity = newEntity("null-actor-1");
+            hookOperator.insert(entity);
+
+            try (Connection conn = dataSource.getConnection();
+                 Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery(
+                         "SELECT created_by, updated_by FROM counting_auditable_entity WHERE id = '"
+                                 + entity.getId() + "'")) {
+                assertThat(rs.next()).isTrue();
+                assertThat(rs.getObject("created_by")).isNull();
+                assertThat(rs.getObject("updated_by")).isNull();
+                // Java's null-to-string coercion for a missing reference would render as the
+                // 4-character literal "null" -- assert the column holds no such string either.
+                assertThat(rs.getString("created_by")).isNotEqualTo("null");
+                assertThat(rs.getString("updated_by")).isNotEqualTo("null");
+            }
+        }
+
+        @Test
+        @DisplayName("insertAll(3 个实体) 按列表顺序恰好触发 3 次 onCreate")
+        void insertAllFiresOnCreateThreeTimesInOrder() {
+            DataEntityTest.CountingAuditableEntity e1 = newEntity("batch-1");
+            e1.setId("batch-id-1");
+            DataEntityTest.CountingAuditableEntity e2 = newEntity("batch-2");
+            e2.setId("batch-id-2");
+            DataEntityTest.CountingAuditableEntity e3 = newEntity("batch-3");
+            e3.setId("batch-id-3");
+
+            hookOperator.insertAll(Arrays.asList(e1, e2, e3));
+
+            assertThat(DataEntityTest.CountingAuditableEntity.onCreateCount()).isEqualTo(3);
+            assertThat(DataEntityTest.CountingAuditableEntity.onCreateOrder())
+                    .containsExactly("batch-id-1", "batch-id-2", "batch-id-3");
+        }
+
+        @Test
+        @DisplayName("updateAll(3 个实体) 按列表顺序恰好触发 3 次 onUpdate")
+        void updateAllFiresOnUpdateThreeTimesInOrder() throws Exception {
+            DataEntityTest.CountingAuditableEntity e1 = newEntity("batch-u-1");
+            e1.setId("batch-u-id-1");
+            DataEntityTest.CountingAuditableEntity e2 = newEntity("batch-u-2");
+            e2.setId("batch-u-id-2");
+            DataEntityTest.CountingAuditableEntity e3 = newEntity("batch-u-3");
+            e3.setId("batch-u-id-3");
+            hookOperator.insertAll(Arrays.asList(e1, e2, e3));
+            DataEntityTest.CountingAuditableEntity.resetCounters();
+
+            hookOperator.updateAll(Arrays.asList(e1, e2, e3));
+
+            assertThat(DataEntityTest.CountingAuditableEntity.onUpdateCount()).isEqualTo(3);
+            assertThat(DataEntityTest.CountingAuditableEntity.onUpdateOrder())
+                    .containsExactly("batch-u-id-1", "batch-u-id-2", "batch-u-id-3");
+        }
+
+        @Test
+        @DisplayName("del(WhereCondition...) 按条件删除，但不会触发 onDelete（未实体化被删行）")
+        void delByConditionDoesNotFireOnDelete() {
+            DataEntityTest.CountingAuditableEntity entity = newEntity("del-condition-1");
+            hookOperator.insert(entity);
+            DataEntityTest.CountingAuditableEntity.resetCounters();
+
+            hookOperator.del(WhereCondition.builder().column("label").value("del-condition-1").build());
+
+            assertThat(DataEntityTest.CountingAuditableEntity.onDeleteCount())
+                    .as("del(WhereCondition...) deletes by predicate without materialising rows -- it must not fire onDelete")
+                    .isEqualTo(0);
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataOperatorTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataOperatorTest.java
@@ -509,6 +509,49 @@ class SQLiteDataOperatorTest {
     }
 
     @Nested
+    @DisplayName("列名白名单测试（T-02-SQLI-1）")
+    class ColumnValidationTests {
+
+        @BeforeEach
+        void insertOneRow() {
+            TestEntity entity = new TestEntity();
+            entity.setId("colval-1");
+            entity.setName("ColVal");
+            entity.setAge(20);
+            operator.insert(entity);
+        }
+
+        @Test
+        @DisplayName("未知列名在 getAll 上被拒绝，消息包含列名与实体类型")
+        void getAllWithUnknownColumnShouldBeRejected() {
+            assertThatThrownBy(() -> operator.getAll(
+                    WhereCondition.builder().column("no_such_column").value("x").build()))
+                    .isInstanceOf(DataAccessException.class)
+                    .hasMessageContaining("no_such_column")
+                    .hasMessageContaining(TestEntity.class.getName());
+        }
+
+        @Test
+        @DisplayName("未知列名在 exist/page/del 上同样被拒绝")
+        void unknownColumnShouldBeRejectedOnExistPageAndDel() {
+            WhereCondition badCondition = WhereCondition.builder().column("no_such_column").value("x").build();
+
+            assertThatThrownBy(() -> operator.exist(badCondition)).isInstanceOf(DataAccessException.class);
+            assertThatThrownBy(() -> operator.page(1, 10, badCondition)).isInstanceOf(DataAccessException.class);
+            assertThatThrownBy(() -> operator.del(badCondition)).isInstanceOf(DataAccessException.class);
+        }
+
+        @Test
+        @DisplayName("正对照：真实 @Column 名不受影响")
+        void realColumnNameShouldNotBeAffected() {
+            List<TestEntity> result = operator.getAll(
+                    WhereCondition.builder().column("name").value("ColVal").build());
+
+            assertThat(result).extracting(TestEntity::getName).containsExactly("ColVal");
+        }
+    }
+
+    @Nested
     @DisplayName("update 方法测试")
     class UpdateTests {
 

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
@@ -2,6 +2,7 @@ package com.ultikits.ultitools.interfaces.impl.data.sqlite;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
@@ -33,7 +34,10 @@ import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.annotations.Column;
 import com.ultikits.ultitools.annotations.Table;
+import com.ultikits.ultitools.exceptions.DataAccessException;
+import com.ultikits.ultitools.exceptions.ErrorCode;
 import com.ultikits.ultitools.interfaces.DataOperator;
+import com.ultikits.ultitools.manager.PluginManager;
 import com.ultikits.ultitools.testutil.PoolStateAssertions;
 
 import com.zaxxer.hikari.HikariConfig;
@@ -57,6 +61,9 @@ class SQLiteDataStoreTest {
 
     @Mock
     private UltiToolsPlugin mockPlugin;
+
+    @Mock
+    private PluginManager mockPluginManager;
 
     private MockedStatic<UltiTools> ultiToolsStaticMock;
 
@@ -92,6 +99,10 @@ class SQLiteDataStoreTest {
 
     public static class NoTableAnnotationEntity extends BaseDataEntity<String> {}
 
+    @EqualsAndHashCode(callSuper = true)
+    @Table("unowned_entity")
+    public static class UnownedEntity extends BaseDataEntity<String> {}
+
     @BeforeEach
     void setUp() {
         ultiToolsStaticMock = mockStatic(UltiTools.class);
@@ -99,6 +110,15 @@ class SQLiteDataStoreTest {
         when(mockUltiTools.getDataFolder()).thenReturn(tempDir);
         // dataOperatorMap is instance-scoped since Task 2 (SILENT-03) - each test constructs its own
         // fresh SQLiteDataStore(), so there is no shared static cache left to clear here anymore.
+
+        // 02-12 Task 2: every getOperator(UltiToolsPlugin, Class) call now runs checkOwnership()
+        // first. Default every entity to "owned by whoever mockPlugin currently claims to be" --
+        // an Answer, not a fixed thenReturn, so it stays correct across the different plugin names
+        // individual tests stub onto mockPlugin. Tests exercising a genuine ownership refusal
+        // override this with a more specific, entity-scoped stub (Mockito: the more specific /
+        // later-registered stub wins for a matching call).
+        when(mockUltiTools.getPluginManager()).thenReturn(mockPluginManager);
+        when(mockPluginManager.findOwningPlugin(any())).thenAnswer(inv -> mockPlugin.getPluginName());
     }
 
     @AfterEach
@@ -404,6 +424,87 @@ class SQLiteDataStoreTest {
                 assertThat(operator).isNotNull();
                 assertThat(mockedOperator.constructed()).hasSize(1);
                 assertThat(operator).isSameAs(mockedOperator.constructed().get(0));
+            }
+        }
+    }
+
+    /**
+     * 02-12 Task 2: {@code checkOwnership} is now called as the first statement of both legacy
+     * {@code getOperator} overrides -- closing the residual bypass 02-07 disclosed (D-14/D-18).
+     * A refused call must not have created a pool, a file, or a cache entry as a side effect
+     * (asserted via {@link PoolStateAssertions} / construction counts, not merely the absence of a
+     * thrown exception).
+     */
+    @Nested
+    @DisplayName("所有权校验测试 (D-14/D-18, 02-12 Task 2)")
+    class OwnershipTests {
+
+        @Test
+        @DisplayName("getOperator(UltiToolsPlugin, Class) 应该拒绝未拥有的实体，且不产生任何连接池或缓存副作用")
+        void shouldRefuseUnownedEntityViaPluginOverloadWithNoSideEffects() {
+            when(mockPlugin.getPluginName()).thenReturn("unowned-test-plugin");
+            when(mockPluginManager.findOwningPlugin(UnownedEntity.class)).thenReturn("SomeOtherPlugin");
+            SQLiteDataStore store = new SQLiteDataStore();
+
+            try (MockedConstruction<HikariConfig> mockedConfig = mockConstruction(HikariConfig.class);
+                 MockedConstruction<HikariDataSource> mockedDataSource = mockConstruction(HikariDataSource.class);
+                 MockedConstruction<SQLiteDataOperator> mockedOperator = mockConstruction(SQLiteDataOperator.class)) {
+
+                assertThatThrownBy(() -> store.getOperator(mockPlugin, UnownedEntity.class))
+                        .isInstanceOf(DataAccessException.class)
+                        .extracting(e -> ((DataAccessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ENTITY_NOT_OWNED);
+
+                assertThat(mockedDataSource.constructed())
+                        .as("a refused call must not have built a connection pool")
+                        .isEmpty();
+                assertThat(mockedOperator.constructed())
+                        .as("a refused call must not have built an operator")
+                        .isEmpty();
+            }
+        }
+
+        @Test
+        @DisplayName("getOperator(File, Class) 应该拒绝其他插件的未注册文件夹，且不产生任何连接池或缓存副作用")
+        void shouldRefuseUnregisteredFolderViaFileOverloadWithNoSideEffects() {
+            File someOtherPluginsFolder = new File(tempDir, "some-other-plugin");
+            when(mockPluginManager.findScopeForDataFolder(someOtherPluginsFolder)).thenReturn(null);
+            SQLiteDataStore store = new SQLiteDataStore();
+
+            try (MockedConstruction<HikariConfig> mockedConfig = mockConstruction(HikariConfig.class);
+                 MockedConstruction<HikariDataSource> mockedDataSource = mockConstruction(HikariDataSource.class);
+                 MockedConstruction<SQLiteDataOperator> mockedOperator = mockConstruction(SQLiteDataOperator.class)) {
+
+                assertThatThrownBy(() -> store.getOperator(someOtherPluginsFolder, UnownedEntity.class))
+                        .isInstanceOf(DataAccessException.class)
+                        .extracting(e -> ((DataAccessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ENTITY_NOT_OWNED);
+
+                assertThat(mockedDataSource.constructed())
+                        .as("a refused call must not have built a connection pool")
+                        .isEmpty();
+                assertThat(mockedOperator.constructed())
+                        .as("a refused call must not have built an operator")
+                        .isEmpty();
+            }
+        }
+
+        @Test
+        @DisplayName("框架自身的核心数据文件夹在 getOperator(File, Class) 上仍然豁免")
+        void shouldExemptFrameworkCoreFolderViaFileOverload() {
+            // mockUltiTools.getDataFolder() is stubbed to tempDir in setUp() -- passing tempDir
+            // itself is exactly the framework-core-folder sentinel checkOwnership(File, Class)
+            // exempts. No PluginManager stub needed for this call to succeed.
+            SQLiteDataStore store = new SQLiteDataStore();
+
+            try (MockedConstruction<HikariConfig> mockedConfig = mockConstruction(HikariConfig.class);
+                 MockedConstruction<HikariDataSource> mockedDataSource = mockConstruction(HikariDataSource.class);
+                 MockedConstruction<SQLiteDataOperator> mockedOperator = mockConstruction(SQLiteDataOperator.class)) {
+
+                DataOperator<UnownedEntity> operator = store.getOperator(tempDir, UnownedEntity.class);
+
+                assertThat(operator).isNotNull();
+                assertThat(mockedOperator.constructed()).hasSize(1);
             }
         }
     }

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
@@ -352,4 +352,59 @@ class SQLiteDataStoreTest {
             assertThat(storeType).isEqualTo("sqlite");
         }
     }
+
+    /**
+     * getOperator(DataScope, Class) 所有权测试（D-14/D-17）。{@code SQLiteDataStore} 没有覆写
+     * 这个新方法（不在本计划的 files_modified 范围内），所以这里验证的是它从 {@code DataStore}
+     * 接口继承来的 default 方法本身在真实存储实现上依然生效——不是只在 stub 上生效。
+     * <p>
+     * {@link com.ultikits.ultitools.manager.DataScope#forExternal} 对 {@code manager} 包之外
+     * 是包私有的（D-17 的不可伪造凭证设计），因此这里通过反射构造 scope，与
+     * {@code PluginManagerClassScanningTest} 里访问私有方法的既有做法一致。
+     */
+    @Nested
+    @DisplayName("getOperator(DataScope, Class) 所有权测试 (D-14, 继承自 DataStore 的 default 方法)")
+    class GetOperatorDataScopeTests {
+
+        private com.ultikits.ultitools.manager.DataScope buildScope(
+                String pluginName, java.util.Set<Class<?>> ownedEntities
+        ) throws ReflectiveOperationException {
+            Class<?> dataScopeClass = com.ultikits.ultitools.manager.DataScope.class;
+            java.lang.reflect.Method factory = dataScopeClass.getDeclaredMethod(
+                    "forExternal", String.class, File.class, java.util.Set.class);
+            factory.setAccessible(true);
+            return (com.ultikits.ultitools.manager.DataScope) factory.invoke(null, pluginName, tempDir, ownedEntities);
+        }
+
+        @Test
+        @DisplayName("继承的 default 方法应该拒绝未拥有的实体")
+        void shouldRefuseUnownedEntity() throws ReflectiveOperationException {
+            SQLiteDataStore store = new SQLiteDataStore();
+            com.ultikits.ultitools.manager.DataScope scope =
+                    buildScope("Requester", java.util.Collections.emptySet());
+
+            assertThatThrownBy(() -> store.getOperator(scope, TestDataEntity.class))
+                    .isInstanceOf(com.ultikits.ultitools.exceptions.DataAccessException.class)
+                    .extracting(e -> ((com.ultikits.ultitools.exceptions.DataAccessException) e).getErrorCode())
+                    .isEqualTo(com.ultikits.ultitools.exceptions.ErrorCode.ENTITY_NOT_OWNED);
+        }
+
+        @Test
+        @DisplayName("继承的 default 方法应该为拥有的实体返回一个真实可用的操作器")
+        void shouldReturnWorkingOperatorForOwnedEntity() throws ReflectiveOperationException {
+            SQLiteDataStore store = new SQLiteDataStore();
+            com.ultikits.ultitools.manager.DataScope scope =
+                    buildScope("Owner", java.util.Collections.singleton(TestDataEntity.class));
+
+            try (MockedConstruction<HikariConfig> mockedConfig = mockConstruction(HikariConfig.class);
+                 MockedConstruction<HikariDataSource> mockedDataSource = mockConstruction(HikariDataSource.class);
+                 MockedConstruction<SQLiteDataOperator> mockedOperator = mockConstruction(SQLiteDataOperator.class)) {
+                DataOperator<TestDataEntity> operator = store.getOperator(scope, TestDataEntity.class);
+
+                assertThat(operator).isNotNull();
+                assertThat(mockedOperator.constructed()).hasSize(1);
+                assertThat(operator).isSameAs(mockedOperator.constructed().get(0));
+            }
+        }
+    }
 }

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
@@ -426,6 +426,41 @@ class SQLiteDataStoreTest {
                 assertThat(operator).isSameAs(mockedOperator.constructed().get(0));
             }
         }
+
+        /**
+         * 02-13 (CR-01/CR-03): {@code buildScope}'s folder is always {@code tempDir}, which {@code
+         * setUp()} also stubs as {@code mockUltiTools.getDataFolder()} -- i.e. every scope this
+         * nested class builds is, by {@code dbPathFor(DataScope)}'s own internal/external
+         * disambiguation, an INTERNAL scope. Before 02-13, {@code getOperator(DataScope, Class)}'s
+         * default body delegated to the public {@code getOperator(File, Class)} overload using
+         * {@code scope.getDataFolder()} directly -- which is the SAME shared core folder for every
+         * internal scope, so two different internal plugins would have resolved to the SAME {@code
+         * .db} file (02-07's stated regression, reopened as CR-01's security bypass). 02-13 routes
+         * through {@code getOperatorUnchecked}, which resolves via {@code dbPathForPlugin(scope
+         * .getPluginName())} instead -- this pins that two internal plugins still get separate
+         * files.
+         */
+        @Test
+        @DisplayName("两个内部 scope（不同插件名）不应该退化成共享同一个 .db 文件（02-07 回归防护，CR-01/02-13）")
+        void twoInternalScopesShouldNotCollapseOntoOneFile() throws ReflectiveOperationException {
+            SQLiteDataStore store = new SQLiteDataStore();
+            com.ultikits.ultitools.manager.DataScope scopeA =
+                    buildScope("InternalPluginA", java.util.Collections.singleton(TestDataEntity.class));
+            com.ultikits.ultitools.manager.DataScope scopeB =
+                    buildScope("InternalPluginB", java.util.Collections.singleton(TestDataEntity.class));
+
+            try (MockedConstruction<HikariConfig> mockedConfig = mockConstruction(HikariConfig.class);
+                 MockedConstruction<HikariDataSource> mockedDataSource = mockConstruction(HikariDataSource.class);
+                 MockedConstruction<SQLiteDataOperator> mockedOperator = mockConstruction(SQLiteDataOperator.class)) {
+                DataOperator<TestDataEntity> operatorA = store.getOperator(scopeA, TestDataEntity.class);
+                DataOperator<TestDataEntity> operatorB = store.getOperator(scopeB, TestDataEntity.class);
+
+                assertThat(operatorA).isNotSameAs(operatorB);
+                assertThat(mockedDataSource.constructed())
+                        .as("two internal plugins must each get their own connection pool/file, not share one")
+                        .hasSize(2);
+            }
+        }
     }
 
     /**

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
@@ -490,21 +490,34 @@ class SQLiteDataStoreTest {
         }
 
         @Test
-        @DisplayName("框架自身的核心数据文件夹在 getOperator(File, Class) 上仍然豁免")
-        void shouldExemptFrameworkCoreFolderViaFileOverload() {
+        @DisplayName("框架自身的核心数据文件夹在 getOperator(File, Class) 上不再豁免 -- CR-01, 02-13")
+        void shouldRefuseFrameworkCoreFolderViaFileOverload() {
             // mockUltiTools.getDataFolder() is stubbed to tempDir in setUp() -- passing tempDir
-            // itself is exactly the framework-core-folder sentinel checkOwnership(File, Class)
-            // exempts. No PluginManager stub needed for this call to succeed.
+            // itself used to be exactly the framework-core-folder sentinel checkOwnership(File,
+            // Class) exempted (D-14/D-17, 02-07/02-12). CR-01 (02-REVIEW.md): that exemption was
+            // keyed purely on a value any caller can obtain (UltiTools#getDataFolder() is public
+            // in the published jar), not on any credential -- so any code sharing the JVM could
+            // reach another module's real MySQL table through it. 02-13 deletes the exemption; no
+            // PluginManager stub is registered here, so the reverse lookup finds no scope for the
+            // core folder either, and the call must refuse exactly like any other unregistered
+            // folder -- not silently succeed.
             SQLiteDataStore store = new SQLiteDataStore();
 
             try (MockedConstruction<HikariConfig> mockedConfig = mockConstruction(HikariConfig.class);
                  MockedConstruction<HikariDataSource> mockedDataSource = mockConstruction(HikariDataSource.class);
                  MockedConstruction<SQLiteDataOperator> mockedOperator = mockConstruction(SQLiteDataOperator.class)) {
 
-                DataOperator<UnownedEntity> operator = store.getOperator(tempDir, UnownedEntity.class);
+                assertThatThrownBy(() -> store.getOperator(tempDir, UnownedEntity.class))
+                        .isInstanceOf(DataAccessException.class)
+                        .extracting(e -> ((DataAccessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ENTITY_NOT_OWNED);
 
-                assertThat(operator).isNotNull();
-                assertThat(mockedOperator.constructed()).hasSize(1);
+                assertThat(mockedDataSource.constructed())
+                        .as("a refused call must not have built a connection pool")
+                        .isEmpty();
+                assertThat(mockedOperator.constructed())
+                        .as("a refused call must not have built an operator")
+                        .isEmpty();
             }
         }
     }

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
@@ -404,9 +404,9 @@ class SQLiteDataStoreTest {
                     buildScope("Requester", java.util.Collections.emptySet());
 
             assertThatThrownBy(() -> store.getOperator(scope, TestDataEntity.class))
-                    .isInstanceOf(com.ultikits.ultitools.exceptions.DataAccessException.class)
-                    .extracting(e -> ((com.ultikits.ultitools.exceptions.DataAccessException) e).getErrorCode())
-                    .isEqualTo(com.ultikits.ultitools.exceptions.ErrorCode.ENTITY_NOT_OWNED);
+                    .isInstanceOf(DataAccessException.class)
+                    .extracting(e -> ((DataAccessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.ENTITY_NOT_OWNED);
         }
 
         @Test

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
@@ -97,16 +97,8 @@ class SQLiteDataStoreTest {
         ultiToolsStaticMock = mockStatic(UltiTools.class);
         ultiToolsStaticMock.when(UltiTools::getInstance).thenReturn(mockUltiTools);
         when(mockUltiTools.getDataFolder()).thenReturn(tempDir);
-        
-        // 清空静态缓存
-        try {
-            Field field = SQLiteDataStore.class.getDeclaredField("dataOperatorMap");
-            field.setAccessible(true); // NOPMD
-            @SuppressWarnings("unchecked")
-            Map<Class<?>, DataOperator<?>> map = (Map<Class<?>, DataOperator<?>>) field.get(null);
-            map.clear();
-        } catch (Exception ignored) {
-        }
+        // dataOperatorMap is instance-scoped since Task 2 (SILENT-03) - each test constructs its own
+        // fresh SQLiteDataStore(), so there is no shared static cache left to clear here anymore.
     }
 
     @AfterEach
@@ -134,26 +126,23 @@ class SQLiteDataStoreTest {
         @Test
         @DisplayName("应该成功获取带 @Table 注解的实体的 DataOperator")
         void shouldGetOperatorForAnnotatedEntity() {
-            // Arrange
-            DataSource h2DataSource = createH2DataSource();
+            // Arrange - dataOperatorMap is instance-scoped and keyed by a private composite type
+            // since Task 2 (SILENT-03), so this drives the real getOperator() path with
+            // HikariConfig/HikariDataSource/SQLiteDataOperator construction mocked out (the SQLite
+            // JDBC driver is not on the test classpath - see PoolStateTests for why).
+            when(mockPlugin.getPluginName()).thenReturn("annotated-entity-plugin");
             SQLiteDataStore store = new SQLiteDataStore();
-            
-            try {
-                SQLiteDataOperator<TestDataEntity> h2Operator = new SQLiteDataOperator<>(h2DataSource, TestDataEntity.class);
-                Field field = SQLiteDataStore.class.getDeclaredField("dataOperatorMap");
-                field.setAccessible(true); // NOPMD
-                @SuppressWarnings("unchecked")
-                Map<Class<?>, DataOperator<?>> map = (Map<Class<?>, DataOperator<?>>) field.get(null);
-                map.put(TestDataEntity.class, h2Operator);
-                
+
+            try (MockedConstruction<HikariConfig> mockedConfig = mockConstruction(HikariConfig.class);
+                 MockedConstruction<HikariDataSource> mockedDataSource = mockConstruction(HikariDataSource.class);
+                 MockedConstruction<SQLiteDataOperator> mockedOperator = mockConstruction(SQLiteDataOperator.class)) {
                 // Act
                 DataOperator<TestDataEntity> operator = store.getOperator(mockPlugin, TestDataEntity.class);
 
                 // Assert
                 assertThat(operator).isNotNull();
-                assertThat(operator).isSameAs(h2Operator);
-            } catch (Exception e) {
-                throw new IllegalStateException(e);
+                assertThat(mockedOperator.constructed()).hasSize(1);
+                assertThat(operator).isSameAs(mockedOperator.constructed().get(0));
             }
         }
 
@@ -173,25 +162,19 @@ class SQLiteDataStoreTest {
         @DisplayName("应该返回缓存的 DataOperator 实例")
         void shouldReturnCachedOperator() {
             // Arrange
-            DataSource h2DataSource = createH2DataSource();
+            when(mockPlugin.getPluginName()).thenReturn("cached-operator-plugin");
             SQLiteDataStore store = new SQLiteDataStore();
-            
-            try {
-                SQLiteDataOperator<TestDataEntity> h2Operator = new SQLiteDataOperator<>(h2DataSource, TestDataEntity.class);
-                Field field = SQLiteDataStore.class.getDeclaredField("dataOperatorMap");
-                field.setAccessible(true); // NOPMD
-                @SuppressWarnings("unchecked")
-                Map<Class<?>, DataOperator<?>> map = (Map<Class<?>, DataOperator<?>>) field.get(null);
-                map.put(TestDataEntity.class, h2Operator);
 
+            try (MockedConstruction<HikariConfig> mockedConfig = mockConstruction(HikariConfig.class);
+                 MockedConstruction<HikariDataSource> mockedDataSource = mockConstruction(HikariDataSource.class);
+                 MockedConstruction<SQLiteDataOperator> mockedOperator = mockConstruction(SQLiteDataOperator.class)) {
                 // Act
                 DataOperator<TestDataEntity> operator1 = store.getOperator(mockPlugin, TestDataEntity.class);
                 DataOperator<TestDataEntity> operator2 = store.getOperator(mockPlugin, TestDataEntity.class);
 
                 // Assert
                 assertThat(operator1).isSameAs(operator2);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+                assertThat(mockedOperator.constructed()).hasSize(1);
             }
         }
 
@@ -199,27 +182,21 @@ class SQLiteDataStoreTest {
         @DisplayName("应该为不同的实体类返回不同的 DataOperator")
         void shouldReturnDifferentOperatorsForDifferentEntities() {
             // Arrange
-            DataSource h2DataSource = createH2DataSource();
+            when(mockPlugin.getPluginName()).thenReturn("different-entities-plugin");
             SQLiteDataStore store = new SQLiteDataStore();
-            
-            try {
-                SQLiteDataOperator<TestDataEntity> h2Operator1 = new SQLiteDataOperator<>(h2DataSource, TestDataEntity.class);
-                SQLiteDataOperator<AnotherDataEntity> h2Operator2 = new SQLiteDataOperator<>(h2DataSource, AnotherDataEntity.class);
-                Field field = SQLiteDataStore.class.getDeclaredField("dataOperatorMap");
-                field.setAccessible(true); // NOPMD
-                @SuppressWarnings("unchecked")
-                Map<Class<?>, DataOperator<?>> map = (Map<Class<?>, DataOperator<?>>) field.get(null);
-                map.put(TestDataEntity.class, h2Operator1);
-                map.put(AnotherDataEntity.class, h2Operator2);
 
+            try (MockedConstruction<HikariConfig> mockedConfig = mockConstruction(HikariConfig.class);
+                 MockedConstruction<HikariDataSource> mockedDataSource = mockConstruction(HikariDataSource.class);
+                 MockedConstruction<SQLiteDataOperator> mockedOperator = mockConstruction(SQLiteDataOperator.class)) {
                 // Act
                 DataOperator<TestDataEntity> operator1 = store.getOperator(mockPlugin, TestDataEntity.class);
                 DataOperator<AnotherDataEntity> operator2 = store.getOperator(mockPlugin, AnotherDataEntity.class);
 
                 // Assert
                 assertThat(operator1).isNotSameAs(operator2);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+                assertThat(mockedOperator.constructed()).hasSize(2);
+                // Both entity classes are backed by the same .db file (same plugin) -> one pool.
+                assertThat(mockedDataSource.constructed()).hasSize(1);
             }
         }
     }
@@ -301,6 +278,59 @@ class SQLiteDataStoreTest {
                 }
                 poolMap.remove("fileA");
                 poolMap.remove("fileB");
+            }
+        }
+
+        /**
+         * Same defect as {@link #shouldShareOnePoolAcrossEntitiesInSameFile()}, but through a real,
+         * live pool instead of a construction count -- pre-seeds a real H2-backed pool at the exact
+         * canonical path {@code getOperator} will resolve to for this plugin, so {@code poolFor}'s
+         * {@code computeIfAbsent} finds it already cached and never attempts a real
+         * {@code jdbc:sqlite:} connection. This lets {@link SQLiteDataOperator} run its real {@code
+         * CREATE TABLE} against the pool, and lets {@link PoolStateAssertions#assertTotalConnections}
+         * assert against genuine {@link com.zaxxer.hikari.HikariPoolMXBean} state, per this plan's
+         * acceptance criteria.
+         */
+        @Test
+        @DisplayName("同一 .db 文件的多个实体类应该共享同一个连接池的真实连接")
+        void shouldReportRealPoolConnectionsSharedAcrossEntities() throws Exception {
+            when(mockPlugin.getPluginName()).thenReturn("real-pool-plugin");
+            File dataFolder = new File(tempDir, "sqliteDB");
+            dataFolder.mkdirs();
+            String dbPath = new File(dataFolder, "real-pool-plugin.db").getCanonicalPath();
+
+            HikariConfig config = new HikariConfig();
+            config.setJdbcUrl("jdbc:h2:mem:realpooltest" + System.nanoTime() + ";DB_CLOSE_DELAY=-1;MODE=MySQL");
+            config.setUsername("sa");
+            config.setMinimumIdle(0);
+            config.setMaximumPoolSize(10);
+            HikariDataSource realPool = new HikariDataSource(config);
+
+            SQLiteDataStore store = new SQLiteDataStore();
+            Field poolMapField = SQLiteDataStore.class.getDeclaredField("dataSourceMap");
+            poolMapField.setAccessible(true); // NOPMD
+            @SuppressWarnings("unchecked")
+            Map<String, DataSource> poolMap = (Map<String, DataSource>) poolMapField.get(store);
+            poolMap.put(dbPath, realPool);
+
+            try {
+                // Each getOperator() call runs a CREATE TABLE that borrows a connection from the pool
+                // and returns it; sequential (non-concurrent) borrow/return cycles against the same
+                // pool settle on one physical connection, so this observes real
+                // HikariPoolMXBean.getTotalConnections() state - not a construction count and not the
+                // absence of a thrown exception.
+                DataOperator<TestDataEntity> op1 = store.getOperator(mockPlugin, TestDataEntity.class);
+                DataOperator<AnotherDataEntity> op2 = store.getOperator(mockPlugin, AnotherDataEntity.class);
+                DataOperator<ThirdDataEntity> op3 = store.getOperator(mockPlugin, ThirdDataEntity.class);
+
+                assertThat(op1).isNotNull();
+                assertThat(op2).isNotNull();
+                assertThat(op3).isNotNull();
+                assertThat(poolMap).hasSize(1);
+                PoolStateAssertions.assertTotalConnections(realPool, 1);
+            } finally {
+                poolMap.remove(dbPath);
+                realPool.close();
             }
         }
     }

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
@@ -3,11 +3,13 @@ package com.ultikits.ultitools.interfaces.impl.data.sqlite;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.Map;
 
 import javax.sql.DataSource;
@@ -20,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -31,6 +34,7 @@ import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.annotations.Column;
 import com.ultikits.ultitools.annotations.Table;
 import com.ultikits.ultitools.interfaces.DataOperator;
+import com.ultikits.ultitools.testutil.PoolStateAssertions;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -74,6 +78,16 @@ class SQLiteDataStoreTest {
 
         public int getValue() { return value; }
         public void setValue(int value) { this.value = value; }
+    }
+
+    @EqualsAndHashCode(callSuper = true)
+    @Table("third_data")
+    public static class ThirdDataEntity extends BaseDataEntity<String> {
+        @Column("label")
+        private String label;
+
+        public String getLabel() { return label; }
+        public void setLabel(String label) { this.label = label; }
     }
 
     public static class NoTableAnnotationEntity extends BaseDataEntity<String> {}
@@ -206,6 +220,87 @@ class SQLiteDataStoreTest {
                 assertThat(operator1).isNotSameAs(operator2);
             } catch (Exception e) {
                 throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("连接池状态测试 (Wave 0 gap 1, SILENT-03)")
+    class PoolStateTests {
+
+        /**
+         * Pins the pool-per-file defect described in 02-VALIDATION.md's Wave 0 requirements: at HEAD,
+         * {@code getOperator(UltiToolsPlugin, Class)} caches by entity class only, so each new entity
+         * class for the same plugin (same backing .db file) triggers its own {@code new
+         * HikariConfig()}/{@code new HikariDataSource(config)} pair. Both are intercepted with
+         * {@code mockConstruction} so the SQLite JDBC driver is never touched -
+         * {@code HikariConfig.setDriverClassName("org.sqlite.JDBC")} performs its own
+         * {@code Class.forName} eagerly and throws on the real class, and that driver ships with
+         * Paper, not with this project's test dependencies.
+         * <p>
+         * RED at HEAD (before Task 2's fix): 3 entity classes -&gt; 3 pool constructions. GREEN after
+         * Task 2 re-keys the pool map by backing-file path with {@code computeIfAbsent}.
+         */
+        @Test
+        @DisplayName("同一 .db 文件的多个实体类应该只创建一个连接池")
+        void shouldShareOnePoolAcrossEntitiesInSameFile() {
+            when(mockPlugin.getPluginName()).thenReturn("pool-state-plugin");
+            SQLiteDataStore store = new SQLiteDataStore();
+
+            // SQLiteDataOperator's constructor eagerly runs a CREATE TABLE against the DataSource it
+            // is given; mocking its construction too keeps this test about pool *count*, not about
+            // whether a mocked DataSource can serve a real connection.
+            try (MockedConstruction<HikariConfig> mockedConfig = mockConstruction(HikariConfig.class);
+                 MockedConstruction<HikariDataSource> mockedConstruction = mockConstruction(HikariDataSource.class);
+                 MockedConstruction<SQLiteDataOperator> mockedOperator = mockConstruction(SQLiteDataOperator.class)) {
+                store.getOperator(mockPlugin, TestDataEntity.class);
+                store.getOperator(mockPlugin, AnotherDataEntity.class);
+                store.getOperator(mockPlugin, ThirdDataEntity.class);
+
+                assertThat(mockedConstruction.constructed())
+                        .as("expected 1 pool for 3 entity classes backed by the same .db file, found %d",
+                                mockedConstruction.constructed().size())
+                        .hasSize(1);
+            }
+        }
+
+        /**
+         * Pins the empty-body {@code destroyAllOperators()} defect: at HEAD it does nothing, so pools
+         * it is handed stay open. Seeds the pool map reflectively with real, H2-backed pools (not
+         * SQLite - the driver is unavailable in tests) so this observes real
+         * {@link com.zaxxer.hikari.HikariPoolMXBean} state via {@link PoolStateAssertions}, not merely
+         * the absence of a thrown exception.
+         * <p>
+         * RED at HEAD (before Task 2's fix): pools remain open. GREEN after Task 2 makes teardown
+         * actually close what it holds.
+         */
+        @Test
+        @DisplayName("destroyAllOperators 应该关闭它持有的每一个连接池")
+        void destroyAllOperatorsShouldCloseEveryPool() throws Exception {
+            SQLiteDataStore store = new SQLiteDataStore();
+            HikariDataSource poolA = (HikariDataSource) createH2DataSource();
+            HikariDataSource poolB = (HikariDataSource) createH2DataSource();
+
+            Field poolMapField = SQLiteDataStore.class.getDeclaredField("dataSourceMap");
+            poolMapField.setAccessible(true); // NOPMD
+            @SuppressWarnings("unchecked")
+            Map<String, DataSource> poolMap = (Map<String, DataSource>) poolMapField.get(store);
+            poolMap.put("fileA", poolA);
+            poolMap.put("fileB", poolB);
+
+            try {
+                store.destroyAllOperators();
+
+                PoolStateAssertions.assertNoOpenConnections(Arrays.asList(poolA, poolB));
+            } finally {
+                if (!poolA.isClosed()) {
+                    poolA.close();
+                }
+                if (!poolB.isClosed()) {
+                    poolB.close();
+                }
+                poolMap.remove("fileA");
+                poolMap.remove("fileB");
             }
         }
     }

--- a/src/test/java/com/ultikits/ultitools/manager/DataSourceTransactionManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DataSourceTransactionManagerTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.*;
 import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.sql.DataSource;
 
@@ -547,6 +549,100 @@ class DataSourceTransactionManagerTest {
 
             // 主线程的事务应该仍然活动
             assertThat(transactionManager.hasActiveTransaction()).isTrue();
+        }
+    }
+
+    /**
+     * FOUND-04: contextHolder is an instance field, not static, so two
+     * {@code DataSourceTransactionManager} instances - each bound to a different
+     * {@link DataSource} - never observe each other's {@link Connection} or transaction state.
+     * These tests fail against the pre-fix {@code static} field: with a static contextHolder,
+     * manager A and manager B would share the same ThreadLocal slot, so B's {@code begin()}
+     * would silently overwrite A's context on the same thread (Test 1), and on two threads the
+     * two managers would still resolve to independent ThreadLocal entries only by accident of
+     * per-thread storage - Test 1 is the one that actually distinguishes "static" from
+     * "instance", because same-thread reuse of one static field is exactly where the two
+     * shapes diverge.
+     */
+    @Nested
+    @DisplayName("跨 DataSource 隔离测试（FOUND-04）")
+    class CrossDataSourceIsolationTests {
+
+        @Test
+        @DisplayName("同一线程上，两个 manager 各自持有独立的连接，互不可见")
+        void shouldIsolateConnectionsAcrossManagersOnSameThread() throws Exception {
+            DataSource dataSourceA = mock(DataSource.class);
+            DataSource dataSourceB = mock(DataSource.class);
+            Connection connectionA = mock(Connection.class);
+            Connection connectionB = mock(Connection.class);
+            when(dataSourceA.getConnection()).thenReturn(connectionA);
+            when(dataSourceB.getConnection()).thenReturn(connectionB);
+
+            DataSourceTransactionManager managerA = new DataSourceTransactionManager(dataSourceA);
+            DataSourceTransactionManager managerB = new DataSourceTransactionManager(dataSourceB);
+
+            managerA.begin();
+            managerB.begin();
+
+            assertThat(managerA.getConnection()).isSameAs(connectionA);
+            assertThat(managerB.getConnection()).isSameAs(connectionB);
+            assertThat(managerA.getConnection()).isNotSameAs(managerB.getConnection());
+
+            // Rolling back manager A must never touch manager B's connection or transaction state.
+            managerA.rollback();
+
+            assertThat(managerA.hasActiveTransaction()).isFalse();
+            assertThat(managerB.hasActiveTransaction()).isTrue();
+            verify(connectionB, never()).rollback();
+            verify(connectionB, never()).close();
+        }
+
+        @Test
+        @DisplayName("两个线程上，两个 manager 的事务同时打开时互不可见")
+        void shouldIsolateConnectionsAcrossManagersOnDifferentThreads() throws Exception {
+            DataSource dataSourceA = mock(DataSource.class);
+            DataSource dataSourceB = mock(DataSource.class);
+            Connection connectionA = mock(Connection.class);
+            Connection connectionB = mock(Connection.class);
+            when(dataSourceA.getConnection()).thenReturn(connectionA);
+            when(dataSourceB.getConnection()).thenReturn(connectionB);
+
+            DataSourceTransactionManager managerA = new DataSourceTransactionManager(dataSourceA);
+            DataSourceTransactionManager managerB = new DataSourceTransactionManager(dataSourceB);
+
+            CountDownLatch bothBegun = new CountDownLatch(2);
+            CountDownLatch releaseThreadA = new CountDownLatch(1);
+            AtomicReference<Connection> seenByThreadA = new AtomicReference<>();
+            AtomicReference<Connection> seenByThreadB = new AtomicReference<>();
+
+            Thread threadA = new Thread(() -> {
+                managerA.begin();
+                bothBegun.countDown();
+                try {
+                    // Hold A's transaction open until B has begun too, so both are active
+                    // simultaneously before either reads its connection back.
+                    releaseThreadA.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                seenByThreadA.set(managerA.getConnection());
+            });
+            Thread threadB = new Thread(() -> {
+                managerB.begin();
+                bothBegun.countDown();
+                seenByThreadB.set(managerB.getConnection());
+                releaseThreadA.countDown();
+            });
+
+            threadA.start();
+            threadB.start();
+            threadA.join();
+            threadB.join();
+
+            assertThat(bothBegun.getCount()).isZero();
+            assertThat(seenByThreadA.get()).isSameAs(connectionA);
+            assertThat(seenByThreadB.get()).isSameAs(connectionB);
+            assertThat(seenByThreadA.get()).isNotSameAs(seenByThreadB.get());
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/manager/DataSourceTransactionManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DataSourceTransactionManagerTest.java
@@ -419,6 +419,99 @@ class DataSourceTransactionManagerTest {
             // 不应该有异常
             assertThat(true).isTrue();
         }
+
+        // ===== D-10: setTimeout records a real deadline (02-09 Task 2) =====
+
+        @Test
+        @DisplayName("no active transaction: getTimeoutDeadlineNanos() returns null")
+        void deadlineIsNullWithNoActiveTransaction() {
+            assertThat(transactionManager.getTimeoutDeadlineNanos()).isNull();
+        }
+
+        @Test
+        @DisplayName("setTimeout(N) with an active transaction records a deadline ~N seconds out")
+        void setTimeoutRecordsDeadlineWhenTransactionActive() throws Exception {
+            transactionManager.begin();
+            long before = System.nanoTime();
+
+            transactionManager.setTimeout(10);
+
+            Long deadline = transactionManager.getTimeoutDeadlineNanos();
+            assertThat(deadline).isNotNull();
+            // Bounds rather than an exact value: real wall-clock time elapses between "before"
+            // and the setTimeout() call itself.
+            assertThat(deadline - before).isBetween(
+                    java.util.concurrent.TimeUnit.SECONDS.toNanos(9),
+                    java.util.concurrent.TimeUnit.SECONDS.toNanos(11));
+        }
+
+        @Test
+        @DisplayName("setTimeout(0) with an active transaction leaves the deadline null")
+        void zeroTimeoutDoesNotRecordDeadlineWhenActive() throws Exception {
+            transactionManager.begin();
+
+            transactionManager.setTimeout(0);
+
+            assertThat(transactionManager.getTimeoutDeadlineNanos()).isNull();
+        }
+
+        @Test
+        @DisplayName("setTimeout(negative) with an active transaction leaves the deadline null")
+        void negativeTimeoutDoesNotRecordDeadlineWhenActive() throws Exception {
+            transactionManager.begin();
+
+            transactionManager.setTimeout(-5);
+
+            assertThat(transactionManager.getTimeoutDeadlineNanos()).isNull();
+        }
+
+        @Test
+        @DisplayName("setTimeout with no active transaction records nothing and does not throw")
+        void setTimeoutWithNoActiveTransactionRecordsNothing() {
+            transactionManager.setTimeout(30);
+
+            assertThat(transactionManager.getTimeoutDeadlineNanos()).isNull();
+        }
+
+        @Test
+        @DisplayName("commit() clears the deadline along with the rest of the context")
+        void deadlineClearedAfterCommit() throws Exception {
+            transactionManager.begin();
+            transactionManager.setTimeout(10);
+            assertThat(transactionManager.getTimeoutDeadlineNanos()).isNotNull();
+
+            transactionManager.commit();
+
+            assertThat(transactionManager.getTimeoutDeadlineNanos()).isNull();
+        }
+
+        @Test
+        @DisplayName("rollback() clears the deadline along with the rest of the context")
+        void deadlineClearedAfterRollback() throws Exception {
+            transactionManager.begin();
+            transactionManager.setTimeout(10);
+
+            transactionManager.rollback();
+
+            assertThat(transactionManager.getTimeoutDeadlineNanos()).isNull();
+        }
+
+        @Test
+        @DisplayName("suspend()/resume() carry the deadline with the detached context")
+        void deadlineSurvivesSuspendResume() throws Exception {
+            transactionManager.begin();
+            transactionManager.setTimeout(10);
+            Long deadlineBeforeSuspend = transactionManager.getTimeoutDeadlineNanos();
+
+            Object suspended = transactionManager.suspend();
+            assertThat(transactionManager.getTimeoutDeadlineNanos())
+                    .as("no active transaction while suspended")
+                    .isNull();
+
+            transactionManager.resume(suspended);
+
+            assertThat(transactionManager.getTimeoutDeadlineNanos()).isEqualTo(deadlineBeforeSuspend);
+        }
     }
 
     @Nested

--- a/src/test/java/com/ultikits/ultitools/manager/DataSourceTransactionManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DataSourceTransactionManagerTest.java
@@ -1,6 +1,7 @@
 package com.ultikits.ultitools.manager;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
@@ -22,6 +23,7 @@ import org.mockito.MockitoAnnotations;
 
 import com.ultikits.ultitools.exceptions.DataAccessException;
 import com.ultikits.ultitools.exceptions.ErrorCode;
+import com.ultikits.ultitools.exceptions.UnexpectedRollbackException;
 import com.ultikits.ultitools.interfaces.JdbcTransactionManager;
 import com.ultikits.ultitools.interfaces.TransactionManager;
 
@@ -231,18 +233,22 @@ class DataSourceTransactionManagerTest {
         }
 
         @Test
-        @DisplayName("嵌套事务 rollback 应该完全回滚")
-        void shouldFullyRollbackNestedTransactions() throws Exception {
+        @DisplayName("嵌套事务 rollback 只标记 rollback-only 并递减深度，不立即清除（D-08，修正自「完全回滚」旧断言）")
+        void nestedRollbackShouldMarkRollbackOnlyInsteadOfTearingDownImmediately() throws Exception {
+            // D-08 corrects this test's pre-6.3.0 assumption: rollback() used to call cleanup(ctx)
+            // "regardless of depth" (the exact HEAD comment this fix removes), silently discarding
+            // whatever the outer scope(s) still expected to do. A rollback() at depth > 1 now only
+            // marks the context rollback-only and decrements depth -- see RollbackOnlyMarkerTests
+            // below for the full depth-2 RED/GREEN pair and the outer commit()'s throw.
             transactionManager.begin();
             transactionManager.begin();
             transactionManager.begin();
 
-            // 回滚应该完全清除，不管嵌套深度
             transactionManager.rollback();
 
-            verify(mockConnection).rollback();
-            assertThat(transactionManager.hasActiveTransaction()).isFalse();
-            assertThat(transactionManager.getTransactionDepth()).isZero();
+            verify(mockConnection, never()).rollback();
+            assertThat(transactionManager.hasActiveTransaction()).isTrue();
+            assertThat(transactionManager.getTransactionDepth()).isEqualTo(2);
         }
 
         @Test
@@ -528,6 +534,7 @@ class DataSourceTransactionManagerTest {
             assertThat(ctx.depth).isZero();
             assertThat(ctx.originalIsolation).isEqualTo(-1);
             assertThat(ctx.originalAutoCommit).isTrue();
+            assertThat(ctx.rollbackOnly).isFalse();
         }
     }
 
@@ -747,6 +754,79 @@ class DataSourceTransactionManagerTest {
         void concreteManagerIsAssignableToBothInterfaces() {
             assertThat(transactionManager).isInstanceOf(TransactionManager.class);
             assertThat(transactionManager).isInstanceOf(JdbcTransactionManager.class);
+        }
+    }
+
+    /**
+     * D-08: an inner {@code rollback()} at depth &gt; 1 marks the transaction rollback-only and
+     * decrements depth instead of tearing the whole {@link DataSourceTransactionManager.TransactionContext}
+     * down. The outer {@code commit()} then performs the real rollback, cleans up, and throws
+     * {@link UnexpectedRollbackException} instead of silently returning after a WARNING log line -
+     * observed HEAD behaviour before this fix (pinned by
+     * {@code shouldFullyRollbackNestedTransactions} above, now rewritten to match the corrected
+     * semantics).
+     */
+    @Nested
+    @DisplayName("回滚只读标记 — 外层 commit() 不再静默丢弃工作（D-08）")
+    class RollbackOnlyMarkerTests {
+
+        @Test
+        @DisplayName("深度 2：内层 rollback() 打标记；外层 commit() 执行真正回滚并抛出 UnexpectedRollbackException")
+        void innerRollbackThenOuterCommitThrowsUnexpectedRollback() throws Exception {
+            transactionManager.begin(); // depth 1
+            transactionManager.begin(); // depth 2
+
+            transactionManager.rollback(); // inner rollback at depth 2 -- must only mark, not tear down
+
+            assertThat(transactionManager.hasActiveTransaction()).isTrue();
+            assertThat(transactionManager.getTransactionDepth()).isEqualTo(1);
+            verify(mockConnection, never()).rollback();
+            verify(mockConnection, never()).close();
+
+            assertThatThrownBy(() -> transactionManager.commit())
+                .isInstanceOf(UnexpectedRollbackException.class)
+                .hasMessageContaining("nested")
+                .satisfies(e -> assertThat(((UnexpectedRollbackException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.TRANSACTION_ROLLBACK_ONLY));
+
+            // Outer commit must have performed the real rollback and cleaned up -- no leaked context.
+            verify(mockConnection).rollback();
+            verify(mockConnection, never()).commit();
+            assertThat(transactionManager.hasActiveTransaction()).isFalse();
+        }
+
+        @Test
+        @DisplayName("深度 2：内层 commit() 再外层 commit() 正常提交，不抛出任何异常（对照组）")
+        void innerCommitThenOuterCommitCommitsNormally() throws Exception {
+            transactionManager.begin();
+            transactionManager.begin();
+
+            transactionManager.commit(); // inner commit, depth 2 -> 1
+
+            assertThatCode(() -> transactionManager.commit()).doesNotThrowAnyException();
+
+            verify(mockConnection).commit();
+            verify(mockConnection, never()).rollback();
+            assertThat(transactionManager.hasActiveTransaction()).isFalse();
+        }
+
+        @Test
+        @DisplayName("深度 1 的 rollback() 行为不变：真正回滚并清理")
+        void depthOneRollbackUnchanged() throws Exception {
+            transactionManager.begin();
+
+            transactionManager.rollback();
+
+            verify(mockConnection).rollback();
+            assertThat(transactionManager.hasActiveTransaction()).isFalse();
+            assertThat(transactionManager.getTransactionDepth()).isZero();
+        }
+
+        @Test
+        @DisplayName("没有活动事务时 commit()/rollback() 仍然只记 WARNING 并正常返回")
+        void noActiveTransactionStillReturnsQuietly() {
+            assertThatCode(() -> transactionManager.commit()).doesNotThrowAnyException();
+            assertThatCode(() -> transactionManager.rollback()).doesNotThrowAnyException();
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/manager/DataSourceTransactionManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DataSourceTransactionManagerTest.java
@@ -22,6 +22,8 @@ import org.mockito.MockitoAnnotations;
 
 import com.ultikits.ultitools.exceptions.DataAccessException;
 import com.ultikits.ultitools.exceptions.ErrorCode;
+import com.ultikits.ultitools.interfaces.JdbcTransactionManager;
+import com.ultikits.ultitools.interfaces.TransactionManager;
 
 /**
  * DataSourceTransactionManager 测试类
@@ -643,6 +645,108 @@ class DataSourceTransactionManagerTest {
             assertThat(seenByThreadA.get()).isSameAs(connectionA);
             assertThat(seenByThreadB.get()).isSameAs(connectionB);
             assertThat(seenByThreadA.get()).isNotSameAs(seenByThreadB.get());
+        }
+    }
+
+    /**
+     * D-04: {@code TransactionManager} is split additively. A backend that only needs the
+     * lifecycle half (begin/commit/rollback/hasActiveTransaction/setTimeout/getTransactionDepth)
+     * implements {@link TransactionManager} directly and is never forced to answer the three
+     * JDBC-only members - those now live only on {@link JdbcTransactionManager}, with a
+     * {@code default} fallback on the base interface that refuses rather than lies.
+     */
+    @Nested
+    @DisplayName("TransactionManager / JdbcTransactionManager split（D-04）")
+    class JdbcSplitTests {
+
+        /**
+         * Test-only backend supplying only the six lifecycle methods - deliberately does not
+         * implement {@link JdbcTransactionManager}, and does not override any of the three
+         * JDBC-only default methods either.
+         */
+        private final class LifecycleOnlyTransactionManager implements TransactionManager {
+            private boolean active;
+            private int depth;
+
+            @Override
+            public void begin() {
+                active = true;
+                depth++;
+            }
+
+            @Override
+            public void commit() {
+                depth = Math.max(0, depth - 1);
+                active = depth > 0;
+            }
+
+            @Override
+            public void rollback() {
+                depth = 0;
+                active = false;
+            }
+
+            @Override
+            public boolean hasActiveTransaction() {
+                return active;
+            }
+
+            @Override
+            public void setTimeout(int seconds) {
+                // no-op: not exercised by this test
+            }
+
+            @Override
+            public int getTransactionDepth() {
+                return depth;
+            }
+        }
+
+        @Test
+        @DisplayName("A lifecycle-only TransactionManager implementation compiles and instantiates")
+        void lifecycleOnlyImplementationCompilesAndInstantiates() {
+            TransactionManager manager = new LifecycleOnlyTransactionManager();
+
+            assertThat(manager).isNotNull();
+            manager.begin();
+            assertThat(manager.hasActiveTransaction()).isTrue();
+        }
+
+        @Test
+        @DisplayName("getConnection() on a lifecycle-only manager throws UnsupportedOperationException naming JdbcTransactionManager")
+        void getConnectionThrowsNamingJdbcTransactionManager() {
+            TransactionManager manager = new LifecycleOnlyTransactionManager();
+
+            assertThatThrownBy(manager::getConnection)
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(JdbcTransactionManager.class.getName());
+        }
+
+        @Test
+        @DisplayName("setIsolationLevel(int) on a lifecycle-only manager throws UnsupportedOperationException naming JdbcTransactionManager")
+        void setIsolationLevelThrowsNamingJdbcTransactionManager() {
+            TransactionManager manager = new LifecycleOnlyTransactionManager();
+
+            assertThatThrownBy(() -> manager.setIsolationLevel(Connection.TRANSACTION_SERIALIZABLE))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(JdbcTransactionManager.class.getName());
+        }
+
+        @Test
+        @DisplayName("setReadOnly(boolean) on a lifecycle-only manager throws UnsupportedOperationException naming JdbcTransactionManager")
+        void setReadOnlyThrowsNamingJdbcTransactionManager() {
+            TransactionManager manager = new LifecycleOnlyTransactionManager();
+
+            assertThatThrownBy(() -> manager.setReadOnly(true))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(JdbcTransactionManager.class.getName());
+        }
+
+        @Test
+        @DisplayName("DataSourceTransactionManager is assignable to both TransactionManager and JdbcTransactionManager")
+        void concreteManagerIsAssignableToBothInterfaces() {
+            assertThat(transactionManager).isInstanceOf(TransactionManager.class);
+            assertThat(transactionManager).isInstanceOf(JdbcTransactionManager.class);
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/manager/DataSourceTransactionManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DataSourceTransactionManagerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.*;
 import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Deque;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -827,6 +828,106 @@ class DataSourceTransactionManagerTest {
         void noActiveTransactionStillReturnsQuietly() {
             assertThatCode(() -> transactionManager.commit()).doesNotThrowAnyException();
             assertThatCode(() -> transactionManager.rollback()).doesNotThrowAnyException();
+        }
+    }
+
+    /**
+     * D-09: {@code suspend()}/{@code resume(Object)} are the mechanism {@code REQUIRES_NEW} and
+     * {@code NOT_SUPPORTED} need in 02-06 - detach the current context from this thread, let an
+     * independent transaction run in its place, then restore the original at its original depth
+     * with its original {@link Connection}.
+     */
+    @Nested
+    @DisplayName("suspend()/resume() — REQUIRES_NEW/NOT_SUPPORTED 所需的挂起机制（D-09）")
+    class SuspendResumeTests {
+
+        @Test
+        @DisplayName("没有活动事务时 suspend() 返回 null，不抛出异常")
+        void suspendWithNothingActiveReturnsNull() {
+            Object suspended = transactionManager.suspend();
+
+            assertThat(suspended).isNull();
+        }
+
+        @Test
+        @DisplayName("resume(null) 是空操作，不会抛出异常，也不会遗留状态")
+        void resumeWithNullIsNoOp() {
+            assertThatCode(() -> transactionManager.resume(null)).doesNotThrowAnyException();
+            assertThat(transactionManager.hasActiveTransaction()).isFalse();
+        }
+
+        @Test
+        @DisplayName("suspend() 摘除当前上下文，之后 hasActiveTransaction() 为 false")
+        void suspendDetachesCurrentContext() {
+            transactionManager.begin();
+            assertThat(transactionManager.hasActiveTransaction()).isTrue();
+
+            Object suspended = transactionManager.suspend();
+
+            assertThat(suspended).isNotNull();
+            assertThat(transactionManager.hasActiveTransaction()).isFalse();
+        }
+
+        @Test
+        @DisplayName("suspend() -> begin() -> commit() -> resume(saved)：原事务在原深度、原 Connection 上恢复")
+        void suspendThenResumeRestoresOriginalContextAtOriginalDepthAndConnection() throws Exception {
+            Connection outerConnection = mock(Connection.class);
+            Connection innerConnection = mock(Connection.class);
+            when(mockDataSource.getConnection()).thenReturn(outerConnection, innerConnection);
+
+            transactionManager.begin(); // outer, depth 1, outerConnection
+            transactionManager.begin(); // outer, depth 2 (still nested on the same context)
+            assertThat(transactionManager.getTransactionDepth()).isEqualTo(2);
+
+            Object suspended = transactionManager.suspend();
+            assertThat(transactionManager.hasActiveTransaction()).isFalse();
+
+            transactionManager.begin(); // inner, independent, depth 1, innerConnection
+            assertThat(transactionManager.getTransactionDepth()).isEqualTo(1);
+            assertThat(transactionManager.getConnection()).isSameAs(innerConnection);
+            transactionManager.commit(); // inner finishes and cleans up completely
+            assertThat(transactionManager.hasActiveTransaction()).isFalse();
+
+            transactionManager.resume(suspended);
+
+            assertThat(transactionManager.hasActiveTransaction()).isTrue();
+            assertThat(transactionManager.getTransactionDepth()).isEqualTo(2);
+            assertThat(transactionManager.getConnection()).isSameAs(outerConnection);
+        }
+
+        @Test
+        @DisplayName("getTransactionDepth() 只报告当前上下文的深度，不会跨挂起栈求和")
+        void depthReportsCurrentContextOnlyNotSummedAcrossStack() {
+            transactionManager.begin(); // depth 1
+            transactionManager.begin(); // depth 2
+            Object suspended = transactionManager.suspend();
+
+            transactionManager.begin(); // new, independent, depth 1
+
+            assertThat(transactionManager.getTransactionDepth()).isEqualTo(1);
+
+            transactionManager.commit();
+            transactionManager.resume(suspended);
+
+            assertThat(transactionManager.getTransactionDepth()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("挂起后正常 resume：挂起栈的 ThreadLocal 不遗留悬空帧（T-02-DOS-5）")
+        void suspendedStackLeavesNoDanglingFrameAfterResume() throws Exception {
+            transactionManager.begin();
+            Object suspended = transactionManager.suspend();
+            transactionManager.resume(suspended);
+
+            assertThat(suspendedStackValue()).isNull();
+        }
+
+        private Deque<?> suspendedStackValue() throws Exception {
+            Field field = DataSourceTransactionManager.class.getDeclaredField("suspendedStack");
+            field.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            ThreadLocal<Deque<?>> threadLocal = (ThreadLocal<Deque<?>>) field.get(transactionManager);
+            return threadLocal.get();
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/manager/DataSourceTransactionManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DataSourceTransactionManagerTest.java
@@ -56,8 +56,9 @@ class DataSourceTransactionManagerTest {
         try {
             Field contextHolderField = DataSourceTransactionManager.class.getDeclaredField("contextHolder");
             contextHolderField.setAccessible(true);
+            // Instance field now (FOUND-04) -- read off transactionManager, not off the class (null).
             @SuppressWarnings("unchecked")
-            ThreadLocal<?> contextHolder = (ThreadLocal<?>) contextHolderField.get(null);
+            ThreadLocal<?> contextHolder = (ThreadLocal<?>) contextHolderField.get(transactionManager);
             contextHolder.remove();
         } catch (Exception ignored) {
         }
@@ -489,8 +490,8 @@ class DataSourceTransactionManagerTest {
         @Test
         @DisplayName("没有事务时应该返回 null")
         void shouldReturnNullWhenNoTransaction() {
-            DataSourceTransactionManager.TransactionContext ctx = 
-                DataSourceTransactionManager.getCurrentContext();
+            DataSourceTransactionManager.TransactionContext ctx =
+                transactionManager.getCurrentContext();
             assertThat(ctx).isNull();
         }
 
@@ -498,10 +499,10 @@ class DataSourceTransactionManagerTest {
         @DisplayName("有事务时应该返回上下文")
         void shouldReturnContextWhenTransactionActive() {
             transactionManager.begin();
-            
-            DataSourceTransactionManager.TransactionContext ctx = 
-                DataSourceTransactionManager.getCurrentContext();
-            
+
+            DataSourceTransactionManager.TransactionContext ctx =
+                transactionManager.getCurrentContext();
+
             assertThat(ctx).isNotNull();
             assertThat(ctx.active).isTrue();
             assertThat(ctx.depth).isEqualTo(1);

--- a/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
@@ -822,4 +822,117 @@ class DataStoreManagerTest {
             assertThat(severeMessages(logger)).anyMatch(msg -> msg.contains("datasource.type"));
         }
     }
+
+    /**
+     * getOperator(DataScope, Class) 所有权校验测试（D-14/D-15/D-17）。
+     * <p>
+     * Task 2's own acceptance criteria: a stub {@link DataStore} that does NOT override
+     * {@code getOperator(DataScope, Class)} still refuses an unowned entity -- proving the
+     * {@code default} body on the interface is what enforces, not any one store's own code.
+     */
+    @Nested
+    @DisplayName("getOperator(DataScope, Class) 所有权校验测试 (D-14/D-15/D-17)")
+    class GetOperatorDataScopeTests {
+
+        @com.ultikits.ultitools.annotations.Table("owned_entity_secret_table")
+        class OwnedEntity extends com.ultikits.ultitools.abstracts.data.BaseDataEntity<String> {
+            @com.ultikits.ultitools.annotations.Column("secret_column_name")
+            private String secretColumnName;
+        }
+
+        class UnownedEntity extends com.ultikits.ultitools.abstracts.data.BaseDataEntity<String> {
+        }
+
+        private DataScope scopeFor(String pluginName, java.util.Set<Class<?>> owned) {
+            return DataScope.forExternal(pluginName, new File(System.getProperty("java.io.tmpdir"),
+                    "ultitools-test-scope-" + pluginName), owned);
+        }
+
+        @Test
+        @DisplayName("stub DataStore 未覆写该方法时，默认实现仍应拒绝未拥有的实体")
+        void defaultBodyOnAStubStoreShouldRefuseUnownedEntity() {
+            DataStore stubStore = mock(DataStore.class, org.mockito.Answers.CALLS_REAL_METHODS);
+            when(stubStore.getStoreType()).thenReturn("stub-store");
+            DataScope scope = scopeFor("Requester", java.util.Collections.emptySet());
+
+            com.ultikits.ultitools.exceptions.DataAccessException thrown =
+                    org.junit.jupiter.api.Assertions.assertThrows(
+                            com.ultikits.ultitools.exceptions.DataAccessException.class,
+                            () -> stubStore.getOperator(scope, OwnedEntity.class));
+
+            assertThat(thrown.getErrorCode())
+                    .isEqualTo(com.ultikits.ultitools.exceptions.ErrorCode.ENTITY_NOT_OWNED);
+            assertThat(thrown.getMessage())
+                    .contains(OwnedEntity.class.getName())
+                    .contains("Requester");
+        }
+
+        @Test
+        @DisplayName("拥有的实体应该返回一个可用的操作器（走 default 方法委托给 File 重载）")
+        void ownedEntityShouldReturnAWorkingOperator() {
+            @SuppressWarnings("unchecked")
+            com.ultikits.ultitools.interfaces.DataOperator<OwnedEntity> fakeOperator =
+                    mock(com.ultikits.ultitools.interfaces.DataOperator.class);
+            DataStore stubStore = mock(DataStore.class, org.mockito.Answers.CALLS_REAL_METHODS);
+            when(stubStore.getStoreType()).thenReturn("stub-store");
+            // doReturn().when(), not when().thenReturn(): the File-overload's real default body
+            // throws unconditionally, and with CALLS_REAL_METHODS as the mock's default answer,
+            // when(stubStore.getOperator(...)) would evaluate that real (throwing) call as part of
+            // recording the stub. doReturn() never invokes the real method to determine this.
+            org.mockito.Mockito.doReturn(fakeOperator).when(stubStore)
+                    .getOperator(org.mockito.ArgumentMatchers.any(File.class), eq(OwnedEntity.class));
+            DataScope scope = scopeFor("Owner", java.util.Collections.singleton(OwnedEntity.class));
+
+            com.ultikits.ultitools.interfaces.DataOperator<OwnedEntity> result =
+                    stubStore.getOperator(scope, OwnedEntity.class);
+
+            assertThat(result).isSameAs(fakeOperator);
+        }
+
+        @Test
+        @DisplayName("已知归属方与未知归属方的拒绝信息必须是两种不同的、可区分的字符串")
+        void refusalMessageShouldDistinguishKnownOwnerFromUnknown() {
+            PluginManager pluginManager = mock(PluginManager.class);
+            when(pluginManager.findOwningPlugin(OwnedEntity.class)).thenReturn("OwnerModule");
+            when(pluginManager.findOwningPlugin(UnownedEntity.class)).thenReturn(null);
+            com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(
+                    ultiTools -> when(ultiTools.getPluginManager()).thenReturn(pluginManager));
+
+            DataScope requester = scopeFor("Requester", java.util.Collections.emptySet());
+
+            com.ultikits.ultitools.exceptions.DataAccessException known =
+                    org.junit.jupiter.api.Assertions.assertThrows(
+                            com.ultikits.ultitools.exceptions.DataAccessException.class,
+                            () -> { throw requester.refusalFor(OwnedEntity.class); });
+            com.ultikits.ultitools.exceptions.DataAccessException unknown =
+                    org.junit.jupiter.api.Assertions.assertThrows(
+                            com.ultikits.ultitools.exceptions.DataAccessException.class,
+                            () -> { throw requester.refusalFor(UnownedEntity.class); });
+
+            assertThat(known.getMessage()).contains("OwnerModule");
+            assertThat(unknown.getMessage()).doesNotContain("OwnerModule");
+            assertThat(known.getMessage()).isNotEqualTo(unknown.getMessage());
+        }
+
+        @Test
+        @DisplayName("拒绝信息不得包含表名、列名或文件路径")
+        void refusalMessageShouldNotDiscloseSchemaOrPaths() {
+            PluginManager pluginManager = mock(PluginManager.class);
+            when(pluginManager.findOwningPlugin(OwnedEntity.class)).thenReturn("OwnerModule");
+            com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(
+                    ultiTools -> when(ultiTools.getPluginManager()).thenReturn(pluginManager));
+
+            DataScope requester = scopeFor("Requester", java.util.Collections.emptySet());
+
+            com.ultikits.ultitools.exceptions.DataAccessException thrown =
+                    org.junit.jupiter.api.Assertions.assertThrows(
+                            com.ultikits.ultitools.exceptions.DataAccessException.class,
+                            () -> { throw requester.refusalFor(OwnedEntity.class); });
+
+            assertThat(thrown.getMessage())
+                    .doesNotContain("owned_entity_secret_table")
+                    .doesNotContain("secret_column_name")
+                    .doesNotContain(System.getProperty("java.io.tmpdir"));
+        }
+    }
 }

--- a/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
@@ -1050,12 +1050,14 @@ class DataStoreManagerTest {
         @Test
         @DisplayName("外部插件经 UltiToolsAPI.getDataOperator 解析到的存储位置，路由前后完全一致（SQLite）")
         void externalPluginStorageLocationShouldBeUnchangedBySqliteRouting() throws Exception {
-            // Proves the D-18 routing change moves no data: SQLiteDataStore.getOperator(File,
-            // Class) itself is byte-for-byte untouched by this plan (git diff confirms zero
-            // changes to SQLiteDataStore.java), and UltiToolsAPI.getDataOperator's final
-            // delegating line is the same call it always was -- the new ownership check only runs
+            // Proves the D-18 routing change moves no data: UltiToolsAPI.getDataOperator's final
+            // delegating line is the same call it always was -- its own ownership check only runs
             // BEFORE it. Both the pre-Task-3 call shape (direct File overload) and the
             // post-Task-3 shape (through UltiToolsAPI) must resolve to the exact same pool.
+            // (02-12 note: SQLiteDataStore.getOperator(File, Class) itself is no longer
+            // byte-for-byte untouched -- 02-12 Task 2 adds a checkOwnership() call as its first
+            // statement, which is why this test now also stubs findScopeForDataFolder below. The
+            // path-resolution and pool-caching logic after that first line remains unchanged.)
             org.bukkit.plugin.java.JavaPlugin externalPlugin =
                     org.mockbukkit.mockbukkit.MockBukkit.createMockPlugin("SqlitePathPreservationFixture");
             com.ultikits.ultitools.api.ExternalPluginAdapter adapter =
@@ -1064,6 +1066,14 @@ class DataStoreManagerTest {
                     java.util.Collections.singleton(OwnedEntity.class), adapter.getDataFolder());
             adapter.setDataScope(scope);
             putAdapter(externalPlugin, adapter);
+
+            // 02-12 Task 2: SQLiteDataStore.getOperator(File, Class) now calls checkOwnership()
+            // as its first statement too, so even the "raw, unchecked" pre-Task-3 call shape
+            // below needs a PluginManager whose findScopeForDataFolder resolves this adapter's
+            // folder back to the same owning scope -- otherwise it refuses before ever reaching
+            // the pool/operator construction this test is actually about.
+            PluginManager pluginManager = mock(PluginManager.class);
+            when(pluginManager.findScopeForDataFolder(adapter.getDataFolder())).thenReturn(scope);
 
             try {
                 SQLiteDataStore sqliteStore = new SQLiteDataStore();
@@ -1075,11 +1085,18 @@ class DataStoreManagerTest {
                              mockedOperator = org.mockito.Mockito.mockConstruction(
                                      (Class<com.ultikits.ultitools.interfaces.impl.data.sqlite.SQLiteDataOperator<OwnedEntity>>)
                                              (Class<?>) com.ultikits.ultitools.interfaces.impl.data.sqlite.SQLiteDataOperator.class)) {
-                    // Pre-Task-3 shape: the raw, unchecked File overload.
+                    com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(
+                            ultiTools -> when(ultiTools.getPluginManager()).thenReturn(pluginManager));
+
+                    // Pre-Task-3 shape: the raw File overload -- unchecked before 02-12, now also
+                    // ownership-checked via checkOwnership(File, Class).
                     Object beforeOperator = sqliteStore.getOperator(adapter.getDataFolder(), OwnedEntity.class);
 
                     com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(
-                            ultiTools -> when(ultiTools.getDataStore()).thenReturn(sqliteStore));
+                            ultiTools -> {
+                                when(ultiTools.getDataStore()).thenReturn(sqliteStore);
+                                when(ultiTools.getPluginManager()).thenReturn(pluginManager);
+                            });
 
                     // Post-Task-3 shape: through UltiToolsAPI's now ownership-checked wrapper.
                     Object afterOperator = com.ultikits.ultitools.api.UltiToolsAPI.getDataOperator(

--- a/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -933,6 +934,224 @@ class DataStoreManagerTest {
                     .doesNotContain("owned_entity_secret_table")
                     .doesNotContain("secret_column_name")
                     .doesNotContain(System.getProperty("java.io.tmpdir"));
+        }
+    }
+
+    /**
+     * D-18: 两个旧入口（{@code getOperator(UltiToolsPlugin, Class)}、
+     * {@code getOperator(File, Class)}）现在都标记 {@code @Deprecated(forRemoval = true)}，且
+     * {@code UltiToolsPlugin.getDataOperator}/{@code UltiToolsAPI.getDataOperator} 这两个
+     * 框架自身的入口在调用它们之前，会先用与 {@code getOperator(DataScope, Class)} 完全相同的
+     * {@link DataScope#refusalFor} 做一次所有权校验。
+     */
+    @Nested
+    @DisplayName("旧入口路由到统一校验测试 (D-18)")
+    class LegacyOverloadRoutingTests {
+
+        @com.ultikits.ultitools.annotations.Table("legacy_routing_owned_entity")
+        class OwnedEntity extends com.ultikits.ultitools.abstracts.data.BaseDataEntity<String> {
+        }
+
+        private DataScope scopeFor(String pluginName, java.util.Set<Class<?>> owned, File folder) {
+            return DataScope.forExternal(pluginName, folder, owned);
+        }
+
+        @Test
+        @DisplayName("两个旧重载都应携带 forRemoval = true 的 @Deprecated")
+        void bothLegacyOverloadsShouldBeDeprecatedForRemoval() throws NoSuchMethodException {
+            Method pluginOverload = DataStore.class.getMethod("getOperator",
+                    com.ultikits.ultitools.abstracts.UltiToolsPlugin.class, Class.class);
+            Method fileOverload = DataStore.class.getMethod("getOperator", File.class, Class.class);
+
+            assertThat(pluginOverload.getAnnotation(Deprecated.class)).isNotNull();
+            assertThat(pluginOverload.getAnnotation(Deprecated.class).forRemoval()).isTrue();
+            assertThat(fileOverload.getAnnotation(Deprecated.class)).isNotNull();
+            assertThat(fileOverload.getAnnotation(Deprecated.class).forRemoval()).isTrue();
+        }
+
+        @Test
+        @DisplayName("UltiToolsPlugin.getDataOperator 拒绝未拥有的实体，消息与 DataScope 重载完全一致")
+        void ultiToolsPluginGetDataOperatorShouldRefuseUnownedEntityIdentically() {
+            DataScope scope = scopeFor("PluginX", java.util.Collections.emptySet(),
+                    new File(System.getProperty("java.io.tmpdir"), "ultitools-test-legacy-plugin"));
+            com.ultikits.ultitools.abstracts.UltiToolsPlugin plugin =
+                    mock(com.ultikits.ultitools.abstracts.UltiToolsPlugin.class, org.mockito.Answers.CALLS_REAL_METHODS);
+            plugin.setDataScope(scope);
+
+            com.ultikits.ultitools.exceptions.DataAccessException viaWrapper =
+                    org.junit.jupiter.api.Assertions.assertThrows(
+                            com.ultikits.ultitools.exceptions.DataAccessException.class,
+                            () -> plugin.getDataOperator(OwnedEntity.class));
+            com.ultikits.ultitools.exceptions.DataAccessException viaDataScope =
+                    org.junit.jupiter.api.Assertions.assertThrows(
+                            com.ultikits.ultitools.exceptions.DataAccessException.class,
+                            () -> { throw scope.refusalFor(OwnedEntity.class); });
+
+            assertThat(viaWrapper.getErrorCode()).isEqualTo(com.ultikits.ultitools.exceptions.ErrorCode.ENTITY_NOT_OWNED);
+            assertThat(viaWrapper.getMessage()).isEqualTo(viaDataScope.getMessage());
+        }
+
+        @Test
+        @DisplayName("拥有的实体不受影响 -- UltiToolsPlugin.getDataOperator 仍然委托给原来的 plugin 重载")
+        void ultiToolsPluginGetDataOperatorShouldStillDelegateForOwnedEntity() {
+            DataScope scope = scopeFor("PluginOwns", java.util.Collections.singleton(OwnedEntity.class),
+                    new File(System.getProperty("java.io.tmpdir"), "ultitools-test-legacy-plugin-owns"));
+            com.ultikits.ultitools.abstracts.UltiToolsPlugin plugin =
+                    mock(com.ultikits.ultitools.abstracts.UltiToolsPlugin.class, org.mockito.Answers.CALLS_REAL_METHODS);
+            plugin.setDataScope(scope);
+
+            @SuppressWarnings("unchecked")
+            com.ultikits.ultitools.interfaces.DataOperator<OwnedEntity> fakeOperator =
+                    mock(com.ultikits.ultitools.interfaces.DataOperator.class);
+            DataStore dataStore = mock(DataStore.class);
+            when(dataStore.getOperator(plugin, OwnedEntity.class)).thenReturn(fakeOperator);
+            com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(
+                    ultiTools -> when(ultiTools.getDataStore()).thenReturn(dataStore));
+
+            com.ultikits.ultitools.interfaces.DataOperator<OwnedEntity> result =
+                    plugin.getDataOperator(OwnedEntity.class);
+
+            assertThat(result).isSameAs(fakeOperator);
+            // Still the original, path-correct plugin overload -- no relocation.
+            verify(dataStore).getOperator(plugin, OwnedEntity.class);
+        }
+
+        @Test
+        @DisplayName("UltiToolsAPI.getDataOperator 拒绝未拥有的实体，消息与 DataScope 重载完全一致")
+        void ultiToolsApiGetDataOperatorShouldRefuseUnownedEntityIdentically() throws Exception {
+            org.bukkit.plugin.java.JavaPlugin externalPlugin =
+                    org.mockbukkit.mockbukkit.MockBukkit.createMockPlugin("UltiToolsApiLegacyRoutingFixture");
+            com.ultikits.ultitools.api.ExternalPluginAdapter adapter =
+                    new com.ultikits.ultitools.api.ExternalPluginAdapter(externalPlugin);
+            DataScope scope = scopeFor(adapter.getPluginName(), java.util.Collections.emptySet(),
+                    adapter.getDataFolder());
+            adapter.setDataScope(scope);
+            putAdapter(externalPlugin, adapter);
+
+            try {
+                com.ultikits.ultitools.exceptions.DataAccessException viaWrapper =
+                        org.junit.jupiter.api.Assertions.assertThrows(
+                                com.ultikits.ultitools.exceptions.DataAccessException.class,
+                                () -> com.ultikits.ultitools.api.UltiToolsAPI.getDataOperator(
+                                        externalPlugin, OwnedEntity.class));
+                com.ultikits.ultitools.exceptions.DataAccessException viaDataScope =
+                        org.junit.jupiter.api.Assertions.assertThrows(
+                                com.ultikits.ultitools.exceptions.DataAccessException.class,
+                                () -> { throw scope.refusalFor(OwnedEntity.class); });
+
+                assertThat(viaWrapper.getErrorCode())
+                        .isEqualTo(com.ultikits.ultitools.exceptions.ErrorCode.ENTITY_NOT_OWNED);
+                assertThat(viaWrapper.getMessage()).isEqualTo(viaDataScope.getMessage());
+            } finally {
+                removeAdapter(externalPlugin);
+            }
+        }
+
+        @Test
+        @DisplayName("外部插件经 UltiToolsAPI.getDataOperator 解析到的存储位置，路由前后完全一致（SQLite）")
+        void externalPluginStorageLocationShouldBeUnchangedBySqliteRouting() throws Exception {
+            // Proves the D-18 routing change moves no data: SQLiteDataStore.getOperator(File,
+            // Class) itself is byte-for-byte untouched by this plan (git diff confirms zero
+            // changes to SQLiteDataStore.java), and UltiToolsAPI.getDataOperator's final
+            // delegating line is the same call it always was -- the new ownership check only runs
+            // BEFORE it. Both the pre-Task-3 call shape (direct File overload) and the
+            // post-Task-3 shape (through UltiToolsAPI) must resolve to the exact same pool.
+            org.bukkit.plugin.java.JavaPlugin externalPlugin =
+                    org.mockbukkit.mockbukkit.MockBukkit.createMockPlugin("SqlitePathPreservationFixture");
+            com.ultikits.ultitools.api.ExternalPluginAdapter adapter =
+                    new com.ultikits.ultitools.api.ExternalPluginAdapter(externalPlugin);
+            DataScope scope = scopeFor(adapter.getPluginName(),
+                    java.util.Collections.singleton(OwnedEntity.class), adapter.getDataFolder());
+            adapter.setDataScope(scope);
+            putAdapter(externalPlugin, adapter);
+
+            try {
+                SQLiteDataStore sqliteStore = new SQLiteDataStore();
+                try (org.mockito.MockedConstruction<HikariConfig> mockedConfig =
+                             org.mockito.Mockito.mockConstruction(HikariConfig.class);
+                     org.mockito.MockedConstruction<HikariDataSource> mockedDataSource =
+                             org.mockito.Mockito.mockConstruction(HikariDataSource.class);
+                     org.mockito.MockedConstruction<com.ultikits.ultitools.interfaces.impl.data.sqlite.SQLiteDataOperator<OwnedEntity>>
+                             mockedOperator = org.mockito.Mockito.mockConstruction(
+                                     (Class<com.ultikits.ultitools.interfaces.impl.data.sqlite.SQLiteDataOperator<OwnedEntity>>)
+                                             (Class<?>) com.ultikits.ultitools.interfaces.impl.data.sqlite.SQLiteDataOperator.class)) {
+                    // Pre-Task-3 shape: the raw, unchecked File overload.
+                    Object beforeOperator = sqliteStore.getOperator(adapter.getDataFolder(), OwnedEntity.class);
+
+                    com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(
+                            ultiTools -> when(ultiTools.getDataStore()).thenReturn(sqliteStore));
+
+                    // Post-Task-3 shape: through UltiToolsAPI's now ownership-checked wrapper.
+                    Object afterOperator = com.ultikits.ultitools.api.UltiToolsAPI.getDataOperator(
+                            externalPlugin, OwnedEntity.class);
+
+                    // One pool, shared by both call shapes -- the routing change moved nothing.
+                    assertThat(mockedDataSource.constructed()).hasSize(1);
+                    assertThat(afterOperator).isSameAs(beforeOperator);
+                }
+            } finally {
+                removeAdapter(externalPlugin);
+            }
+        }
+
+        @Test
+        @DisplayName("getOperator(File, Class) 默认实现：未注册的数据文件夹应该被拒绝，而不是不加校验地放行")
+        void unregisteredDataFolderShouldBeRefusedNotServed() {
+            PluginManager pluginManager = mock(PluginManager.class);
+            when(pluginManager.findScopeForDataFolder(org.mockito.ArgumentMatchers.any(File.class)))
+                    .thenReturn(null);
+            com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(
+                    ultiTools -> when(ultiTools.getPluginManager()).thenReturn(pluginManager));
+
+            DataStore stubStore = mock(DataStore.class, org.mockito.Answers.CALLS_REAL_METHODS);
+            when(stubStore.getStoreType()).thenReturn("stub-store");
+            File unregisteredFolder = new File(System.getProperty("java.io.tmpdir"), "ultitools-test-unregistered");
+
+            com.ultikits.ultitools.exceptions.DataAccessException thrown =
+                    org.junit.jupiter.api.Assertions.assertThrows(
+                            com.ultikits.ultitools.exceptions.DataAccessException.class,
+                            () -> stubStore.getOperator(unregisteredFolder, OwnedEntity.class));
+
+            assertThat(thrown.getErrorCode()).isEqualTo(com.ultikits.ultitools.exceptions.ErrorCode.ENTITY_NOT_OWNED);
+        }
+
+        @Test
+        @DisplayName("getOperator(File, Class) 默认实现：注册过的文件夹里未拥有的实体也应该被拒绝")
+        void registeredFolderWithUnownedEntityShouldBeRefused() {
+            File folder = new File(System.getProperty("java.io.tmpdir"), "ultitools-test-registered-unowned");
+            DataScope scope = scopeFor("RegisteredPlugin", java.util.Collections.emptySet(), folder);
+            PluginManager pluginManager = mock(PluginManager.class);
+            when(pluginManager.findScopeForDataFolder(folder)).thenReturn(scope);
+            com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(
+                    ultiTools -> when(ultiTools.getPluginManager()).thenReturn(pluginManager));
+
+            DataStore stubStore = mock(DataStore.class, org.mockito.Answers.CALLS_REAL_METHODS);
+            when(stubStore.getStoreType()).thenReturn("stub-store");
+
+            com.ultikits.ultitools.exceptions.DataAccessException thrown =
+                    org.junit.jupiter.api.Assertions.assertThrows(
+                            com.ultikits.ultitools.exceptions.DataAccessException.class,
+                            () -> stubStore.getOperator(folder, OwnedEntity.class));
+
+            assertThat(thrown.getErrorCode()).isEqualTo(com.ultikits.ultitools.exceptions.ErrorCode.ENTITY_NOT_OWNED);
+        }
+
+        private void putAdapter(org.bukkit.plugin.java.JavaPlugin plugin,
+                com.ultikits.ultitools.api.ExternalPluginAdapter adapter) throws Exception {
+            adaptersField().put(plugin, adapter);
+        }
+
+        private void removeAdapter(org.bukkit.plugin.java.JavaPlugin plugin) throws Exception {
+            adaptersField().remove(plugin);
+        }
+
+        @SuppressWarnings("unchecked")
+        private java.util.Map<org.bukkit.plugin.java.JavaPlugin, com.ultikits.ultitools.api.ExternalPluginAdapter>
+                adaptersField() throws Exception {
+            Field field = com.ultikits.ultitools.api.UltiToolsAPI.class.getDeclaredField("adapters");
+            field.setAccessible(true);
+            return (java.util.Map<org.bukkit.plugin.java.JavaPlugin, com.ultikits.ultitools.api.ExternalPluginAdapter>)
+                    field.get(null);
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
@@ -12,11 +12,14 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import javax.sql.DataSource;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +31,10 @@ import org.mockito.ArgumentCaptor;
 
 import com.ultikits.ultitools.interfaces.DataStore;
 import com.ultikits.ultitools.interfaces.impl.data.json.JsonStore;
+import com.ultikits.ultitools.interfaces.impl.data.sqlite.SQLiteDataStore;
+import com.ultikits.ultitools.testutil.PoolStateAssertions;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.ServerMock;
@@ -571,6 +578,62 @@ class DataStoreManagerTest {
             org.mockito.Mockito.verify(store1).destroyAllOperators();
             org.mockito.Mockito.verify(store2).destroyAllOperators();
             org.mockito.Mockito.verify(store3).destroyAllOperators();
+        }
+    }
+
+    @Nested
+    @DisplayName("destroyAllOperators 真实连接池状态测试 (Wave 0 gap 1, SILENT-03)")
+    class PoolTeardownRealPoolTests {
+
+        private HikariDataSource createH2Pool() {
+            HikariConfig config = new HikariConfig();
+            // H2 stands in for SQLite here - the SQLite JDBC driver ships with Paper, not with this
+            // project's test dependencies, so a real jdbc:sqlite: pool cannot be constructed in tests.
+            config.setJdbcUrl("jdbc:h2:mem:datastoremanagerpooltest" + System.nanoTime() + ";DB_CLOSE_DELAY=-1;MODE=MySQL");
+            config.setUsername("sa");
+            return new HikariDataSource(config);
+        }
+
+        /**
+         * Pins ROADMAP success criterion 3 through the actual {@code DataStoreManager.close()} call
+         * path (not just {@code SQLiteDataStore.destroyAllOperators()} in isolation): registers a real
+         * {@code SQLiteDataStore} carrying two live H2-backed pools, closes the manager, and asserts
+         * against {@link com.zaxxer.hikari.HikariPoolMXBean} state via {@link PoolStateAssertions} -
+         * not against the absence of a thrown exception.
+         * <p>
+         * RED at HEAD (before Task 2's fix): {@code SQLiteDataStore.destroyAllOperators()} is an empty
+         * body, so both pools remain open. GREEN after Task 2.
+         */
+        @Test
+        @DisplayName("close() 应该让已注册 SQLiteDataStore 持有的每个连接池归零")
+        void closeShouldLeaveZeroOpenConnectionsAcrossRegisteredStore() throws Exception {
+            SQLiteDataStore sqliteStore = new SQLiteDataStore();
+            HikariDataSource poolA = createH2Pool();
+            HikariDataSource poolB = createH2Pool();
+
+            Field poolMapField = SQLiteDataStore.class.getDeclaredField("dataSourceMap");
+            poolMapField.setAccessible(true); // NOPMD
+            @SuppressWarnings("unchecked")
+            Map<String, DataSource> poolMap = (Map<String, DataSource>) poolMapField.get(sqliteStore);
+            poolMap.put("fileA", poolA);
+            poolMap.put("fileB", poolB);
+
+            try {
+                DataStoreManager.register(sqliteStore);
+
+                DataStoreManager.close();
+
+                PoolStateAssertions.assertNoOpenConnections(Arrays.asList(poolA, poolB));
+            } finally {
+                if (!poolA.isClosed()) {
+                    poolA.close();
+                }
+                if (!poolB.isClosed()) {
+                    poolB.close();
+                }
+                poolMap.remove("fileA");
+                poolMap.remove("fileB");
+            }
         }
     }
 

--- a/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
@@ -992,8 +992,15 @@ class DataStoreManagerTest {
         }
 
         @Test
-        @DisplayName("拥有的实体不受影响 -- UltiToolsPlugin.getDataOperator 仍然委托给原来的 plugin 重载")
-        void ultiToolsPluginGetDataOperatorShouldStillDelegateForOwnedEntity() {
+        @DisplayName("拥有的实体不受影响 -- UltiToolsPlugin.getDataOperator 现在路由到 getOperator(DataScope, Class)（CR-03, 02-13）")
+        void ultiToolsPluginGetDataOperatorShouldRouteThroughDataScopeOverload() {
+            // Was: ultiToolsPluginGetDataOperatorShouldStillDelegateForOwnedEntity, which verified
+            // this called the deprecated getOperator(UltiToolsPlugin, Class) overload. CR-03
+            // (02-REVIEW.md) found getOperator(DataScope, Class) -- the method D-17/02-07 built
+            // specifically as "the supported path" -- had ZERO real callers under src/main; both
+            // framework entry points performed their own ownership check and then called straight
+            // into the legacy overloads instead. 02-13 fixes this: production now reaches the
+            // credential-typed method it was built for.
             DataScope scope = scopeFor("PluginOwns", java.util.Collections.singleton(OwnedEntity.class),
                     new File(System.getProperty("java.io.tmpdir"), "ultitools-test-legacy-plugin-owns"));
             com.ultikits.ultitools.abstracts.UltiToolsPlugin plugin =
@@ -1004,7 +1011,7 @@ class DataStoreManagerTest {
             com.ultikits.ultitools.interfaces.DataOperator<OwnedEntity> fakeOperator =
                     mock(com.ultikits.ultitools.interfaces.DataOperator.class);
             DataStore dataStore = mock(DataStore.class);
-            when(dataStore.getOperator(plugin, OwnedEntity.class)).thenReturn(fakeOperator);
+            when(dataStore.getOperator(scope, OwnedEntity.class)).thenReturn(fakeOperator);
             com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(
                     ultiTools -> when(ultiTools.getDataStore()).thenReturn(dataStore));
 
@@ -1012,8 +1019,9 @@ class DataStoreManagerTest {
                     plugin.getDataOperator(OwnedEntity.class);
 
             assertThat(result).isSameAs(fakeOperator);
-            // Still the original, path-correct plugin overload -- no relocation.
-            verify(dataStore).getOperator(plugin, OwnedEntity.class);
+            // The documented supported path, not the deprecated plugin overload.
+            verify(dataStore).getOperator(scope, OwnedEntity.class);
+            verify(dataStore, org.mockito.Mockito.never()).getOperator(plugin, OwnedEntity.class);
         }
 
         @Test
@@ -1042,6 +1050,41 @@ class DataStoreManagerTest {
                 assertThat(viaWrapper.getErrorCode())
                         .isEqualTo(com.ultikits.ultitools.exceptions.ErrorCode.ENTITY_NOT_OWNED);
                 assertThat(viaWrapper.getMessage()).isEqualTo(viaDataScope.getMessage());
+            } finally {
+                removeAdapter(externalPlugin);
+            }
+        }
+
+        @Test
+        @DisplayName("拥有的实体不受影响 -- UltiToolsAPI.getDataOperator 现在路由到 getOperator(DataScope, Class)（CR-03, 02-13）")
+        void ultiToolsApiGetDataOperatorShouldRouteThroughDataScopeOverload() throws Exception {
+            // Counterpart of ultiToolsPluginGetDataOperatorShouldRouteThroughDataScopeOverload for
+            // the external-plugin entry point (CR-03, 02-REVIEW.md).
+            org.bukkit.plugin.java.JavaPlugin externalPlugin =
+                    org.mockbukkit.mockbukkit.MockBukkit.createMockPlugin("UltiToolsApiDataScopeRoutingFixture");
+            com.ultikits.ultitools.api.ExternalPluginAdapter adapter =
+                    new com.ultikits.ultitools.api.ExternalPluginAdapter(externalPlugin);
+            DataScope scope = scopeFor(adapter.getPluginName(),
+                    java.util.Collections.singleton(OwnedEntity.class), adapter.getDataFolder());
+            adapter.setDataScope(scope);
+            putAdapter(externalPlugin, adapter);
+
+            try {
+                @SuppressWarnings("unchecked")
+                com.ultikits.ultitools.interfaces.DataOperator<OwnedEntity> fakeOperator =
+                        mock(com.ultikits.ultitools.interfaces.DataOperator.class);
+                DataStore dataStore = mock(DataStore.class);
+                when(dataStore.getOperator(scope, OwnedEntity.class)).thenReturn(fakeOperator);
+                com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(
+                        ultiTools -> when(ultiTools.getDataStore()).thenReturn(dataStore));
+
+                com.ultikits.ultitools.interfaces.DataOperator<OwnedEntity> result =
+                        com.ultikits.ultitools.api.UltiToolsAPI.getDataOperator(externalPlugin, OwnedEntity.class);
+
+                assertThat(result).isSameAs(fakeOperator);
+                verify(dataStore).getOperator(scope, OwnedEntity.class);
+                verify(dataStore, org.mockito.Mockito.never())
+                        .getOperator(adapter.getDataFolder(), OwnedEntity.class);
             } finally {
                 removeAdapter(externalPlugin);
             }

--- a/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
@@ -1050,7 +1050,7 @@ class DataStoreManagerTest {
             // touching getDataStore(). A real DataStore (default methods live) is needed here so
             // the interface's own getOperator(DataScope, Class) body actually runs the check.
             org.bukkit.plugin.java.JavaPlugin externalPlugin =
-                    org.mockbukkit.mockbukkit.MockBukkit.createMockPlugin("UltiToolsApiLegacyRoutingFixture");
+                    MockBukkit.createMockPlugin("UltiToolsApiLegacyRoutingFixture");
             com.ultikits.ultitools.api.ExternalPluginAdapter adapter =
                     new com.ultikits.ultitools.api.ExternalPluginAdapter(externalPlugin);
             DataScope scope = scopeFor(adapter.getPluginName(), java.util.Collections.emptySet(),
@@ -1086,7 +1086,7 @@ class DataStoreManagerTest {
             // Counterpart of ultiToolsPluginGetDataOperatorShouldRouteThroughDataScopeOverload for
             // the external-plugin entry point (CR-03, 02-REVIEW.md).
             org.bukkit.plugin.java.JavaPlugin externalPlugin =
-                    org.mockbukkit.mockbukkit.MockBukkit.createMockPlugin("UltiToolsApiDataScopeRoutingFixture");
+                    MockBukkit.createMockPlugin("UltiToolsApiDataScopeRoutingFixture");
             com.ultikits.ultitools.api.ExternalPluginAdapter adapter =
                     new com.ultikits.ultitools.api.ExternalPluginAdapter(externalPlugin);
             DataScope scope = scopeFor(adapter.getPluginName(),
@@ -1127,7 +1127,7 @@ class DataStoreManagerTest {
             // statement, which is why this test now also stubs findScopeForDataFolder below. The
             // path-resolution and pool-caching logic after that first line remains unchanged.)
             org.bukkit.plugin.java.JavaPlugin externalPlugin =
-                    org.mockbukkit.mockbukkit.MockBukkit.createMockPlugin("SqlitePathPreservationFixture");
+                    MockBukkit.createMockPlugin("SqlitePathPreservationFixture");
             com.ultikits.ultitools.api.ExternalPluginAdapter adapter =
                     new com.ultikits.ultitools.api.ExternalPluginAdapter(externalPlugin);
             DataScope scope = scopeFor(adapter.getPluginName(),
@@ -1231,11 +1231,11 @@ class DataStoreManagerTest {
         }
 
         @SuppressWarnings("unchecked")
-        private java.util.Map<org.bukkit.plugin.java.JavaPlugin, com.ultikits.ultitools.api.ExternalPluginAdapter>
+        private Map<org.bukkit.plugin.java.JavaPlugin, com.ultikits.ultitools.api.ExternalPluginAdapter>
                 adaptersField() throws Exception {
             Field field = com.ultikits.ultitools.api.UltiToolsAPI.class.getDeclaredField("adapters");
             field.setAccessible(true);
-            return (java.util.Map<org.bukkit.plugin.java.JavaPlugin, com.ultikits.ultitools.api.ExternalPluginAdapter>)
+            return (Map<org.bukkit.plugin.java.JavaPlugin, com.ultikits.ultitools.api.ExternalPluginAdapter>)
                     field.get(null);
         }
     }

--- a/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
@@ -869,25 +869,33 @@ class DataStoreManagerTest {
         }
 
         @Test
-        @DisplayName("拥有的实体应该返回一个可用的操作器（走 default 方法委托给 File 重载）")
+        @DisplayName("拥有的实体应该返回一个可用的操作器（走 default 方法委托给 getOperatorUnchecked，CR-01/02-13）")
         void ownedEntityShouldReturnAWorkingOperator() {
+            // Was: delegates to the File overload. CR-01 (02-REVIEW.md) found that delegation path
+            // was exactly how the framework-core-folder ownership bypass reached an INTERNAL
+            // scope -- 02-13 changes getOperator(DataScope, Class)'s default body to delegate to
+            // the new unchecked getOperatorUnchecked(DataScope, Class) instead, which carries no
+            // ownership check of its own and is reachable only after this method's own
+            // scope.owns(...) check has already passed.
             @SuppressWarnings("unchecked")
             com.ultikits.ultitools.interfaces.DataOperator<OwnedEntity> fakeOperator =
                     mock(com.ultikits.ultitools.interfaces.DataOperator.class);
             DataStore stubStore = mock(DataStore.class, org.mockito.Answers.CALLS_REAL_METHODS);
             when(stubStore.getStoreType()).thenReturn("stub-store");
-            // doReturn().when(), not when().thenReturn(): the File-overload's real default body
+            // doReturn().when(), not when().thenReturn(): getOperatorUnchecked's real default body
             // throws unconditionally, and with CALLS_REAL_METHODS as the mock's default answer,
-            // when(stubStore.getOperator(...)) would evaluate that real (throwing) call as part of
-            // recording the stub. doReturn() never invokes the real method to determine this.
-            org.mockito.Mockito.doReturn(fakeOperator).when(stubStore)
-                    .getOperator(org.mockito.ArgumentMatchers.any(File.class), eq(OwnedEntity.class));
+            // when(stubStore.getOperatorUnchecked(...)) would evaluate that real (throwing) call as
+            // part of recording the stub. doReturn() never invokes the real method to determine this.
             DataScope scope = scopeFor("Owner", java.util.Collections.singleton(OwnedEntity.class));
+            org.mockito.Mockito.doReturn(fakeOperator).when(stubStore)
+                    .getOperatorUnchecked(scope, OwnedEntity.class);
 
             com.ultikits.ultitools.interfaces.DataOperator<OwnedEntity> result =
                     stubStore.getOperator(scope, OwnedEntity.class);
 
             assertThat(result).isSameAs(fakeOperator);
+            verify(stubStore, org.mockito.Mockito.never())
+                    .getOperator(org.mockito.ArgumentMatchers.any(File.class), eq(OwnedEntity.class));
         }
 
         @Test
@@ -972,11 +980,19 @@ class DataStoreManagerTest {
         @Test
         @DisplayName("UltiToolsPlugin.getDataOperator 拒绝未拥有的实体，消息与 DataScope 重载完全一致")
         void ultiToolsPluginGetDataOperatorShouldRefuseUnownedEntityIdentically() {
+            // 02-13 (CR-03): getDataOperator now routes unconditionally through
+            // getDataStore().getOperator(dataScope, dataClazz) -- including the refusal path,
+            // which previously short-circuited on its own inline dataScope.owns(...) check before
+            // ever touching getDataStore(). A real DataStore (default methods live) is needed here
+            // so the interface's own getOperator(DataScope, Class) body actually runs the check.
             DataScope scope = scopeFor("PluginX", java.util.Collections.emptySet(),
                     new File(System.getProperty("java.io.tmpdir"), "ultitools-test-legacy-plugin"));
             com.ultikits.ultitools.abstracts.UltiToolsPlugin plugin =
                     mock(com.ultikits.ultitools.abstracts.UltiToolsPlugin.class, org.mockito.Answers.CALLS_REAL_METHODS);
             plugin.setDataScope(scope);
+            DataStore dataStore = mock(DataStore.class, org.mockito.Answers.CALLS_REAL_METHODS);
+            com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(
+                    ultiTools -> when(ultiTools.getDataStore()).thenReturn(dataStore));
 
             com.ultikits.ultitools.exceptions.DataAccessException viaWrapper =
                     org.junit.jupiter.api.Assertions.assertThrows(
@@ -1027,6 +1043,11 @@ class DataStoreManagerTest {
         @Test
         @DisplayName("UltiToolsAPI.getDataOperator 拒绝未拥有的实体，消息与 DataScope 重载完全一致")
         void ultiToolsApiGetDataOperatorShouldRefuseUnownedEntityIdentically() throws Exception {
+            // 02-13 (CR-03): getDataOperator now routes unconditionally through
+            // getDataStore().getOperator(scope, dataEntity) -- including the refusal path, which
+            // previously short-circuited on its own inline scope.owns(...) check before ever
+            // touching getDataStore(). A real DataStore (default methods live) is needed here so
+            // the interface's own getOperator(DataScope, Class) body actually runs the check.
             org.bukkit.plugin.java.JavaPlugin externalPlugin =
                     org.mockbukkit.mockbukkit.MockBukkit.createMockPlugin("UltiToolsApiLegacyRoutingFixture");
             com.ultikits.ultitools.api.ExternalPluginAdapter adapter =
@@ -1035,6 +1056,9 @@ class DataStoreManagerTest {
                     adapter.getDataFolder());
             adapter.setDataScope(scope);
             putAdapter(externalPlugin, adapter);
+            DataStore dataStore = mock(DataStore.class, org.mockito.Answers.CALLS_REAL_METHODS);
+            com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(
+                    ultiTools -> when(ultiTools.getDataStore()).thenReturn(dataStore));
 
             try {
                 com.ultikits.ultitools.exceptions.DataAccessException viaWrapper =

--- a/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
+import com.ultikits.ultitools.context.SimpleContainer;
 import com.ultikits.ultitools.interfaces.DataStore;
 import com.ultikits.ultitools.interfaces.impl.data.json.JsonStore;
 import com.ultikits.ultitools.interfaces.impl.data.sqlite.SQLiteDataStore;
@@ -1236,6 +1237,130 @@ class DataStoreManagerTest {
             field.setAccessible(true);
             return (java.util.Map<org.bukkit.plugin.java.JavaPlugin, com.ultikits.ultitools.api.ExternalPluginAdapter>)
                     field.get(null);
+        }
+    }
+
+    /**
+     * 02-14 Task 2: an external scope registration cannot displace an existing one.
+     * <p>
+     * {@code registerExternalScope} previously used a plain {@code .put()} -- so wrapping another,
+     * already-registered plugin's data folder (all public calls -- {@code new
+     * ExternalPluginAdapter(Bukkit.getPluginManager().getPlugin("Victim"))}) and calling the public
+     * {@code registerExternal} would silently displace the victim's legitimate scope, poisoning the
+     * D-18 reverse lookup {@code DataStore.getOperator(File, Class)}'s default body depends on.
+     * These tests go through the real, un-mocked {@code PluginManager} end-to-end (not a stub),
+     * because the guard lives inside {@code registerExternal}'s own call to the private
+     * {@code registerExternalScope} -- there is no other way to exercise it.
+     */
+    @Nested
+    @DisplayName("registerExternalScope 不可被覆盖测试 (D-18, 02-14 Task 2)")
+    class RegisterExternalScopeTests {
+
+        private PluginManager pluginManager;
+
+        @BeforeEach
+        void setUpPluginManager() {
+            DependenceManagers dependenceManagers = mock(DependenceManagers.class);
+            SimpleContainer parentContext = new SimpleContainer();
+            parentContext.refresh();
+            when(dependenceManagers.getContext()).thenReturn(parentContext);
+
+            pluginManager = new PluginManager();
+            com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+                when(ultiTools.getDependenceManagers()).thenReturn(dependenceManagers);
+                when(ultiTools.getPluginManager()).thenReturn(pluginManager);
+                when(ultiTools.getCommandManager()).thenReturn(new CommandManager());
+                when(ultiTools.getListenerManager()).thenReturn(new ListenerManager());
+                // wireAop (02-01) resolves a DataSource through getDataStore() for the
+                // @Transactional advisor -- CALLS_REAL_METHODS lets the interface's own default
+                // getDataSource(DataScope) run and throw UnsupportedOperationException (wireAop's
+                // existing graceful "declare unavailable" fallback) instead of a bare mock's null
+                // surfacing as an NPE.
+                when(ultiTools.getDataStore()).thenReturn(mock(DataStore.class, org.mockito.Answers.CALLS_REAL_METHODS));
+            });
+        }
+
+        private org.bukkit.plugin.java.JavaPlugin mockExternal(String name, File dataFolder) {
+            org.bukkit.plugin.java.JavaPlugin plugin = mock(org.bukkit.plugin.java.JavaPlugin.class);
+            org.bukkit.plugin.PluginDescriptionFile desc = mock(org.bukkit.plugin.PluginDescriptionFile.class);
+            when(plugin.getName()).thenReturn(name);
+            when(plugin.getDescription()).thenReturn(desc);
+            when(desc.getVersion()).thenReturn("1.0.0");
+            when(desc.getAuthors()).thenReturn(java.util.Collections.emptyList());
+            // Top-level main class name (no dot) -> ExternalPluginAdapter.getScanPackage() is
+            // empty, so registerExternal skips component scanning entirely.
+            when(desc.getMain()).thenReturn(name + "Main");
+            when(plugin.getDataFolder()).thenReturn(dataFolder);
+            when(plugin.getLogger()).thenReturn(Logger.getLogger(name));
+            return plugin;
+        }
+
+        @Test
+        @DisplayName("第二个插件为已注册的数据文件夹注册 scope 时应被拒绝，原 scope 保持不变")
+        void secondRegistrationForSameFolderByDifferentPluginShouldBeRefused() {
+            File sharedFolder = new File(System.getProperty("java.io.tmpdir"), "ultitools-test-shared-folder-02-14");
+            org.bukkit.plugin.java.JavaPlugin victim = mockExternal("Victim", sharedFolder);
+            org.bukkit.plugin.java.JavaPlugin attacker = mockExternal("Attacker", sharedFolder);
+
+            com.ultikits.ultitools.api.ExternalPluginAdapter victimAdapter =
+                    new com.ultikits.ultitools.api.ExternalPluginAdapter(victim);
+            pluginManager.registerExternal(victimAdapter);
+            DataScope originalScope = pluginManager.findScopeForDataFolder(sharedFolder);
+            assertThat(originalScope).isNotNull();
+            assertThat(originalScope.getPluginName()).isEqualTo("Victim");
+
+            com.ultikits.ultitools.api.ExternalPluginAdapter attackerAdapter =
+                    new com.ultikits.ultitools.api.ExternalPluginAdapter(attacker);
+
+            com.ultikits.ultitools.exceptions.PluginModuleException thrown =
+                    org.junit.jupiter.api.Assertions.assertThrows(
+                            com.ultikits.ultitools.exceptions.PluginModuleException.class,
+                            () -> pluginManager.registerExternal(attackerAdapter));
+            assertThat(thrown.getMessage()).contains("Victim").contains("Attacker");
+
+            // The original scope must still be exactly what findScopeForDataFolder returns -- not
+            // displaced, and not even replaced by an equal-looking new instance.
+            assertThat(pluginManager.findScopeForDataFolder(sharedFolder)).isSameAs(originalScope);
+        }
+
+        @Test
+        @DisplayName("同一个插件重复注册同一个数据文件夹是幂等的，不应被拒绝")
+        void reRegistrationBySamePluginShouldBeIdempotent() {
+            File folder = new File(System.getProperty("java.io.tmpdir"), "ultitools-test-idempotent-folder-02-14");
+            org.bukkit.plugin.java.JavaPlugin plugin = mockExternal("SamePlugin", folder);
+
+            com.ultikits.ultitools.api.ExternalPluginAdapter firstAdapter =
+                    new com.ultikits.ultitools.api.ExternalPluginAdapter(plugin);
+            pluginManager.registerExternal(firstAdapter);
+
+            com.ultikits.ultitools.api.ExternalPluginAdapter secondAdapter =
+                    new com.ultikits.ultitools.api.ExternalPluginAdapter(plugin);
+            assertDoesNotThrow(() -> pluginManager.registerExternal(secondAdapter));
+            assertThat(pluginManager.findScopeForDataFolder(folder).getPluginName()).isEqualTo("SamePlugin");
+        }
+
+        @Test
+        @DisplayName("unregisterExternal 之后重新 registerExternal 同一文件夹应该成功（不会被永久锁死）")
+        void unregisterThenReRegisterForSameFolderShouldSucceed() {
+            File folder = new File(System.getProperty("java.io.tmpdir"), "ultitools-test-reconnect-folder-02-14");
+            org.bukkit.plugin.java.JavaPlugin plugin = mockExternal("ReconnectPlugin", folder);
+
+            com.ultikits.ultitools.api.ExternalPluginAdapter adapter =
+                    new com.ultikits.ultitools.api.ExternalPluginAdapter(plugin);
+            pluginManager.registerExternal(adapter);
+            assertThat(pluginManager.findScopeForDataFolder(folder)).isNotNull();
+
+            pluginManager.unregisterExternal(adapter);
+            // The previous behavior (the plan's "second finding"): unregisterExternal never
+            // cleared externalScopesByFolder, so this stayed non-null indefinitely after
+            // disconnect, and a fresh registerExternal for the same folder would have been wrongly
+            // refused as "already registered" by the very guard this Task adds.
+            assertThat(pluginManager.findScopeForDataFolder(folder)).isNull();
+
+            com.ultikits.ultitools.api.ExternalPluginAdapter freshAdapter =
+                    new com.ultikits.ultitools.api.ExternalPluginAdapter(plugin);
+            assertDoesNotThrow(() -> pluginManager.registerExternal(freshAdapter));
+            assertThat(pluginManager.findScopeForDataFolder(folder)).isNotNull();
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerAopWiringTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerAopWiringTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.mockito.MockedStatic;
 
 import com.ultikits.ultitools.UltiTools;
@@ -127,6 +128,39 @@ class PluginManagerAopWiringTest {
         String message = rootMessage(thrown);
         assertTrue(message.contains("Transactional"), message);
         assertTrue(message.contains("datasource.type"), message);
+    }
+
+    @Test
+    @DisplayName("Should declare @Transactional unavailable for any DataStore whose getDataSource(DataScope) "
+            + "throws UnsupportedOperationException, naming the configured backend (D-01, decoupled from JsonStore)")
+    void shouldRejectTransactionalBeanForAnyUnsupportedDataSource() {
+        // This is deliberately independent of JsonStore (see shouldRejectTransactionalBean above,
+        // which exercises the same fallback branch indirectly through JSON's real behavior at
+        // HEAD). 02-05 replaces JsonStore.getDataSource(DataScope) with a real snapshot-based
+        // implementation, at which point shouldRejectTransactionalBean's JSON-backed assertion
+        // stops applying -- this test pins the fallback branch itself, against a store built to
+        // throw regardless of what any concrete backend does, so it survives that change (02-04
+        // Task 3 action item: "so 02-05 has a test to flip rather than a behaviour to discover").
+        DataStore unsupportedStore = mock(DataStore.class, Answers.CALLS_REAL_METHODS);
+        when(unsupportedStore.getStoreType()).thenReturn("mystery-backend");
+        DataScope unsupportedScope = DataScope.forExternal("shouldRejectTransactionalBeanForAnyUnsupportedDataSource",
+                new File("build/test-wireaop-unsupported"), Collections.emptySet());
+
+        // Reuse the class-level static mock (setUpDataStore() already opened one for UltiTools on
+        // this thread) rather than opening a second one -- Mockito forbids two concurrent static
+        // mocks for the same class on the same thread.
+        UltiTools mockUltiTools = mock(UltiTools.class);
+        when(mockUltiTools.getDataStore()).thenReturn(unsupportedStore);
+        ultiToolsMock.when(UltiTools::getInstance).thenReturn(mockUltiTools);
+
+        SimpleContainer context = new SimpleContainer();
+        PluginManager.wireAop(context, unsupportedScope);
+        context.registerBean(Transactionally.class);
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, context::refresh);
+        String message = rootMessage(thrown);
+        assertTrue(message.contains("Transactional"), message);
+        assertTrue(message.contains("mystery-backend"), message);
     }
 
     @Test

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerAopWiringTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerAopWiringTest.java
@@ -6,16 +6,23 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
+import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.annotations.ExceptionCatch;
 import com.ultikits.ultitools.annotations.Transactional;
 import com.ultikits.ultitools.aop.AopAdvisor;
@@ -24,9 +31,36 @@ import com.ultikits.ultitools.aop.AopProxyResolver;
 import com.ultikits.ultitools.aop.ProxyFactory;
 import com.ultikits.ultitools.context.SimpleContainer;
 import com.ultikits.ultitools.exceptions.ContainerException;
+import com.ultikits.ultitools.interfaces.DataStore;
+import com.ultikits.ultitools.interfaces.impl.data.json.JsonStore;
 
 @DisplayName("PluginManager AOP wiring")
 class PluginManagerAopWiringTest {
+
+    // wireAop now resolves a DataSource through UltiTools.getInstance().getDataStore() (D-01).
+    // Every test in this file exercises @ExceptionCatch wiring or annotation-coverage plumbing,
+    // not @Transactional's JDBC path, so the JSON store's UnsupportedOperationException branch
+    // (declare-unavailable, matching pre-6.3.0 behavior) is the right stand-in here.
+    private MockedStatic<UltiTools> ultiToolsMock;
+    private DataScope scope;
+
+    @BeforeEach
+    void setUpDataStore() {
+        UltiTools mockUltiTools = mock(UltiTools.class);
+        DataStore jsonStore = new JsonStore("build/test-wireaop-json");
+        when(mockUltiTools.getDataStore()).thenReturn(jsonStore);
+        ultiToolsMock = mockStatic(UltiTools.class);
+        ultiToolsMock.when(UltiTools::getInstance).thenReturn(mockUltiTools);
+        scope = DataScope.forExternal("PluginManagerAopWiringTest", new File("build/test-wireaop-json"),
+                Collections.emptySet());
+    }
+
+    @AfterEach
+    void tearDownDataStore() {
+        if (ultiToolsMock != null) {
+            ultiToolsMock.close();
+        }
+    }
 
     public static class Guarded {
         @ExceptionCatch(silent = true)
@@ -46,7 +80,7 @@ class PluginManagerAopWiringTest {
     @DisplayName("Should register exactly one advisor, for @ExceptionCatch")
     void shouldRegisterExceptionCatchAdvisorOnly() {
         SimpleContainer context = new SimpleContainer();
-        PluginManager.wireAop(context);
+        PluginManager.wireAop(context, scope);
 
         AopProxyResolver resolver = context.getAopProxyResolver();
         assertNotNull(resolver, "wireAop must attach a resolver");
@@ -61,7 +95,7 @@ class PluginManagerAopWiringTest {
     @DisplayName("Should proxy a bean using @ExceptionCatch")
     void shouldProxyExceptionCatchBean() {
         SimpleContainer context = new SimpleContainer();
-        PluginManager.wireAop(context);
+        PluginManager.wireAop(context, scope);
         context.registerBean(Guarded.class);
         context.refresh();
 
@@ -74,7 +108,7 @@ class PluginManagerAopWiringTest {
     @DisplayName("Should swallow the exception through the wired @ExceptionCatch interceptor")
     void shouldSwallowThroughWiredInterceptor() {
         SimpleContainer context = new SimpleContainer();
-        PluginManager.wireAop(context);
+        PluginManager.wireAop(context, scope);
         context.registerBean(Guarded.class);
         context.refresh();
 
@@ -83,23 +117,23 @@ class PluginManagerAopWiringTest {
     }
 
     @Test
-    @DisplayName("Should reject a bean using @Transactional with a message naming #195/#196")
+    @DisplayName("Should reject a bean using @Transactional when the backend has no DataSource yet (JSON)")
     void shouldRejectTransactionalBean() {
         SimpleContainer context = new SimpleContainer();
-        PluginManager.wireAop(context);
+        PluginManager.wireAop(context, scope);
         context.registerBean(Transactionally.class);
 
         RuntimeException thrown = assertThrows(RuntimeException.class, context::refresh);
         String message = rootMessage(thrown);
         assertTrue(message.contains("Transactional"), message);
-        assertTrue(message.contains("#195"), message);
+        assertTrue(message.contains("datasource.type"), message);
     }
 
     @Test
     @DisplayName("Should leave plain beans unproxied")
     void shouldLeavePlainBeansAlone() {
         SimpleContainer context = new SimpleContainer();
-        PluginManager.wireAop(context);
+        PluginManager.wireAop(context, scope);
         context.registerBean(Plain.class);
         context.refresh();
 
@@ -110,7 +144,7 @@ class PluginManagerAopWiringTest {
     @DisplayName("Should produce a resolver that passes annotation coverage validation")
     void shouldPassAnnotationCoverageValidation() {
         SimpleContainer context = new SimpleContainer();
-        PluginManager.wireAop(context);
+        PluginManager.wireAop(context, scope);
 
         assertDoesNotThrow(() -> context.getAopProxyResolver().validateAnnotationCoverage());
     }
@@ -132,7 +166,7 @@ class PluginManagerAopWiringTest {
             SimpleContainer context = new SimpleContainer();
 
             ContainerException thrown =
-                    assertThrows(ContainerException.class, () -> PluginManager.wireAop(context));
+                    assertThrows(ContainerException.class, () -> PluginManager.wireAop(context, scope));
             assertTrue(thrown.getMessage().contains("Deprecated"), thrown.getMessage());
         }
     }

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerAopWiringTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerAopWiringTest.java
@@ -71,6 +71,29 @@ class PluginManagerAopWiringTest {
         }
     }
 
+    /**
+     * 02-12 Task 2: {@code JsonStore.getOperator(File, Class)} now calls {@code checkOwnership}
+     * as its first statement, so the two JSON-backend tests below (which call it directly,
+     * bypassing {@code getOperator(DataScope, Class)}) need a {@code PluginManager} whose {@code
+     * findScopeForDataFolder} resolves {@code "build/test-wireaop-json"} back to a scope that owns
+     * {@link JsonTestEntity} -- otherwise the call refuses before ever reaching the write it is
+     * actually testing. {@link #scope} itself is left with its pre-existing empty owned-entity set
+     * (it is also used by every other test in this file for {@code wireAop}, which does not
+     * examine that set); a separate scope carries the ownership these two tests specifically need.
+     */
+    private void stubJsonTestFolderOwnership() {
+        File dataFolder = new File("build/test-wireaop-json");
+        DataScope entityScope = DataScope.forExternal("PluginManagerAopWiringTest", dataFolder,
+                Collections.singleton(JsonTestEntity.class));
+        PluginManager pluginManager = mock(PluginManager.class);
+        when(pluginManager.findScopeForDataFolder(dataFolder)).thenReturn(entityScope);
+
+        UltiTools mockUltiTools = mock(UltiTools.class);
+        when(mockUltiTools.getDataStore()).thenReturn(jsonStore);
+        when(mockUltiTools.getPluginManager()).thenReturn(pluginManager);
+        ultiToolsMock.when(UltiTools::getInstance).thenReturn(mockUltiTools);
+    }
+
     public static class Guarded {
         @ExceptionCatch(silent = true)
         public String boom() { throw new IllegalStateException("boom"); }
@@ -172,6 +195,7 @@ class PluginManagerAopWiringTest {
     @DisplayName("A @Transactional method on the JSON backend that writes then throws leaves "
             + "the operator's contents unchanged (D-03, flipped from the pre-02-05 rejection case)")
     void shouldRollBackOnJsonBackendWhenTransactionalMethodThrows() {
+        stubJsonTestFolderOwnership();
         DataOperator<JsonTestEntity> operator =
                 jsonStore.getOperator(new File("build/test-wireaop-json"), JsonTestEntity.class);
 
@@ -191,6 +215,7 @@ class PluginManagerAopWiringTest {
     @DisplayName("A @Transactional method on the JSON backend that writes and returns normally "
             + "leaves the write committed")
     void shouldCommitOnJsonBackendWhenTransactionalMethodSucceeds() {
+        stubJsonTestFolderOwnership();
         DataOperator<JsonTestEntity> operator =
                 jsonStore.getOperator(new File("build/test-wireaop-json"), JsonTestEntity.class);
 

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerAopWiringTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerAopWiringTest.java
@@ -406,7 +406,7 @@ class PluginManagerAopWiringTest {
             }
 
             @Override
-            public <T extends com.ultikits.ultitools.abstracts.data.BaseDataEntity<String>> DataOperator<T> getOperator(
+            public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(
                     com.ultikits.ultitools.abstracts.UltiToolsPlugin plugin, Class<T> dataEntity) {
                 throw new UnsupportedOperationException("not needed by this test");
             }
@@ -418,6 +418,7 @@ class PluginManagerAopWiringTest {
 
             @Override
             public void destroyAllOperators() {
+                // intentional no-op: this fake DataStore has no operator pool for this test to tear down
             }
         };
         UltiTools mockUltiTools = mock(UltiTools.class);

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerAopWiringTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerAopWiringTest.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import javax.sql.DataSource;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,8 @@ import com.ultikits.ultitools.interfaces.TransactionManager;
 import com.ultikits.ultitools.interfaces.impl.data.json.JsonStore;
 import com.ultikits.ultitools.interfaces.impl.data.mysql.MysqlDataStore;
 import com.ultikits.ultitools.interfaces.impl.data.sqlite.SQLiteDataStore;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 
 @DisplayName("PluginManager AOP wiring")
 class PluginManagerAopWiringTest {
@@ -58,6 +61,23 @@ class PluginManagerAopWiringTest {
     private MockedStatic<UltiTools> ultiToolsMock;
     private DataScope scope;
     private JsonStore jsonStore;
+
+    // Real H2 DataSource backing the TimedTransactionally tests below (D-10 self-invocation
+    // proof) -- same "fake JDBC-capable DataStore" pattern TransactionalRollbackEndToEndTest
+    // uses for its own tracer test, needed here because a mocked JdbcTransactionManager cannot
+    // run a real begin()/setTimeout()/commit() cycle.
+    private static DataSource timedH2DataSource;
+
+    @BeforeAll
+    static void initTimedH2DataSource() {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:h2:mem:pluginmanageraopwiringtest_timed;DB_CLOSE_DELAY=-1;MODE=MySQL");
+        config.setUsername("sa");
+        // Deliberately no setPassword(): the in-memory DB is created password-less on first
+        // connection; an empty-string password reads as a hardcoded credential to static
+        // analysis. There is no credential here.
+        timedH2DataSource = new HikariDataSource(config);
+    }
 
     @BeforeEach
     void setUpDataStore() {
@@ -112,6 +132,47 @@ class PluginManagerAopWiringTest {
 
     public static class Plain {
         public String work() { return "plain"; }
+    }
+
+    /**
+     * Exercises {@code @Transactional(timeout=)} (D-10, 02-09) through both an external call and
+     * a self-invocation call, per the phase's standing obligation for AOP semantic changes.
+     * Reports the deadline the interceptor recorded via {@link TransactionManager#setTimeout} --
+     * the manager-level half of D-10; {@code TransactionDataOperatorTest.PerStatementTimeoutTests}
+     * (in scope for this same plan) separately proves the deadline flows through to an actual
+     * {@code PreparedStatement}'s {@code getQueryTimeout()} once read off the SAME kind of
+     * manager. Self-invocation dispatches through the identical {@code
+     * TransactionInterceptor.executeInNewTransaction} call site as an external call -- this
+     * repository's proxy is a subclass of the bean itself, not a delegate, so there is no second
+     * code path for self-invocation to diverge on (see CLAUDE.md's AOP section).
+     */
+    public static class TimedTransactionally {
+        private final TransactionManager txManager;
+
+        public TimedTransactionally(TransactionManager txManager) {
+            this.txManager = txManager;
+        }
+
+        @Transactional(timeout = 10)
+        public Long externalDeadline() {
+            return txManager.getTimeoutDeadlineNanos();
+        }
+
+        /** External caller invokes this; it self-invokes {@link #innerDeadline()}. */
+        public Long outerCallsInnerDeadline() {
+            return innerDeadline();
+        }
+
+        @Transactional(timeout = 10)
+        public Long innerDeadline() {
+            return txManager.getTimeoutDeadlineNanos();
+        }
+
+        /** No timeout requested -- the default. Neither call shape should record a deadline. */
+        @Transactional
+        public Long externalDeadlineNoTimeout() {
+            return txManager.getTimeoutDeadlineNanos();
+        }
     }
 
     @Table("plugin_manager_aop_wiring_test")
@@ -332,6 +393,76 @@ class PluginManagerAopWiringTest {
         assertSame(sharedManager, context.getBean(TransactionManager.class),
                 "wireAop must bind the interceptor to the exact manager MysqlDataStore itself "
                         + "resolves for this scope, not a second, independently-constructed one");
+    }
+
+    // ===== @Transactional(timeout=) via external call and self-invocation (D-10, 02-09) =====
+
+    /** Wires a real, working DataSourceTransactionManager -- see {@link #timedH2DataSource}. */
+    private TimedTransactionally buildTimedTransactionallyBean() {
+        DataStore fakeJdbcStore = new DataStore() {
+            @Override
+            public String getStoreType() {
+                return "fake-jdbc-timed";
+            }
+
+            @Override
+            public <T extends com.ultikits.ultitools.abstracts.data.BaseDataEntity<String>> DataOperator<T> getOperator(
+                    com.ultikits.ultitools.abstracts.UltiToolsPlugin plugin, Class<T> dataEntity) {
+                throw new UnsupportedOperationException("not needed by this test");
+            }
+
+            @Override
+            public DataSource getDataSource(DataScope scope) {
+                return timedH2DataSource;
+            }
+
+            @Override
+            public void destroyAllOperators() {
+            }
+        };
+        UltiTools mockUltiTools = mock(UltiTools.class);
+        when(mockUltiTools.getDataStore()).thenReturn(fakeJdbcStore);
+        ultiToolsMock.when(UltiTools::getInstance).thenReturn(mockUltiTools);
+
+        DataScope timedScope = DataScope.forExternal("TimedTransactionally", new File("build/test-wireaop-timed"),
+                Collections.emptySet());
+        SimpleContainer context = new SimpleContainer();
+        PluginManager.wireAop(context, timedScope);
+        context.registerBean(TimedTransactionally.class);
+        context.refresh();
+        return context.getBean(TimedTransactionally.class);
+    }
+
+    @Test
+    @DisplayName("@Transactional(timeout=10) via an external call records a real deadline")
+    void externalCallRecordsTimeoutDeadline() {
+        TimedTransactionally bean = buildTimedTransactionallyBean();
+
+        Long deadline = bean.externalDeadline();
+
+        assertNotNull(deadline, "an external call to a timed @Transactional method must record a deadline");
+    }
+
+    @Test
+    @DisplayName("@Transactional(timeout=10) via self-invocation records a real deadline too")
+    void selfInvocationRecordsTimeoutDeadline() {
+        TimedTransactionally bean = buildTimedTransactionallyBean();
+
+        Long deadline = bean.outerCallsInnerDeadline();
+
+        assertNotNull(deadline, "self-invocation dispatches through the same "
+                + "executeInNewTransaction call site as an external call -- see the class javadoc "
+                + "on TimedTransactionally");
+    }
+
+    @Test
+    @DisplayName("@Transactional() with no timeout (the default) records no deadline, externally called")
+    void externalCallWithNoTimeoutRecordsNoDeadline() {
+        TimedTransactionally bean = buildTimedTransactionallyBean();
+
+        Long deadline = bean.externalDeadlineNoTimeout();
+
+        assertNull(deadline, "the interceptor never calls setTimeout for the default (-1)");
     }
 
     @Test

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerAopWiringTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerAopWiringTest.java
@@ -3,6 +3,7 @@ package com.ultikits.ultitools.manager;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -15,6 +16,8 @@ import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +27,9 @@ import org.mockito.Answers;
 import org.mockito.MockedStatic;
 
 import com.ultikits.ultitools.UltiTools;
+import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
 import com.ultikits.ultitools.annotations.ExceptionCatch;
+import com.ultikits.ultitools.annotations.Table;
 import com.ultikits.ultitools.annotations.Transactional;
 import com.ultikits.ultitools.aop.AopAdvisor;
 import com.ultikits.ultitools.aop.AopEligibility;
@@ -32,6 +37,7 @@ import com.ultikits.ultitools.aop.AopProxyResolver;
 import com.ultikits.ultitools.aop.ProxyFactory;
 import com.ultikits.ultitools.context.SimpleContainer;
 import com.ultikits.ultitools.exceptions.ContainerException;
+import com.ultikits.ultitools.interfaces.DataOperator;
 import com.ultikits.ultitools.interfaces.DataStore;
 import com.ultikits.ultitools.interfaces.impl.data.json.JsonStore;
 
@@ -39,16 +45,18 @@ import com.ultikits.ultitools.interfaces.impl.data.json.JsonStore;
 class PluginManagerAopWiringTest {
 
     // wireAop now resolves a DataSource through UltiTools.getInstance().getDataStore() (D-01).
-    // Every test in this file exercises @ExceptionCatch wiring or annotation-coverage plumbing,
-    // not @Transactional's JDBC path, so the JSON store's UnsupportedOperationException branch
-    // (declare-unavailable, matching pre-6.3.0 behavior) is the right stand-in here.
+    // Every test in this file except the JSON-backend-specific ones below exercises
+    // @ExceptionCatch wiring or annotation-coverage plumbing, not @Transactional -- the JSON
+    // store is the stand-in DataStore for all of them, and since 02-05 it is genuinely wired
+    // rather than declared unavailable (D-03).
     private MockedStatic<UltiTools> ultiToolsMock;
     private DataScope scope;
+    private JsonStore jsonStore;
 
     @BeforeEach
     void setUpDataStore() {
         UltiTools mockUltiTools = mock(UltiTools.class);
-        DataStore jsonStore = new JsonStore("build/test-wireaop-json");
+        jsonStore = new JsonStore("build/test-wireaop-json");
         when(mockUltiTools.getDataStore()).thenReturn(jsonStore);
         ultiToolsMock = mockStatic(UltiTools.class);
         ultiToolsMock.when(UltiTools::getInstance).thenReturn(mockUltiTools);
@@ -77,19 +85,62 @@ class PluginManagerAopWiringTest {
         public String work() { return "plain"; }
     }
 
+    @Table("plugin_manager_aop_wiring_test")
+    public static class JsonTestEntity extends BaseDataEntity<String> {
+        private String name;
+
+        public JsonTestEntity() {
+        }
+
+        public JsonTestEntity(String id, String name) {
+            setId(id);
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    /** A bean carrying a real @Transactional write against a real JSON-backed DataOperator. */
+    public static class JsonTransactionally {
+        private final DataOperator<JsonTestEntity> operator;
+
+        public JsonTransactionally(DataOperator<JsonTestEntity> operator) {
+            this.operator = operator;
+        }
+
+        @Transactional
+        public void writeThenFail() {
+            operator.insert(new JsonTestEntity("json-tx-fail", "before-rollback"));
+            throw new RuntimeException("boom - json backend");
+        }
+
+        @Transactional
+        public void writeThenSucceed() {
+            operator.insert(new JsonTestEntity("json-tx-success", "after-commit"));
+        }
+    }
+
     @Test
-    @DisplayName("Should register exactly one advisor, for @ExceptionCatch")
-    void shouldRegisterExceptionCatchAdvisorOnly() {
+    @DisplayName("Should register both advisors -- @ExceptionCatch and @Transactional -- for the JSON backend")
+    void shouldRegisterBothAdvisorsForJsonBackend() {
         SimpleContainer context = new SimpleContainer();
         PluginManager.wireAop(context, scope);
 
         AopProxyResolver resolver = context.getAopProxyResolver();
         assertNotNull(resolver, "wireAop must attach a resolver");
         List<AopAdvisor> advisors = resolver.getAdvisors();
-        assertEquals(1, advisors.size(),
-                "@Transactional is declared unavailable this release, so only one advisor");
-        assertEquals(ExceptionCatch.class, advisors.get(0).getAnnotationType(),
-                "the one registered advisor must actually be the one that serves @ExceptionCatch");
+        assertEquals(2, advisors.size(),
+                "@Transactional is wired on the JSON backend since 02-05 (D-03), so both advisors register");
+        Set<Class<? extends Annotation>> annotationTypes =
+                advisors.stream().map(AopAdvisor::getAnnotationType).collect(Collectors.toSet());
+        assertTrue(annotationTypes.contains(ExceptionCatch.class), annotationTypes.toString());
+        assertTrue(annotationTypes.contains(Transactional.class), annotationTypes.toString());
     }
 
     @Test
@@ -118,16 +169,41 @@ class PluginManagerAopWiringTest {
     }
 
     @Test
-    @DisplayName("Should reject a bean using @Transactional when the backend has no DataSource yet (JSON)")
-    void shouldRejectTransactionalBean() {
+    @DisplayName("A @Transactional method on the JSON backend that writes then throws leaves "
+            + "the operator's contents unchanged (D-03, flipped from the pre-02-05 rejection case)")
+    void shouldRollBackOnJsonBackendWhenTransactionalMethodThrows() {
+        DataOperator<JsonTestEntity> operator =
+                jsonStore.getOperator(new File("build/test-wireaop-json"), JsonTestEntity.class);
+
         SimpleContainer context = new SimpleContainer();
         PluginManager.wireAop(context, scope);
-        context.registerBean(Transactionally.class);
+        context.registerType(DataOperator.class, operator);
+        context.registerBean(JsonTransactionally.class);
+        context.refresh();
 
-        RuntimeException thrown = assertThrows(RuntimeException.class, context::refresh);
-        String message = rootMessage(thrown);
-        assertTrue(message.contains("Transactional"), message);
-        assertTrue(message.contains("datasource.type"), message);
+        JsonTransactionally bean = context.getBean(JsonTransactionally.class);
+
+        assertThrows(RuntimeException.class, bean::writeThenFail);
+        assertNull(operator.getById("json-tx-fail"), "the insert must have been rolled back");
+    }
+
+    @Test
+    @DisplayName("A @Transactional method on the JSON backend that writes and returns normally "
+            + "leaves the write committed")
+    void shouldCommitOnJsonBackendWhenTransactionalMethodSucceeds() {
+        DataOperator<JsonTestEntity> operator =
+                jsonStore.getOperator(new File("build/test-wireaop-json"), JsonTestEntity.class);
+
+        SimpleContainer context = new SimpleContainer();
+        PluginManager.wireAop(context, scope);
+        context.registerType(DataOperator.class, operator);
+        context.registerBean(JsonTransactionally.class);
+        context.refresh();
+
+        JsonTransactionally bean = context.getBean(JsonTransactionally.class);
+
+        bean.writeThenSucceed();
+        assertNotNull(operator.getById("json-tx-success"), "the insert must have been committed");
     }
 
     @Test

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerAopWiringTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerAopWiringTest.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.sql.DataSource;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -39,7 +41,11 @@ import com.ultikits.ultitools.context.SimpleContainer;
 import com.ultikits.ultitools.exceptions.ContainerException;
 import com.ultikits.ultitools.interfaces.DataOperator;
 import com.ultikits.ultitools.interfaces.DataStore;
+import com.ultikits.ultitools.interfaces.JdbcTransactionManager;
+import com.ultikits.ultitools.interfaces.TransactionManager;
 import com.ultikits.ultitools.interfaces.impl.data.json.JsonStore;
+import com.ultikits.ultitools.interfaces.impl.data.mysql.MysqlDataStore;
+import com.ultikits.ultitools.interfaces.impl.data.sqlite.SQLiteDataStore;
 
 @DisplayName("PluginManager AOP wiring")
 class PluginManagerAopWiringTest {
@@ -262,6 +268,70 @@ class PluginManagerAopWiringTest {
         String message = rootMessage(thrown);
         assertTrue(message.contains("Transactional"), message);
         assertTrue(message.contains("mystery-backend"), message);
+    }
+
+    // ===== Single-instance TransactionManager property (02-09, T-02-TAM-11) =====
+
+    /**
+     * {@code SQLiteDataStore}/{@code MysqlDataStore} are concrete classes -- {@code
+     * mock(...)} bypasses their real constructors entirely (no pool, no connection, no
+     * {@code org.sqlite.JDBC}/live MySQL needed), while still satisfying {@code PluginManager}'s
+     * {@code instanceof SQLiteDataStore}/{@code instanceof MysqlDataStore} checks, which a
+     * hand-written {@code DataStore} stand-in (as most of this file's tests use) could not: those
+     * checks are on the concrete class, not the interface.
+     */
+    @Test
+    @DisplayName("Should bind the @Transactional advisor to the SAME JdbcTransactionManager "
+            + "SQLiteDataStore wires onto the operators it hands out, not an independent second "
+            + "instance (T-02-TAM-11)")
+    void shouldBindTransactionalAdvisorToSqliteStoreSharedManager() {
+        SQLiteDataStore sqliteStore = mock(SQLiteDataStore.class);
+        DataSource fakeDataSource = mock(DataSource.class);
+        JdbcTransactionManager sharedManager = mock(JdbcTransactionManager.class);
+        DataScope sqliteScope = DataScope.forExternal("shouldBindTransactionalAdvisorToSqliteStoreSharedManager",
+                new File("build/test-wireaop-sqlite"), Collections.emptySet());
+        when(sqliteStore.getStoreType()).thenReturn("sqlite");
+        when(sqliteStore.getDataSource(sqliteScope)).thenReturn(fakeDataSource);
+        when(sqliteStore.transactionManagerFor(sqliteScope)).thenReturn(sharedManager);
+
+        UltiTools mockUltiTools = mock(UltiTools.class);
+        when(mockUltiTools.getDataStore()).thenReturn(sqliteStore);
+        ultiToolsMock.when(UltiTools::getInstance).thenReturn(mockUltiTools);
+
+        SimpleContainer context = new SimpleContainer();
+        PluginManager.wireAop(context, sqliteScope);
+        context.refresh();
+
+        assertSame(sharedManager, context.getBean(TransactionManager.class),
+                "wireAop must bind the interceptor to the exact manager SQLiteDataStore itself "
+                        + "resolves for this scope, not a second, independently-constructed one");
+    }
+
+    @Test
+    @DisplayName("Should bind the @Transactional advisor to the SAME JdbcTransactionManager "
+            + "MysqlDataStore wires onto the operators it hands out, not an independent second "
+            + "instance (T-02-TAM-11)")
+    void shouldBindTransactionalAdvisorToMysqlStoreSharedManager() {
+        MysqlDataStore mysqlStore = mock(MysqlDataStore.class);
+        DataSource fakeDataSource = mock(DataSource.class);
+        JdbcTransactionManager sharedManager = mock(JdbcTransactionManager.class);
+        DataScope mysqlScope = DataScope.forExternal("shouldBindTransactionalAdvisorToMysqlStoreSharedManager",
+                new File("build/test-wireaop-mysql"), Collections.emptySet());
+        when(mysqlStore.getStoreType()).thenReturn("mysql");
+        when(mysqlStore.getDataSource(mysqlScope)).thenReturn(fakeDataSource);
+        when(mysqlStore.transactionManagerFor(mysqlScope)).thenReturn(sharedManager);
+
+        UltiTools mockUltiTools = mock(UltiTools.class);
+        when(mockUltiTools.getDataStore()).thenReturn(mysqlStore);
+        ultiToolsMock.when(UltiTools::getInstance).thenReturn(mockUltiTools);
+
+        SimpleContainer context = new SimpleContainer();
+        PluginManager.wireAop(context, mysqlScope);
+        context.refresh();
+
+        assertSame(sharedManager, context.getBean(TransactionManager.class),
+                "wireAop must bind the interceptor to the exact manager MysqlDataStore itself "
+                        + "resolves for this scope, not a second, independently-constructed one");
     }
 
     @Test

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerClassScanningTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerClassScanningTest.java
@@ -1,10 +1,13 @@
 package com.ultikits.ultitools.manager;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -158,13 +161,19 @@ class PluginManagerClassScanningTest {
     }
 
     @Test
-    @DisplayName("@UltiToolsModule#additionalEntities 声明的实体并入插件的 scope")
+    @DisplayName("@UltiToolsModule#additionalEntities 声明的实体并入插件的 scope（D-19 合法用例：不在自身 jar 中、"
+            + "不属于任何其他已知插件——不会被 02-14 的校验拒绝）")
     void additionalEntitiesAttributeShouldBeAddedToPluginScope() throws Exception {
         // scanPluginEntities takes the plugin's Class, not an instance -- everything it reads (the
         // jar's own CodeSource and the class-level @UltiToolsModule annotation) is a class-level
         // fact, so no UltiToolsPlugin construction (real plugin.yml/language/config I/O) is needed
         // here at all.
-        Set<Class<?>> scanned = invokeScanPluginEntities(ModuleWithAdditionalEntities.class);
+        //
+        // 02-14: ModuleWithAdditionalEntities and UnrelatedEntity are both nested test classes with
+        // no real jar (resolveOwnJarFile returns null for both), and UnrelatedEntity is not
+        // recorded to any other plugin in entityOwnership -- neither of validateAdditionalEntity's
+        // refusal conditions fires, so this stays accepted exactly as D-19 intends.
+        Set<Class<?>> scanned = invokeScanPluginEntities("ModuleWithAdditionalEntities", ModuleWithAdditionalEntities.class);
 
         assertThat(scanned).contains(UnrelatedEntity.class);
     }
@@ -172,7 +181,7 @@ class PluginManagerClassScanningTest {
     @Test
     @DisplayName("没有声明任何实体的插件得到空集合而非 null，owns() 不抛异常")
     void pluginWithNoEntitiesGetsEmptySetNotNull() throws Exception {
-        Set<Class<?>> scanned = invokeScanPluginEntities(ConcretePlugin.class);
+        Set<Class<?>> scanned = invokeScanPluginEntities("ConcretePlugin", ConcretePlugin.class);
 
         assertThat(scanned).isNotNull().isEmpty();
         DataScope scope = DataScope.forExternal("no-entities-plugin", tempDir, scanned);
@@ -180,7 +189,7 @@ class PluginManagerClassScanningTest {
     }
 
     @Test
-    @DisplayName("connect(plugin, additionalEntities) 声明的实体并入外部插件的 scope")
+    @DisplayName("connect(plugin, additionalEntities) 声明的实体并入外部插件的 scope（D-19 合法用例，同上不会被拒绝）")
     void externalConnectAdditionalEntitiesShouldBeAddedToScope() throws Exception {
         org.bukkit.plugin.java.JavaPlugin mockPlugin = MockBukkit.createMockPlugin("ExternalScanFixture");
         com.ultikits.ultitools.api.ExternalPluginAdapter adapter =
@@ -191,6 +200,103 @@ class PluginManagerClassScanningTest {
         assertThat(scanned).contains(EntityA.class);
     }
 
+    @Test
+    @DisplayName("02-14: @UltiToolsModule#additionalEntities 声明一个已确认属于另一个已注册模块的实体时应被拒绝"
+            + "（02-SECURITY.md 内部路径）")
+    void additionalEntitiesNamingAnotherModulesOwnedEntityShouldBeRefused() throws Exception {
+        // UnrelatedEntity is already confirmed owned by "VictimModule" (mirrors PluginManager's own
+        // registerEntityOwnership having run for Victim's scope first). ModuleWithAdditionalEntities
+        // (standing in for "AttackerModule") declares that exact same entity in its own
+        // additionalEntities -- the internal equivalent of the two-line public attack.
+        registerOwnership("VictimModule", UnrelatedEntity.class);
+
+        assertThrows(com.ultikits.ultitools.exceptions.PluginModuleException.class,
+                () -> invokeScanPluginEntities("ModuleWithAdditionalEntities", ModuleWithAdditionalEntities.class));
+    }
+
+    @Test
+    @DisplayName("02-14: 公开路径 UltiToolsAPI.connect(attacker, VictimEntity.class) 应该被拒绝"
+            + "（02-SECURITY.md 两行攻击，经公开 API 表面）")
+    void publicConnectWithAnotherPluginsRealEntityShouldBeRefused() throws Exception {
+        // The exact two-line attack 02-SECURITY.md demonstrated: no reflection, no reference to the
+        // victim's own scope -- just naming its real @Table class in additionalEntities through the
+        // PUBLIC UltiToolsAPI.connect(plugin, additionalEntities...) overload D-19 introduced.
+        registerOwnership("VictimModule", UnrelatedEntity.class);
+
+        com.ultikits.ultitools.manager.DependenceManagers dependenceManagers =
+                org.mockito.Mockito.mock(com.ultikits.ultitools.manager.DependenceManagers.class);
+        org.mockito.Mockito.when(dependenceManagers.getContext())
+                .thenReturn(new com.ultikits.ultitools.context.SimpleContainer());
+        com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
+            org.mockito.Mockito.when(ultiTools.getDependenceManagers()).thenReturn(dependenceManagers);
+            org.mockito.Mockito.when(ultiTools.getPluginManager()).thenReturn(pluginManager);
+        });
+
+        org.bukkit.plugin.java.JavaPlugin attacker = org.mockito.Mockito.mock(org.bukkit.plugin.java.JavaPlugin.class);
+        org.bukkit.plugin.PluginDescriptionFile desc = org.mockito.Mockito.mock(org.bukkit.plugin.PluginDescriptionFile.class);
+        org.mockito.Mockito.when(attacker.getName()).thenReturn("AttackerPlugin");
+        org.mockito.Mockito.when(attacker.getDescription()).thenReturn(desc);
+        org.mockito.Mockito.when(desc.getVersion()).thenReturn("1.0.0");
+        org.mockito.Mockito.when(desc.getAuthors()).thenReturn(java.util.Collections.emptyList());
+        // Top-level main class name (no dot) -> ExternalPluginAdapter.getScanPackage() is empty,
+        // so registerExternal skips component scanning -- keeps this test focused on the ownership
+        // refusal, not on IoC container plumbing.
+        org.mockito.Mockito.when(desc.getMain()).thenReturn("AttackerMain");
+        org.mockito.Mockito.when(attacker.getDataFolder()).thenReturn(new File(tempDir, "attacker-data"));
+        org.mockito.Mockito.when(attacker.getLogger()).thenReturn(java.util.logging.Logger.getLogger("AttackerPluginTest"));
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> com.ultikits.ultitools.api.UltiToolsAPI.connect(attacker, UnrelatedEntity.class));
+
+        assertThat(thrown.getCause()).isInstanceOf(com.ultikits.ultitools.exceptions.PluginModuleException.class);
+        assertThat(thrown.getCause().getMessage())
+                .contains("VictimModule")
+                .contains(UnrelatedEntity.class.getName());
+        // Refusal happens before any scope is minted or operator cached -- connect()'s own catch
+        // block removes the adapter it optimistically registered, so the attacker never ends up
+        // "connected".
+        assertThat(com.ultikits.ultitools.api.UltiToolsAPI.isConnected(attacker)).isFalse();
+    }
+
+    @Test
+    @DisplayName("02-14: 附加实体的 jar 是另一个已发现模块自身的 jar 时应被结构性拒绝，即使尚未有任何所有权登记"
+            + "（防先手窗口——entityOwnership 的 putIfAbsent 语义单独无法关闭这个窗口）")
+    void additionalEntityStructurallyBelongingToAnotherDiscoveredModuleShouldBeRefusedEvenWithoutPriorOwnershipRecord()
+            throws Exception {
+        // Real, already-on-disk jars from the test's own Maven dependencies stand in for "the
+        // declarer's own jar" and "another module's own jar" -- this exercises the actual
+        // java.security.CodeSource-based resolveOwnJarFile() comparison, not a fabricated File, and
+        // crucially registers NOTHING in entityOwnership for either side first: this proves the
+        // structural check alone (independent of registration order) is what closes the
+        // first-mover window, not the registry-conflict check exercised by the two tests above.
+        File declarerJar = invokeResolveOwnJarFile(org.assertj.core.api.Assertions.class);
+        File otherModuleJar = invokeResolveOwnJarFile(org.mockito.Mockito.class);
+        org.junit.jupiter.api.Assumptions.assumeTrue(
+                declarerJar != null && otherModuleJar != null && !declarerJar.equals(otherModuleJar),
+                "requires assertj-core and mockito-core to resolve to two distinct real jars on the test classpath");
+
+        // Stands in for "Victim's own module main class, already discovered by init()'s upfront
+        // scan" -- populated regardless of whether Victim has registered a DataScope yet.
+        addToPluginClassList(org.mockito.Mockito.class);
+
+        assertThat(pluginManager.findOwningPlugin(org.mockito.Answers.class)).isNull();
+
+        assertThrows(com.ultikits.ultitools.exceptions.PluginModuleException.class,
+                () -> invokeValidateAdditionalEntity(
+                        "Declarer", org.assertj.core.api.Assertions.class, declarerJar, org.mockito.Answers.class));
+    }
+
+    @Test
+    @DisplayName("02-14: 附加实体与声明方位于同一个物理 jar 时视为合法（共享库被 shade 进了声明方自身的 jar）")
+    void additionalEntityFromDeclarersOwnJarShouldBeAccepted() throws Exception {
+        File jar = invokeResolveOwnJarFile(org.mockito.Mockito.class);
+        org.junit.jupiter.api.Assumptions.assumeTrue(jar != null,
+                "requires mockito-core to resolve to a real jar on the test classpath");
+
+        assertDoesNotThrow(() -> invokeValidateAdditionalEntity(
+                "Declarer", org.mockito.Mockito.class, jar, org.mockito.Answers.class));
+    }
+
     @SuppressWarnings("unchecked")
     private Set<Class<?>> invokeScanEntitiesInJar(File pluginJar) throws Exception {
         Method method = PluginManager.class.getDeclaredMethod("scanEntitiesInJar", File.class);
@@ -199,10 +305,15 @@ class PluginManagerClassScanningTest {
     }
 
     @SuppressWarnings("unchecked")
-    private Set<Class<?>> invokeScanPluginEntities(Class<? extends UltiToolsPlugin> pluginClass) throws Exception {
-        Method method = PluginManager.class.getDeclaredMethod("scanPluginEntities", Class.class);
+    private Set<Class<?>> invokeScanPluginEntities(String pluginName, Class<? extends UltiToolsPlugin> pluginClass)
+            throws Exception {
+        Method method = PluginManager.class.getDeclaredMethod("scanPluginEntities", String.class, Class.class);
         method.setAccessible(true);
-        return (Set<Class<?>>) method.invoke(pluginManager, pluginClass);
+        try {
+            return (Set<Class<?>>) method.invoke(pluginManager, pluginName, pluginClass);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            throw unwrap(e);
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -213,7 +324,68 @@ class PluginManagerClassScanningTest {
                 "scanExternalEntities", com.ultikits.ultitools.api.ExternalPluginAdapter.class, Class[].class
         );
         method.setAccessible(true);
-        return (Set<Class<?>>) method.invoke(pluginManager, adapter, additionalEntities);
+        try {
+            return (Set<Class<?>>) method.invoke(pluginManager, adapter, additionalEntities);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            throw unwrap(e);
+        }
+    }
+
+    private void invokeValidateAdditionalEntity(
+            String declaringPluginName, Class<?> declaringClass, File declaringOwnJarFile, Class<?> entityClass
+    ) throws Exception {
+        Method method = PluginManager.class.getDeclaredMethod(
+                "validateAdditionalEntity", String.class, Class.class, File.class, Class.class);
+        method.setAccessible(true);
+        try {
+            method.invoke(pluginManager, declaringPluginName, declaringClass, declaringOwnJarFile, entityClass);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            throw unwrap(e);
+        }
+    }
+
+    private File invokeResolveOwnJarFile(Class<?> aClass) throws Exception {
+        Method method = PluginManager.class.getDeclaredMethod("resolveOwnJarFile", Class.class);
+        method.setAccessible(true);
+        return (File) method.invoke(null, aClass);
+    }
+
+    /**
+     * Directly populates {@code PluginManager.entityOwnership} (bypassing DataScope minting
+     * entirely) so a test can assert the registry-conflict branch of {@code
+     * validateAdditionalEntity} without needing a full, real plugin registration for the "owner".
+     */
+    @SuppressWarnings("unchecked")
+    private void registerOwnership(String owner, Class<?> entity) throws Exception {
+        Field field = PluginManager.class.getDeclaredField("entityOwnership");
+        field.setAccessible(true);
+        ((java.util.Map<Class<?>, String>) field.get(pluginManager)).put(entity, owner);
+    }
+
+    /**
+     * Directly populates {@code PluginManager.pluginClassList} (bypassing {@code init()}'s real
+     * jar-discovery loop) so a test can assert the structural, first-mover-independent branch of
+     * {@code validateAdditionalEntity} in isolation. Raw/unchecked on purpose: at runtime generics
+     * are erased, so a class that does not literally extend {@code UltiToolsPlugin} can still
+     * stand in for "another already-discovered module's own class" for jar-identity comparison
+     * purposes -- only {@code resolveOwnJarFile}'s {@code CodeSource} resolution is exercised.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void addToPluginClassList(Class<?> standIn) throws Exception {
+        Field field = PluginManager.class.getDeclaredField("pluginClassList");
+        field.setAccessible(true);
+        ((java.util.List) field.get(pluginManager)).add(standIn);
+    }
+
+    private static Exception unwrap(java.lang.reflect.InvocationTargetException e) {
+        Throwable cause = e.getCause();
+        if (cause instanceof RuntimeException) {
+            return (RuntimeException) cause;
+        }
+        if (cause instanceof Exception) {
+            return (Exception) cause;
+        }
+        return e;
     }
 
     private Class<? extends UltiToolsPlugin> invokeLoadPluginMainClass(File pluginJar) throws Exception {

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerClassScanningTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerClassScanningTest.java
@@ -160,16 +160,11 @@ class PluginManagerClassScanningTest {
     @Test
     @DisplayName("@UltiToolsModule#additionalEntities 声明的实体并入插件的 scope")
     void additionalEntitiesAttributeShouldBeAddedToPluginScope() throws Exception {
-        // Objenesis bypasses every UltiToolsPlugin constructor (all of which do real plugin.yml/
-        // language/config I/O against UltiTools.getInstance()) so this test exercises only what
-        // scanPluginEntities actually reads: plugin.getClass() -- for the CodeSource-based jar
-        // resolution and the @UltiToolsModule annotation lookup. Mockito's mock() cannot stand in
-        // here: getClass() is final on Object, so a mock's generated subclass never carries the
-        // literal ModuleWithAdditionalEntities class -- and @UltiToolsModule is not @Inherited.
-        ModuleWithAdditionalEntities plugin =
-                new org.objenesis.ObjenesisStd().newInstance(ModuleWithAdditionalEntities.class);
-
-        Set<Class<?>> scanned = invokeScanPluginEntities(plugin);
+        // scanPluginEntities takes the plugin's Class, not an instance -- everything it reads (the
+        // jar's own CodeSource and the class-level @UltiToolsModule annotation) is a class-level
+        // fact, so no UltiToolsPlugin construction (real plugin.yml/language/config I/O) is needed
+        // here at all.
+        Set<Class<?>> scanned = invokeScanPluginEntities(ModuleWithAdditionalEntities.class);
 
         assertThat(scanned).contains(UnrelatedEntity.class);
     }
@@ -177,9 +172,7 @@ class PluginManagerClassScanningTest {
     @Test
     @DisplayName("没有声明任何实体的插件得到空集合而非 null，owns() 不抛异常")
     void pluginWithNoEntitiesGetsEmptySetNotNull() throws Exception {
-        ConcretePlugin plugin = new org.objenesis.ObjenesisStd().newInstance(ConcretePlugin.class);
-
-        Set<Class<?>> scanned = invokeScanPluginEntities(plugin);
+        Set<Class<?>> scanned = invokeScanPluginEntities(ConcretePlugin.class);
 
         assertThat(scanned).isNotNull().isEmpty();
         DataScope scope = DataScope.forExternal("no-entities-plugin", tempDir, scanned);
@@ -206,10 +199,10 @@ class PluginManagerClassScanningTest {
     }
 
     @SuppressWarnings("unchecked")
-    private Set<Class<?>> invokeScanPluginEntities(UltiToolsPlugin plugin) throws Exception {
-        Method method = PluginManager.class.getDeclaredMethod("scanPluginEntities", UltiToolsPlugin.class);
+    private Set<Class<?>> invokeScanPluginEntities(Class<? extends UltiToolsPlugin> pluginClass) throws Exception {
+        Method method = PluginManager.class.getDeclaredMethod("scanPluginEntities", Class.class);
         method.setAccessible(true);
-        return (Set<Class<?>>) method.invoke(pluginManager, plugin);
+        return (Set<Class<?>>) method.invoke(pluginManager, pluginClass);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerClassScanningTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerClassScanningTest.java
@@ -223,8 +223,8 @@ class PluginManagerClassScanningTest {
         // PUBLIC UltiToolsAPI.connect(plugin, additionalEntities...) overload D-19 introduced.
         registerOwnership("VictimModule", UnrelatedEntity.class);
 
-        com.ultikits.ultitools.manager.DependenceManagers dependenceManagers =
-                org.mockito.Mockito.mock(com.ultikits.ultitools.manager.DependenceManagers.class);
+        DependenceManagers dependenceManagers =
+                org.mockito.Mockito.mock(DependenceManagers.class);
         org.mockito.Mockito.when(dependenceManagers.getContext())
                 .thenReturn(new com.ultikits.ultitools.context.SimpleContainer());
         com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance(ultiTools -> {
@@ -237,7 +237,7 @@ class PluginManagerClassScanningTest {
         org.mockito.Mockito.when(attacker.getName()).thenReturn("AttackerPlugin");
         org.mockito.Mockito.when(attacker.getDescription()).thenReturn(desc);
         org.mockito.Mockito.when(desc.getVersion()).thenReturn("1.0.0");
-        org.mockito.Mockito.when(desc.getAuthors()).thenReturn(java.util.Collections.emptyList());
+        org.mockito.Mockito.when(desc.getAuthors()).thenReturn(Collections.emptyList());
         // Top-level main class name (no dot) -> ExternalPluginAdapter.getScanPackage() is empty,
         // so registerExternal skips component scanning -- keeps this test focused on the ownership
         // refusal, not on IoC container plumbing.
@@ -374,7 +374,7 @@ class PluginManagerClassScanningTest {
     private void addToPluginClassList(Class<?> standIn) throws Exception {
         Field field = PluginManager.class.getDeclaredField("pluginClassList");
         field.setAccessible(true);
-        ((java.util.List) field.get(pluginManager)).add(standIn);
+        ((List) field.get(pluginManager)).add(standIn);
     }
 
     private static Exception unwrap(java.lang.reflect.InvocationTargetException e) {

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerClassScanningTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerClassScanningTest.java
@@ -7,10 +7,18 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
 
+import org.bukkit.Bukkit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,6 +28,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockbukkit.mockbukkit.MockBukkit;
 
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
+import com.ultikits.ultitools.annotations.Table;
+import com.ultikits.ultitools.annotations.UltiToolsModule;
 import com.ultikits.ultitools.interfaces.IPlugin;
 
 /**
@@ -34,6 +44,8 @@ class PluginManagerClassScanningTest {
     File tempDir;
 
     private PluginManager pluginManager;
+    private final List<LogRecord> bukkitLogs = new ArrayList<>();
+    private Handler captureHandler;
 
     @BeforeEach
     void setUp() {
@@ -42,10 +54,30 @@ class PluginManagerClassScanningTest {
         MockBukkit.createMockPlugin();
         com.ultikits.ultitools.utils.TestHelper.mockUltiToolsInstance();
         pluginManager = new PluginManager();
+
+        bukkitLogs.clear();
+        captureHandler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                bukkitLogs.add(record);
+            }
+
+            @Override
+            public void flush() {
+                // nothing buffered
+            }
+
+            @Override
+            public void close() {
+                // nothing to release
+            }
+        };
+        Bukkit.getLogger().addHandler(captureHandler);
     }
 
     @AfterEach
     void tearDown() {
+        Bukkit.getLogger().removeHandler(captureHandler);
         com.ultikits.ultitools.utils.MockBukkitHelper.safeUnmock();
     }
 
@@ -74,6 +106,121 @@ class PluginManagerClassScanningTest {
 
         assertThat(invokeLoadPluginMainClass(badJar)).isNull();
         assertThat(invokeLoadPluginMainClass(validJar)).isEqualTo(ConcretePlugin.class);
+    }
+
+    @Test
+    @DisplayName("扫描应只收集本 JAR 中携带 @Table 的类，忽略非 @Table 类")
+    void shouldScanTableAnnotatedClassesAndOnlyThoseInThisJar() throws Exception {
+        File pluginJar = createJar("entity-plugin.jar", EntityA.class, EntityB.class, PlainPlugin.class);
+
+        Set<Class<?>> scanned = invokeScanEntitiesInJar(pluginJar);
+
+        assertThat(scanned).containsExactlyInAnyOrder(EntityA.class, EntityB.class);
+
+        DataScope scope = DataScope.forExternal("entity-plugin", tempDir, scanned);
+        assertThat(scope.owns(EntityA.class)).isTrue();
+        assertThat(scope.owns(EntityB.class)).isTrue();
+        assertThat(scope.owns(UnrelatedEntity.class)).isFalse();
+    }
+
+    @Test
+    @DisplayName("零 @Table 类的 JAR 扫描出空集合，不影响插件加载")
+    void shouldReturnEmptySetForJarWithNoTableClasses() throws Exception {
+        File pluginJar = createJar("no-entity-plugin.jar", ConcretePlugin.class);
+
+        Set<Class<?>> scanned = invokeScanEntitiesInJar(pluginJar);
+
+        assertThat(scanned).isNotNull().isEmpty();
+    }
+
+    @Test
+    @DisplayName("超过 1000 类上限只报告、不截断——扫描完整跑完并记录一条 WARNING")
+    void shouldReportWithoutTruncatingWhenClassCountExceedsCap() throws Exception {
+        File pluginJar = new File(tempDir, "oversized-plugin.jar");
+        try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(pluginJar.toPath()))) {
+            for (int i = 0; i < 1001; i++) {
+                output.putNextEntry(new JarEntry(
+                        "com/ultikits/ultitools/manager/scanfixture/SyntheticClass" + i + ".class"));
+                output.closeEntry();
+            }
+        }
+
+        Set<Class<?>> scanned = invokeScanEntitiesInJar(pluginJar);
+
+        assertThat(scanned).isNotNull();
+        boolean warned = bukkitLogs.stream().anyMatch(record ->
+                Level.WARNING.equals(record.getLevel())
+                        && record.getMessage() != null
+                        && record.getMessage().contains(pluginJar.getName())
+                        && record.getMessage().contains("1000"));
+        assertThat(warned).as("expected a WARNING naming the jar and the 1000-class cap, got: %s", bukkitLogs)
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("@UltiToolsModule#additionalEntities 声明的实体并入插件的 scope")
+    void additionalEntitiesAttributeShouldBeAddedToPluginScope() throws Exception {
+        // Objenesis bypasses every UltiToolsPlugin constructor (all of which do real plugin.yml/
+        // language/config I/O against UltiTools.getInstance()) so this test exercises only what
+        // scanPluginEntities actually reads: plugin.getClass() -- for the CodeSource-based jar
+        // resolution and the @UltiToolsModule annotation lookup. Mockito's mock() cannot stand in
+        // here: getClass() is final on Object, so a mock's generated subclass never carries the
+        // literal ModuleWithAdditionalEntities class -- and @UltiToolsModule is not @Inherited.
+        ModuleWithAdditionalEntities plugin =
+                new org.objenesis.ObjenesisStd().newInstance(ModuleWithAdditionalEntities.class);
+
+        Set<Class<?>> scanned = invokeScanPluginEntities(plugin);
+
+        assertThat(scanned).contains(UnrelatedEntity.class);
+    }
+
+    @Test
+    @DisplayName("没有声明任何实体的插件得到空集合而非 null，owns() 不抛异常")
+    void pluginWithNoEntitiesGetsEmptySetNotNull() throws Exception {
+        ConcretePlugin plugin = new org.objenesis.ObjenesisStd().newInstance(ConcretePlugin.class);
+
+        Set<Class<?>> scanned = invokeScanPluginEntities(plugin);
+
+        assertThat(scanned).isNotNull().isEmpty();
+        DataScope scope = DataScope.forExternal("no-entities-plugin", tempDir, scanned);
+        assertThat(scope.owns(EntityA.class)).isFalse();
+    }
+
+    @Test
+    @DisplayName("connect(plugin, additionalEntities) 声明的实体并入外部插件的 scope")
+    void externalConnectAdditionalEntitiesShouldBeAddedToScope() throws Exception {
+        org.bukkit.plugin.java.JavaPlugin mockPlugin = MockBukkit.createMockPlugin("ExternalScanFixture");
+        com.ultikits.ultitools.api.ExternalPluginAdapter adapter =
+                new com.ultikits.ultitools.api.ExternalPluginAdapter(mockPlugin);
+
+        Set<Class<?>> scanned = invokeScanExternalEntities(adapter, new Class<?>[]{EntityA.class});
+
+        assertThat(scanned).contains(EntityA.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<Class<?>> invokeScanEntitiesInJar(File pluginJar) throws Exception {
+        Method method = PluginManager.class.getDeclaredMethod("scanEntitiesInJar", File.class);
+        method.setAccessible(true);
+        return (Set<Class<?>>) method.invoke(pluginManager, pluginJar);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<Class<?>> invokeScanPluginEntities(UltiToolsPlugin plugin) throws Exception {
+        Method method = PluginManager.class.getDeclaredMethod("scanPluginEntities", UltiToolsPlugin.class);
+        method.setAccessible(true);
+        return (Set<Class<?>>) method.invoke(pluginManager, plugin);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<Class<?>> invokeScanExternalEntities(
+            com.ultikits.ultitools.api.ExternalPluginAdapter adapter, Class<?>[] additionalEntities
+    ) throws Exception {
+        Method method = PluginManager.class.getDeclaredMethod(
+                "scanExternalEntities", com.ultikits.ultitools.api.ExternalPluginAdapter.class, Class[].class
+        );
+        method.setAccessible(true);
+        return (Set<Class<?>>) method.invoke(pluginManager, adapter, additionalEntities);
     }
 
     private Class<? extends UltiToolsPlugin> invokeLoadPluginMainClass(File pluginJar) throws Exception {
@@ -137,6 +284,26 @@ class PluginManagerClassScanningTest {
     }
 
     static class ConcretePlugin extends UltiToolsPlugin {
+        @Override
+        public boolean registerSelf() {
+            return true;
+        }
+    }
+
+    @Table("scan_entity_a")
+    static class EntityA {
+    }
+
+    @Table("scan_entity_b")
+    static class EntityB {
+    }
+
+    @Table("scan_entity_other")
+    static class UnrelatedEntity {
+    }
+
+    @UltiToolsModule(additionalEntities = {UnrelatedEntity.class})
+    static class ModuleWithAdditionalEntities extends UltiToolsPlugin {
         @Override
         public boolean registerSelf() {
             return true;

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.MockedStatic;
@@ -36,6 +37,7 @@ import org.mockito.MockedStatic;
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.context.SimpleContainer;
+import com.ultikits.ultitools.interfaces.DataStore;
 
 import org.bukkit.Bukkit;
 import org.mockbukkit.mockbukkit.MockBukkit;
@@ -775,6 +777,15 @@ class PluginManagerTest {
             lenient().when(dependenceManagers.getContext()).thenReturn(new SimpleContainer());
             lenient().when(ultiTools.getDependenceManagers()).thenReturn(dependenceManagers);
             lenient().when(ultiTools.getLogger()).thenReturn(mockLogger);
+
+            // wireAop (02-01) now resolves a DataSource through UltiTools.getInstance().getDataStore()
+            // for the @Transactional advisor. This suite is about the compatibility gate, not
+            // persistence, so CALLS_REAL_METHODS lets the interface's own default
+            // getDataSource(DataScope) run and throw UnsupportedOperationException - the same
+            // graceful "declare unavailable" fallback wireAop already has for a backend that
+            // doesn't support one, rather than letting a bare mock's null answer surface as an NPE.
+            DataStore dataStore = mock(DataStore.class, Answers.CALLS_REAL_METHODS);
+            lenient().when(ultiTools.getDataStore()).thenReturn(dataStore);
 
             // getPluginVersion() 走 getEnv() → getInstance().getTextResource("env.yml")，
             // 而那个方法在 JavaPlugin 里是 protected，测试包里打不了桩，所以直接桩静态方法。

--- a/src/test/java/com/ultikits/ultitools/manager/TransactionalRollbackEndToEndTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/TransactionalRollbackEndToEndTest.java
@@ -58,7 +58,6 @@ class TransactionalRollbackEndToEndTest {
 
     private static DataSource h2DataSource;
 
-    private DataStore fakeDataStore;
     private MockedStatic<UltiTools> ultiToolsMock;
     private DataScope scope;
 
@@ -84,7 +83,7 @@ class TransactionalRollbackEndToEndTest {
         // The DataStore extension point this task's D-17 seam exists for: a third-party
         // implementation whose getDataSource(DataScope) hands back a real DataSource, exercised
         // exactly the way SQLiteDataStore's own override will be.
-        fakeDataStore = new DataStore() {
+        DataStore fakeDataStore = new DataStore() {
             @Override
             public String getStoreType() {
                 return "fake-jdbc";
@@ -103,6 +102,7 @@ class TransactionalRollbackEndToEndTest {
 
             @Override
             public void destroyAllOperators() {
+                // intentional no-op: this fake DataStore has no operator pool for this test to tear down
             }
         };
 

--- a/src/test/java/com/ultikits/ultitools/manager/TransactionalRollbackEndToEndTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/TransactionalRollbackEndToEndTest.java
@@ -1,0 +1,213 @@
+package com.ultikits.ultitools.manager;
+
+// NOTE: PLAN DEVIATION (Rule 3 - blocking issue). 02-01-PLAN.md's frontmatter names this file's
+// path as src/test/java/com/ultikits/ultitools/aop/TransactionalRollbackEndToEndTest.java, but the
+// test must call PluginManager.wireAop(SimpleContainer, DataScope) and DataScope.forExternal(...),
+// both package-private to com.ultikits.ultitools.manager. A test class in the aop package cannot
+// see either member (package-private access is not inherited across sibling packages), so the file
+// could not compile there without widening internal API visibility purely for test convenience.
+// Placed in the manager package instead, following the existing precedent of
+// PluginManagerAopWiringTest (also manager-package, also drives wireAop directly). Recorded in the
+// plan's SUMMARY as a deviation.
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.ultikits.ultitools.UltiTools;
+import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
+import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
+import com.ultikits.ultitools.annotations.Transactional;
+import com.ultikits.ultitools.context.SimpleContainer;
+import com.ultikits.ultitools.interfaces.DataOperator;
+import com.ultikits.ultitools.interfaces.DataStore;
+import com.ultikits.ultitools.interfaces.TransactionManager;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+/**
+ * End-to-end proof for Phase 2 Plan 1's tracer task: a {@code @Transactional} method on a bean
+ * built by {@link PluginManager#wireAop(SimpleContainer, DataScope)} opens a real JDBC transaction
+ * through the real proxy and really rolls it back, exercised through both an external call and a
+ * self-invocation call.
+ * <p>
+ * This is deliberately one end-to-end test, not four unit tests: it drives the whole path
+ * {@code DataScope -> DataStore -> DataSource -> DataSourceTransactionManager -> wireAop advisor
+ * -> TransactionInterceptor -> real JDBC rollback}, using an in-memory H2 database standing in for
+ * SQLite (the SQLite JDBC driver is supplied by Paper at runtime and is not on the test classpath).
+ */
+@DisplayName("wireAop -> @Transactional -> real JDBC rollback (Phase 2 Plan 1 tracer)")
+class TransactionalRollbackEndToEndTest {
+
+    private static DataSource h2DataSource;
+
+    private DataStore fakeDataStore;
+    private MockedStatic<UltiTools> ultiToolsMock;
+    private DataScope scope;
+
+    @BeforeAll
+    static void initDataSource() {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:h2:mem:txe2e;DB_CLOSE_DELAY=-1;MODE=MySQL");
+        config.setUsername("sa");
+        // Deliberately no setPassword() call: the in-memory DB is created password-less on first
+        // connection, and passing an empty string reads as a hardcoded credential to static
+        // analysis (Codacy/Semgrep). There is no credential here.
+        h2DataSource = new HikariDataSource(config);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        try (Connection conn = h2DataSource.getConnection();
+                Statement st = conn.createStatement()) {
+            st.execute("DROP TABLE IF EXISTS tx_test");
+            st.execute("CREATE TABLE tx_test (id INT PRIMARY KEY)");
+        }
+
+        // The DataStore extension point this task's D-17 seam exists for: a third-party
+        // implementation whose getDataSource(DataScope) hands back a real DataSource, exercised
+        // exactly the way SQLiteDataStore's own override will be.
+        fakeDataStore = new DataStore() {
+            @Override
+            public String getStoreType() {
+                return "fake-jdbc";
+            }
+
+            @Override
+            public <T extends BaseDataEntity<String>> DataOperator<T> getOperator(UltiToolsPlugin plugin,
+                    Class<T> dataEntity) {
+                throw new UnsupportedOperationException("not needed by this test");
+            }
+
+            @Override
+            public DataSource getDataSource(DataScope scope) {
+                return h2DataSource;
+            }
+
+            @Override
+            public void destroyAllOperators() {
+            }
+        };
+
+        UltiTools mockUltiTools = mock(UltiTools.class);
+        when(mockUltiTools.getDataStore()).thenReturn(fakeDataStore);
+        ultiToolsMock = mockStatic(UltiTools.class);
+        ultiToolsMock.when(UltiTools::getInstance).thenReturn(mockUltiTools);
+
+        scope = DataScope.forExternal("tracer-plugin", new File("."), Collections.emptySet());
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (ultiToolsMock != null) {
+            ultiToolsMock.close();
+        }
+    }
+
+    private int countRows() throws SQLException {
+        try (Connection conn = h2DataSource.getConnection();
+                Statement st = conn.createStatement();
+                java.sql.ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM tx_test")) {
+            rs.next();
+            return rs.getInt(1);
+        }
+    }
+
+    /** A bean carrying both a self-invoking and an externally-called {@code @Transactional} path. */
+    public static class TxBean {
+        private final TransactionManager txManager;
+
+        public TxBean(TransactionManager txManager) {
+            this.txManager = txManager;
+        }
+
+        @Transactional
+        public void writeThenFail() {
+            insert(1);
+            throw new RuntimeException("boom - external call");
+        }
+
+        @Transactional
+        public void writeThenSucceed() {
+            insert(2);
+        }
+
+        /** External caller invokes this; it self-invokes {@link #innerWriteThenFail()}. */
+        public void outerCallsInnerThenFails() {
+            innerWriteThenFail();
+        }
+
+        @Transactional
+        public void innerWriteThenFail() {
+            insert(3);
+            throw new RuntimeException("boom - self-invocation");
+        }
+
+        private void insert(int id) {
+            try (Statement st = txManager.getConnection().createStatement()) {
+                st.execute("INSERT INTO tx_test (id) VALUES (" + id + ")");
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("A @Transactional method that writes then throws leaves the row count at 0")
+    void shouldRollBackOnException() throws Exception {
+        SimpleContainer context = new SimpleContainer();
+        PluginManager.wireAop(context, scope);
+        context.registerBean(TxBean.class);
+        context.refresh();
+
+        TxBean bean = context.getBean(TxBean.class);
+
+        assertThrows(RuntimeException.class, bean::writeThenFail);
+        assertThat(countRows()).isZero();
+    }
+
+    @Test
+    @DisplayName("A @Transactional method that writes and returns normally leaves the row committed")
+    void shouldCommitOnSuccess() throws Exception {
+        SimpleContainer context = new SimpleContainer();
+        PluginManager.wireAop(context, scope);
+        context.registerBean(TxBean.class);
+        context.refresh();
+
+        TxBean bean = context.getBean(TxBean.class);
+
+        bean.writeThenSucceed();
+        assertThat(countRows()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Self-invocation of a @Transactional method rolls back exactly like an external call")
+    void shouldRollBackOnSelfInvocation() throws Exception {
+        SimpleContainer context = new SimpleContainer();
+        PluginManager.wireAop(context, scope);
+        context.registerBean(TxBean.class);
+        context.refresh();
+
+        TxBean bean = context.getBean(TxBean.class);
+
+        assertThrows(RuntimeException.class, bean::outerCallsInnerThenFails);
+        assertThat(countRows()).isZero();
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/testutil/PoolStateAssertions.java
+++ b/src/test/java/com/ultikits/ultitools/testutil/PoolStateAssertions.java
@@ -1,0 +1,79 @@
+package com.ultikits.ultitools.testutil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.HikariPoolMXBean;
+
+/**
+ * Live HikariCP pool-state assertions, used in place of "no exception was thrown" as evidence
+ * that a connection pool was actually released.
+ * <p>
+ * {@link HikariDataSource#getHikariPoolMXBean()} is only meaningful while the pool is running -
+ * calling it on a closed pool is undefined, so every assertion here checks {@link
+ * HikariDataSource#isClosed()} first rather than dereferencing the MXBean unconditionally.
+ * <p>
+ * 基于真实 HikariCP 连接池状态的断言助手，取代「没有抛出异常」作为连接池确实被释放的证据。
+ * {@link HikariDataSource#getHikariPoolMXBean()} 只有在连接池运行中才有意义——在已关闭的连接池
+ * 上调用它是未定义行为，所以这里的每个断言都先检查 {@link HikariDataSource#isClosed()}，
+ * 而不是无条件地解引用 MXBean。
+ *
+ * @author wisdomme
+ * @since 6.3.0
+ */
+public final class PoolStateAssertions {
+
+    private PoolStateAssertions() {
+        // Static utility - not instantiable.
+    }
+
+    /**
+     * Asserts that the given pool currently holds exactly {@code expected} connections
+     * (active + idle), failing with a message naming the actual count when it differs.
+     *
+     * @param dataSource the live pool to inspect <br> 待检查的存活连接池
+     * @param expected   the expected total connection count <br> 期望的连接总数
+     */
+    public static void assertTotalConnections(HikariDataSource dataSource, int expected) {
+        assertThat(dataSource.isClosed())
+                .as("pool must be open to inspect its connection count")
+                .isFalse();
+        HikariPoolMXBean pool = dataSource.getHikariPoolMXBean();
+        assertThat(pool.getTotalConnections())
+                .as("expected %d total connections in pool, found %d", expected, pool.getTotalConnections())
+                .isEqualTo(expected);
+    }
+
+    /**
+     * Asserts that the given pool is closed. Passes only when {@link HikariDataSource#isClosed()}
+     * is {@code true}; never dereferences the MXBean, since it is not meaningful once a pool is
+     * closed.
+     *
+     * @param dataSource the pool to inspect <br> 待检查的连接池
+     */
+    public static void assertClosed(HikariDataSource dataSource) {
+        assertThat(dataSource.isClosed())
+                .as("expected pool to be closed, but it is still open")
+                .isTrue();
+    }
+
+    /**
+     * Sums {@link HikariPoolMXBean#getTotalConnections()} across every still-open pool in the
+     * given collection and asserts the sum is zero. Pools that report closed are skipped rather
+     * than causing the assertion helper itself to throw.
+     *
+     * @param dataSources the pools to inspect <br> 待检查的连接池集合
+     */
+    public static void assertNoOpenConnections(Iterable<HikariDataSource> dataSources) {
+        int total = 0;
+        for (HikariDataSource dataSource : dataSources) {
+            if (dataSource == null || dataSource.isClosed()) {
+                continue;
+            }
+            total += dataSource.getHikariPoolMXBean().getTotalConnections();
+        }
+        assertThat(total)
+                .as("expected zero open connections across all pools, found %d", total)
+                .isZero();
+    }
+}


### PR DESCRIPTION
Closes the gap between what the ORM and the transaction interceptor **declare** and what they **do**.

**Targets `alpha`, not `main`.** 6.3.0 is unreleased; `main` is the released branch.

**Phase goal (ROADMAP, verbatim):** *The ORM and the transaction interceptor do exactly what their annotations and javadoc say, with no connection or operator state shared across a DataSource or a plugin boundary.*

Requirements: FOUND-04, SILENT-01, SILENT-02, SILENT-03, SILENT-04, WIRE-04, WIRE-13, WIRE-14, WIRE-15.

## Gates

| Gate | Result |
|---|---|
| Test suite | **4718 passed, 0 failures** (baseline 4482 → +236); `BugEvidenceTest` 15/15 |
| `mvn -B package javadoc:javadoc -DskipTests` (what CI runs) | exit 0, 0 javadoc errors |
| Regression — Phase 1's 13 test classes | all green, none missing |
| japicmp | additive; no new binary-incompatible entries introduced by this phase |
| Code review (deep, 26 production files) | 3 Critical **closed**; 4 Warning + 1 Info deferred by decision |
| Security audit (35 threat IDs) | **SECURED**, `threats_open: 0` |
| Phase verification | passed — 5/5 success criteria, 9/9 requirement IDs |

## Behaviour changes third-party module authors must read

`COMPATIBILITY.md` carries the full record with a worked before/after example. The ones that change results without breaking compilation:

- **`WhereCondition`'s `Comparison` is now honoured on relational backends.** All four relational WHERE builders previously hard-coded `= ?`, so `comparison(GREATER)` meant `>` on JSON and `=` on SQLite/MySQL. The same query object can now return different rows than it did on 6.2.5.
- **`@Transactional(rollbackFor = ...)` is additive**, not replacing. A non-empty but unmatched `rollbackFor` no longer commits. On overlap with `noRollbackFor`, the shallowest inheritance-depth match wins; rollback wins an exact tie.
- **Entity lifecycle hooks now fire** (`onCreate`/`onUpdate`/`onDelete`/`onLoad`, exactly once per operation, both backends). They never fired before.
- **Audit columns are populated** — `created_by`/`updated_by`/`created_at`/`updated_at` were always NULL.
- **`del()` with no conditions is refused** instead of emitting a bare `DELETE FROM`.
- **Requesting an operator for an entity you do not own is refused** with `ErrorCode.ENTITY_NOT_OWNED`, on every overload and all three stores.

Removals and deprecations: `Propagation.NESTED` removed (source- and binary-breaking); `TransactionManager`'s three JDBC methods demoted to `@Deprecated default` throwing (japicmp reports `METHOD_ABSTRACT_NOW_DEFAULT` as `binaryCompatible="false"` — recorded honestly in `COMPATIBILITY.md` alongside the practical linking analysis); both legacy `DataStore.getOperator` overloads `@Deprecated(forRemoval = true)`.

New: `@Transactional` now works on the JSON backend; `@Transactional(timeout=)` is enforced per statement against a shared shrinking budget on JDBC; `REQUIRES_NEW`/`NOT_SUPPORTED` genuinely suspend on all three backends.

## Four plans were added mid-phase

Planned as 10, shipped as 14. Each addition came from a different verification layer finding what the previous one could not:

| Plan | Found by | What it closed |
|---|---|---|
| 02-11 | 02-06's executor, self-disclosed | `JsonTransactionManager` never overrode `suspend()`, so `REQUIRES_NEW`/`NOT_SUPPORTED` silently failed on JSON |
| 02-12 | 02-07's executor, self-disclosed | The ownership check lived only in `DataStore`'s `default` bodies, which all three concrete stores override — it never ran on the real path |
| 02-13 | Code review | Three Criticals: an unauthenticated ownership bypass, a javadoc contract honoured on only one backend, and a "supported" entry point with zero callers |
| 02-14 | Security audit | `additionalEntities` was folded into a minted `DataScope` with no validation — two public calls granted an operator on another plugin's entity |

All five defects had the same shape: **declared behaviour that does not happen on the real path** — the exact defect class this milestone exists to eliminate.

## Known and deliberately deferred

- Code-review **WR-01…WR-04, IN-01**. **WR-02** (`%`/`_` unescaped in the newly-wired `LIKE` comparisons) is the only one with a data-correctness consequence for a module author who has migrated to `Comparison`-aware queries.
- `PluginManager.register(UltiToolsPlugin)` (direct-instance overload) bypasses `pluginClassList`, so 02-14's structural check is blind there. **Zero production call sites**; low severity.
- Two accepted risks registered in the security artifact: a byte-identical shaded copy of another plugin's entity class, and `@Table` name collision. Both follow from one shared MySQL `DataSource` with no table namespacing — pre-existing, and not closable by provenance validation.
- **Invariant with no compiler or test enforcing it:** `DataStore.getOperatorUnchecked(DataScope, Class)` is `public` (Java gives interface members no narrower visibility) and performs no ownership check. What closes it is that no public API hands any caller a populated `DataScope`. **Adding a `public getDataScope()` to `UltiToolsPlugin` would silently reopen the bypass, with no test failing.**

## Companion PR

`UltiKits/UltiTools-Dev-Doc#48`, targeting that repo's newly created `alpha`. This phase ships as exactly two PRs, one per affected repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQ8annckTbswRvUEZrkNYj