### PR TITLE
chore(test): suppress four PMD patterns at their deliberate call sites

### DIFF
--- a/src/test/java/com/ultikits/ultitools/UltiToolsTest.java
+++ b/src/test/java/com/ultikits/ultitools/UltiToolsTest.java
@@ -359,6 +359,7 @@ class UltiToolsTest {
 
         @Test
         @DisplayName("getInstance should return null before initialization")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void getInstanceShouldReturnNullBeforeInitialization() {
             try {
                 Field ultiToolsField = UltiTools.class.getDeclaredField("ultiTools");

--- a/src/test/java/com/ultikits/ultitools/abstracts/AbstractCommandTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/AbstractCommandTest.java
@@ -285,6 +285,7 @@ class AbstractCommandTest {
             return executeCommand(sender, command, label, args);
         }
 
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         protected boolean executeCommand(CommandSender sender, Command command, String alias, String[] args) {
             if (shouldThrowException) {
                 throw new RuntimeException("Test exception");

--- a/src/test/java/com/ultikits/ultitools/abstracts/command/BaseCommandExecutorTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/command/BaseCommandExecutorTest.java
@@ -118,6 +118,7 @@ class BaseCommandExecutorTest {
         
         @Test
         @DisplayName("Should match method for valid arguments")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void shouldMatchMethod() throws Exception {
             TestCommandExecutor executor = new TestCommandExecutor();
             Method matchMethod = BaseCommandExecutor.class.getDeclaredMethod("matchMethod", String[].class);
@@ -146,6 +147,7 @@ class BaseCommandExecutorTest {
         
         @Test
         @DisplayName("Should parse simple parameters")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void shouldParseSimpleParameters() throws Exception {
             TestCommandExecutor executor = new TestCommandExecutor();
             Method parseMethod = BaseCommandExecutor.class.getDeclaredMethod("parseParameters", String[].class, String.class);
@@ -303,6 +305,7 @@ class BaseCommandExecutorTest {
         
         @Test
         @DisplayName("Should calculate higher score for exact match")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void shouldCalculateHigherScoreForExactMatch() throws Exception {
             TestCommandExecutor executor = new TestCommandExecutor();
             Method calcMethod = BaseCommandExecutor.class.getDeclaredMethod("calculateMatchScore", String[].class, String[].class);
@@ -435,6 +438,7 @@ class BaseCommandExecutorTest {
         
         @Test
         @DisplayName("Should validate parameter count correctly")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void shouldValidateParameterCount() throws Exception {
             TestCommandExecutor executor = new TestCommandExecutor();
             Method validateMethod = BaseCommandExecutor.class.getDeclaredMethod(
@@ -495,6 +499,7 @@ class BaseCommandExecutorTest {
         
         @Test
         @DisplayName("Should build params with no parameters")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void shouldBuildParamsWithNoParameters() throws Exception {
             TypedParamsExecutor executor = new TypedParamsExecutor();
             Method buildMethod = BaseCommandExecutor.class.getDeclaredMethod(
@@ -773,6 +778,7 @@ class BaseCommandExecutorTest {
         
         @Test
         @DisplayName("Should extract name from simple parameter")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void shouldExtractSimpleName() throws Exception {
             TestCommandExecutor executor = new TestCommandExecutor();
             Method extractMethod = BaseCommandExecutor.class.getDeclaredMethod("extractParameterName", String.class);
@@ -912,6 +918,7 @@ class BaseCommandExecutorTest {
         
         @Test
         @DisplayName("Should detect parameter placeholder")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void shouldDetectParameter() throws Exception {
             TestCommandExecutor executor = new TestCommandExecutor();
             Method isParamMethod = BaseCommandExecutor.class.getDeclaredMethod("isParameter", String.class);

--- a/src/test/java/com/ultikits/ultitools/abstracts/data/DataEntityTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/data/DataEntityTest.java
@@ -917,6 +917,7 @@ public class DataEntityTest {
             // Not exercised by these tests.
         }
 
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         private void probeBody() {
             observedDuringHandler = AuditableDataEntity.getCurrentUser();
             invoked = true;

--- a/src/test/java/com/ultikits/ultitools/abstracts/guis/PagingPageTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/guis/PagingPageTest.java
@@ -82,6 +82,7 @@ class PagingPageTest {
 
     @Test
     @DisplayName("Should calculate correct page count")
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     void testPageCount() {
         // We can check if pagination manager has items
         // Accessing private field via reflection

--- a/src/test/java/com/ultikits/ultitools/aop/AopActivationTest.java
+++ b/src/test/java/com/ultikits/ultitools/aop/AopActivationTest.java
@@ -224,6 +224,7 @@ class AopActivationTest {
      * {@code @Transactional} is genuinely wired here too, not merely declared unavailable. See
      * {@link #shouldInterceptInheritedTransactionalMethod()}.
      */
+    @SuppressWarnings({"PMD.AvoidAccessibilityAlteration", "PMD.AvoidThrowingRawExceptionTypes"})
     private static void invokeWireAop(SimpleContainer context) {
         try (MockedStatic<UltiTools> ultiToolsMock = mockStatic(UltiTools.class)) {
             UltiTools mockUltiTools = mock(UltiTools.class);
@@ -239,6 +240,7 @@ class AopActivationTest {
         }
     }
 
+    @SuppressWarnings({"PMD.AvoidAccessibilityAlteration", "PMD.AvoidThrowingRawExceptionTypes"})
     private static DataScope newDataScope() {
         try {
             Constructor<DataScope> ctor = DataScope.class.getDeclaredConstructor(String.class, File.class, Set.class);

--- a/src/test/java/com/ultikits/ultitools/aop/AopAdvisorTest.java
+++ b/src/test/java/com/ultikits/ultitools/aop/AopAdvisorTest.java
@@ -371,6 +371,7 @@ class AopAdvisorTest {
             }
         }
 
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         private Object readLookupCache(Object owner) throws Exception {
             Field field = owner.getClass().getDeclaredField("lookupCache");
             field.setAccessible(true);

--- a/src/test/java/com/ultikits/ultitools/aop/ExceptionHandlerRethrowTest.java
+++ b/src/test/java/com/ultikits/ultitools/aop/ExceptionHandlerRethrowTest.java
@@ -97,6 +97,7 @@ class ExceptionHandlerRethrowTest {
     @Service
     public static class NoThrowsClauseTarget {
         @ExceptionCatch(handler = "checkedRethrowingHandler", defaultValue = "fallback")
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         public String call() {
             throw new RuntimeException("target-trigger");
         }
@@ -167,6 +168,7 @@ class ExceptionHandlerRethrowTest {
      * the duration of the call: this file is about {@code @ExceptionCatch}'s custom-handler
      * rethrow semantics, not the {@code @Transactional} JDBC path 02-01 added.
      */
+    @SuppressWarnings({"PMD.AvoidAccessibilityAlteration", "PMD.AvoidThrowingRawExceptionTypes"})
     private static void invokeWireAop(SimpleContainer context) {
         try (MockedStatic<UltiTools> ultiToolsMock = mockStatic(UltiTools.class)) {
             UltiTools mockUltiTools = mock(UltiTools.class);
@@ -182,6 +184,7 @@ class ExceptionHandlerRethrowTest {
         }
     }
 
+    @SuppressWarnings({"PMD.AvoidAccessibilityAlteration", "PMD.AvoidThrowingRawExceptionTypes"})
     private static DataScope newDataScope() {
         try {
             Constructor<DataScope> ctor = DataScope.class.getDeclaredConstructor(String.class, File.class, Set.class);

--- a/src/test/java/com/ultikits/ultitools/aop/ProxyFactoryIsolationTest.java
+++ b/src/test/java/com/ultikits/ultitools/aop/ProxyFactoryIsolationTest.java
@@ -83,7 +83,7 @@ class ProxyFactoryIsolationTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "PMD.AvoidAccessibilityAlteration"})
     @DisplayName("Should intercept package-private methods across class loaders")
     void shouldInterceptPackagePrivateAcrossClassLoaders() throws Exception {
         try (URLClassLoader isolated = newIsolatedLoader()) {

--- a/src/test/java/com/ultikits/ultitools/aop/ProxyIdentityConsolidationTest.java
+++ b/src/test/java/com/ultikits/ultitools/aop/ProxyIdentityConsolidationTest.java
@@ -42,6 +42,7 @@ class ProxyIdentityConsolidationTest {
     }
 
     /** Reflectively invokes {@code TaskManager}'s private unwrap site. */
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     private static Class<?> taskManagerResolves(Class<?> clazz) throws Exception {
         Method getTargetClass = TaskManager.class.getDeclaredMethod("getTargetClass", Class.class);
         getTargetClass.setAccessible(true);
@@ -50,6 +51,7 @@ class ProxyIdentityConsolidationTest {
     }
 
     /** Reflectively invokes {@code ExceptionInterceptor}'s private unwrap site. */
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     private static Class<?> exceptionInterceptorResolves(Object target) throws Exception {
         Method beanClassOf = ExceptionInterceptor.class
                 .getDeclaredMethod("beanClassOf", MethodInvocation.class, Method.class);

--- a/src/test/java/com/ultikits/ultitools/aop/ReflectiveMethodInvocationTest.java
+++ b/src/test/java/com/ultikits/ultitools/aop/ReflectiveMethodInvocationTest.java
@@ -336,6 +336,7 @@ class ReflectiveMethodInvocationTest {
         void shouldPropagateTargetException() throws NoSuchMethodException {
             TestTarget exceptionTarget = new TestTarget() {
                 @Override
+                @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
                 public String process(String input) {
                     throw new RuntimeException("Target error");
                 }
@@ -383,6 +384,7 @@ class ReflectiveMethodInvocationTest {
         void shouldAllowInterceptorToCatchException() throws Throwable {
             TestTarget exceptionTarget = new TestTarget() {
                 @Override
+                @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
                 public String process(String input) {
                     throw new RuntimeException("Original error");
                 }

--- a/src/test/java/com/ultikits/ultitools/aop/TransactionInterceptorTest.java
+++ b/src/test/java/com/ultikits/ultitools/aop/TransactionInterceptorTest.java
@@ -180,23 +180,27 @@ class TransactionInterceptorTest {
         }
 
         @Transactional
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         public void inner() {
             write(1);
             throw new RuntimeException("boom - self-invocation");
         }
 
         @Transactional
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         public void external() {
             write(2);
             throw new RuntimeException("boom - external call");
         }
 
         /** Negative control: not @Transactional, so its write must survive the throw. */
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         public void plainWriteThenThrow() {
             write(3);
             throw new RuntimeException("boom - not transactional");
         }
 
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         private void write(int id) {
             try (Statement st = txManager.getConnection().createStatement()) {
                 st.execute("INSERT INTO tx_test (id) VALUES (" + id + ")");
@@ -233,6 +237,7 @@ class TransactionInterceptorTest {
         // --- D-06: an unmatched rollbackFor no longer commits; it falls through to the default. ---
 
         @Transactional(rollbackFor = BusinessException.class)
+        @SuppressWarnings("PMD.AvoidThrowingNullPointerException")
         public void unmatchedRollbackForExternal() {
             write(101);
             throw new NullPointerException("boom - unmatched rollbackFor, external");
@@ -243,6 +248,7 @@ class TransactionInterceptorTest {
         }
 
         @Transactional(rollbackFor = BusinessException.class)
+        @SuppressWarnings("PMD.AvoidThrowingNullPointerException")
         public void unmatchedRollbackForSelf() {
             write(102);
             throw new NullPointerException("boom - unmatched rollbackFor, self-invocation");
@@ -369,6 +375,7 @@ class TransactionInterceptorTest {
         }
 
         @Transactional(propagation = Propagation.REQUIRES_NEW)
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         public void innerRequiresNewFailsSelf() {
             write(99);
             throw new RuntimeException("boom - inner REQUIRES_NEW, self-invocation");
@@ -401,6 +408,7 @@ class TransactionInterceptorTest {
 
         /** Externally-called REQUIRES_NEW method whose body throws. */
         @Transactional(propagation = Propagation.REQUIRES_NEW)
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         public void requiresNewExternalFails() {
             write(101);
             throw new RuntimeException("boom - external REQUIRES_NEW");
@@ -411,6 +419,7 @@ class TransactionInterceptorTest {
          * so the outer rolls back. The NOT_SUPPORTED write must survive the outer's rollback.
          */
         @Transactional
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         public void outerRequiredThenSelfInvokesNotSupportedThenFails() {
             write(4);
             innerNotSupportedWriteSelf();

--- a/src/test/java/com/ultikits/ultitools/api/ExternalDataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/api/ExternalDataStoreTest.java
@@ -60,6 +60,7 @@ public class ExternalDataStoreTest {
      * before Task 3, since this default body genuinely has no storage implementation of its own.
      */
     @Test
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     void defaultMethodThrowsUnsupportedOnceOwnershipCheckPasses() throws Exception {
         java.lang.reflect.Method forExternal = DataScope.class.getDeclaredMethod(
                 "forExternal", String.class, File.class, java.util.Set.class);

--- a/src/test/java/com/ultikits/ultitools/commands/PluginInstallCommandsEnhancedTest.java
+++ b/src/test/java/com/ultikits/ultitools/commands/PluginInstallCommandsEnhancedTest.java
@@ -654,6 +654,7 @@ class PluginInstallCommandsEnhancedTest {
         server.getScheduler().performTicks(20);
     }
     
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     private void registerPluginToMockBukkit(org.bukkit.plugin.Plugin plugin) {
         try {
             org.bukkit.plugin.PluginManager pluginManager = server.getPluginManager();

--- a/src/test/java/com/ultikits/ultitools/commands/tabcomplete/MethodInvocationCompleterTest.java
+++ b/src/test/java/com/ultikits/ultitools/commands/tabcomplete/MethodInvocationCompleterTest.java
@@ -399,6 +399,7 @@ class MethodInvocationCompleterTest {
         public void testMethod(@CmdParam(value = "param", suggest = "suggestThrowing") String param) {
         }
 
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         public List<String> suggestThrowing() {
             throw new RuntimeException("Test exception");
         }

--- a/src/test/java/com/ultikits/ultitools/commands/tabcomplete/TabCompletionManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/commands/tabcomplete/TabCompletionManagerTest.java
@@ -58,6 +58,7 @@ class TabCompletionManagerTest {
         resetSingleton();
     }
 
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     private void resetSingleton() throws Exception {
         Field instanceField = TabCompletionManager.class.getDeclaredField("instance");
         instanceField.setAccessible(true);

--- a/src/test/java/com/ultikits/ultitools/config/ConfigChangeListenerTest.java
+++ b/src/test/java/com/ultikits/ultitools/config/ConfigChangeListenerTest.java
@@ -168,6 +168,7 @@ class ConfigChangeListenerTest {
 
         @Test
         @DisplayName("should continue notifying after listener exception")
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         void shouldContinueAfterListenerException() {
             AtomicBoolean firstCalled = new AtomicBoolean(false);
             AtomicBoolean secondCalled = new AtomicBoolean(false);
@@ -186,6 +187,7 @@ class ConfigChangeListenerTest {
 
         @Test
         @DisplayName("should handle multiple exceptions")
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         void shouldHandleMultipleExceptions() {
             AtomicInteger callCount = new AtomicInteger(0);
             

--- a/src/test/java/com/ultikits/ultitools/context/ConditionalOnConfigTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ConditionalOnConfigTest.java
@@ -88,6 +88,7 @@ class ConditionalOnConfigTest {
      * But scanPackages needs actual classes on classpath — so we test the
      * shouldRegister logic directly by reflectively invoking it.
      */
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     private boolean invokesShouldRegister(Class<?> clazz) throws Exception {
         ComponentScanner scanner = new ComponentScanner(container);
         java.lang.reflect.Method shouldRegister =

--- a/src/test/java/com/ultikits/ultitools/entities/ButtonsTest.java
+++ b/src/test/java/com/ultikits/ultitools/entities/ButtonsTest.java
@@ -22,6 +22,7 @@ class ButtonsTest {
     private static UltiTools originalInstance;
 
     @BeforeAll
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     static void setUp() throws Exception {
         // Save original instance
         Field instanceField = UltiTools.class.getDeclaredField("ultiTools");

--- a/src/test/java/com/ultikits/ultitools/entities/ViewTypeTest.java
+++ b/src/test/java/com/ultikits/ultitools/entities/ViewTypeTest.java
@@ -25,6 +25,7 @@ class ViewTypeTest {
     private static UltiTools originalInstance;
 
     @BeforeAll
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     static void setUp() throws Exception {
         // Save original instance
         Field instanceField = UltiTools.class.getDeclaredField("ultiTools");

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/PlayerTempListenerTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/PlayerTempListenerTest.java
@@ -34,6 +34,7 @@ class PlayerTempListenerTest {
     private static PluginManager mockPluginManager;
 
     @BeforeAll
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     static void setUpClass() throws Exception {
         if (Bukkit.getServer() == null) {
             mockServer = mock(Server.class);

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/SimpleTempListenerTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/SimpleTempListenerTest.java
@@ -35,6 +35,7 @@ class SimpleTempListenerTest {
     private static PluginManager mockPluginManager;
 
     @BeforeAll
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     static void setUpClass() throws Exception {
         // Mock Server and PluginManager
         if (Bukkit.getServer() == null) {

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonTransactionTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/JsonTransactionTest.java
@@ -127,6 +127,7 @@ class JsonTransactionTest {
          * then itself throws so the outer rolls back. The inner's committed write must survive.
          */
         @Transactional
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         public void outerRequiredThenSelfInvokesRequiresNewThenFails() {
             outerOperator.insert(new TestData("outer", "Outer", 1));
             innerRequiresNewSucceedsSelf();
@@ -225,6 +226,7 @@ class JsonTransactionTest {
 
         @Test
         @DisplayName("Should rollback inserts on RuntimeException")
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         void rollbackInsertsOnException() {
             operator.insert(new TestData("0", "Pre-existing", 0));
 
@@ -246,6 +248,7 @@ class JsonTransactionTest {
 
         @Test
         @DisplayName("Should rollback updates on exception")
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         void rollbackUpdatesOnException() {
             operator.insert(new TestData("1", "Original", 100));
 
@@ -263,6 +266,7 @@ class JsonTransactionTest {
 
         @Test
         @DisplayName("Should rollback deletes on exception")
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         void rollbackDeletesOnException() {
             operator.insert(new TestData("1", "Alice", 100));
             operator.insert(new TestData("2", "Bob", 200));
@@ -283,6 +287,7 @@ class JsonTransactionTest {
 
         @Test
         @DisplayName("Should rollback mixed operations on exception")
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         void rollbackMixedOperations() {
             operator.insert(new TestData("1", "Alice", 100));
 
@@ -302,6 +307,7 @@ class JsonTransactionTest {
 
         @Test
         @DisplayName("Callable transaction should rollback on checked exception")
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         void callableRollbackOnCheckedException() throws Exception {
             operator.insert(new TestData("1", "Original", 100));
 
@@ -325,6 +331,7 @@ class JsonTransactionTest {
 
         @Test
         @DisplayName("Rollback should restore entity state even after in-place mutation")
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         void deepCopyPreventsSharedReferenceCorruption() {
             // This tests that the snapshot is a deep copy, not a shallow copy.
             // update(T) calls BeanCopyUtil.copyProperties which mutates entities in-place.
@@ -743,6 +750,7 @@ class JsonTransactionTest {
             assertThat(suspendedStackValue()).isNull();
         }
 
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         private Deque<?> suspendedStackValue() throws Exception {
             Field field = JsonTransactionManager.class.getDeclaredField("suspendedStack");
             field.setAccessible(true);

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperatorTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/json/SimpleJsonDataOperatorTest.java
@@ -989,6 +989,7 @@ class SimpleJsonDataOperatorTest {
 
         @Test
         @DisplayName("a snapshot restore (rolled-back transaction) does not re-fire onLoad for restored entries")
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         void snapshotRestoreDoesNotRefireOnLoad() {
             hookOperator.insert(newEntity("txn-1"));
             DataEntityTest.CountingAuditableEntity.resetCounters();

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/mysql/MysqlDataStoreTest.java
@@ -202,6 +202,7 @@ class MysqlDataStoreTest {
 
         @Test
         @DisplayName("应该处理 HikariDataSource 初始化失败")
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         void shouldHandleHikariDataSourceInitializationFailure() {
             // Arrange
             setupMysqlConfig();
@@ -456,6 +457,7 @@ class MysqlDataStoreTest {
 
         @Test
         @DisplayName("应该安全处理当 dataSource 为 null")
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         void shouldHandleNullDataSourceSafely() {
             // Arrange
             setupMysqlConfig();
@@ -591,6 +593,7 @@ class MysqlDataStoreTest {
 
         @Test
         @DisplayName("应该正确处理 HikariDataSource 构造函数异常")
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         void shouldHandleHikariDataSourceConstructorException() {
             // Arrange
             setupMysqlConfig();
@@ -611,6 +614,7 @@ class MysqlDataStoreTest {
 
         @Test
         @DisplayName("应该使用 i18n 转换错误消息")
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         void shouldUseI18nForErrorMessage() {
             // Arrange
             setupMysqlConfig();

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataOperatorTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataOperatorTest.java
@@ -495,6 +495,7 @@ class SQLiteDataOperatorTest {
 
         @Test
         @DisplayName("Test G: 守卫在触及 QueryRunner 之前就已生效——update 从未被调用")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void delWithNoConditionsShouldNeverReachQueryRunner() throws Exception {
             QueryRunner spyRunner = Mockito.spy(new QueryRunner(dataSource));
             Field field = AbstractRelationalDataOperator.class.getDeclaredField("queryRunner");

--- a/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
+++ b/src/test/java/com/ultikits/ultitools/interfaces/impl/data/sqlite/SQLiteDataStoreTest.java
@@ -273,6 +273,7 @@ class SQLiteDataStoreTest {
          */
         @Test
         @DisplayName("destroyAllOperators 应该关闭它持有的每一个连接池")
+        @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
         void destroyAllOperatorsShouldCloseEveryPool() throws Exception {
             SQLiteDataStore store = new SQLiteDataStore();
             HikariDataSource poolA = (HikariDataSource) createH2DataSource();
@@ -386,6 +387,7 @@ class SQLiteDataStoreTest {
     @DisplayName("getOperator(DataScope, Class) 所有权测试 (D-14, 继承自 DataStore 的 default 方法)")
     class GetOperatorDataScopeTests {
 
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         private com.ultikits.ultitools.manager.DataScope buildScope(
                 String pluginName, java.util.Set<Class<?>> ownedEntities
         ) throws ReflectiveOperationException {

--- a/src/test/java/com/ultikits/ultitools/manager/ChatCallbackManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ChatCallbackManagerTest.java
@@ -458,6 +458,7 @@ class ChatCallbackManagerTest {
 
         @Test
         @DisplayName("多个回调可以独立执行")
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         void multipleCallbacksAreIndependent() throws Exception {
             // Arrange
             AtomicInteger successCount = new AtomicInteger(0);

--- a/src/test/java/com/ultikits/ultitools/manager/CommandExecutionManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/CommandExecutionManagerTest.java
@@ -317,6 +317,7 @@ class CommandExecutionManagerTest {
 
         @Test
         @DisplayName("sendMessage(String) 应该捕获消息并添加换行")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void sendMessageShouldCaptureWithNewline() throws Exception {
             // 使用反射访问内部类
             Class<?> captureClass = Class.forName("com.ultikits.ultitools.manager.CommandExecutionManager$CommandOutputCapture");
@@ -706,6 +707,7 @@ class CommandExecutionManagerTest {
 
         @Test
         @DisplayName("pendingCommands 应该初始化为 ConcurrentHashMap")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void pendingCommandsShouldBeConcurrentHashMap() throws Exception {
             // Arrange
             CommandExecutionManager newManager = new CommandExecutionManager();

--- a/src/test/java/com/ultikits/ultitools/manager/CommandManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/CommandManagerTest.java
@@ -664,6 +664,7 @@ class CommandManagerTest {
 
         @Test
         @DisplayName("handleHelp 应该发送帮助消息")
+        @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
         void handleHelpShouldSendMessage() {
             // Arrange
             ManualRegisterCommandExecutor executor = new ManualRegisterCommandExecutor();

--- a/src/test/java/com/ultikits/ultitools/manager/DataSourceTransactionManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DataSourceTransactionManagerTest.java
@@ -59,6 +59,7 @@ class DataSourceTransactionManagerTest {
         mocks.close();
     }
 
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     private void clearThreadLocalContext() {
         try {
             Field contextHolderField = DataSourceTransactionManager.class.getDeclaredField("contextHolder");
@@ -1015,6 +1016,7 @@ class DataSourceTransactionManagerTest {
             assertThat(suspendedStackValue()).isNull();
         }
 
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         private Deque<?> suspendedStackValue() throws Exception {
             Field field = DataSourceTransactionManager.class.getDeclaredField("suspendedStack");
             field.setAccessible(true);

--- a/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DataStoreManagerTest.java
@@ -80,6 +80,7 @@ class DataStoreManagerTest {
     /**
      * 清理 DataStoreManager 的静态 map
      */
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     private void clearDataMap() {
         try {
             Field dataMapField = DataStoreManager.class.getDeclaredField("dataMap");
@@ -292,6 +293,7 @@ class DataStoreManagerTest {
 
         @Test
         @DisplayName("关闭时应该调用每个 DataStore 的 destroyAllOperators")
+        @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
         void shouldDestroyAllOperatorsOnClose() {
             // Arrange
             DataStore store1 = mock(DataStore.class);
@@ -560,6 +562,7 @@ class DataStoreManagerTest {
 
         @Test
         @DisplayName("close 时应该为每个 store 调用 destroyAllOperators")
+        @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
         void closeShouldCallDestroyForEach() {
             // Arrange
             DataStore store1 = mock(DataStore.class);
@@ -608,6 +611,7 @@ class DataStoreManagerTest {
          */
         @Test
         @DisplayName("close() 应该让已注册 SQLiteDataStore 持有的每个连接池归零")
+        @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
         void closeShouldLeaveZeroOpenConnectionsAcrossRegisteredStore() throws Exception {
             SQLiteDataStore sqliteStore = new SQLiteDataStore();
             HikariDataSource poolA = createH2Pool();
@@ -1230,7 +1234,7 @@ class DataStoreManagerTest {
             adaptersField().remove(plugin);
         }
 
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings({"unchecked", "PMD.AvoidAccessibilityAlteration"})
         private Map<org.bukkit.plugin.java.JavaPlugin, com.ultikits.ultitools.api.ExternalPluginAdapter>
                 adaptersField() throws Exception {
             Field field = com.ultikits.ultitools.api.UltiToolsAPI.class.getDeclaredField("adapters");

--- a/src/test/java/com/ultikits/ultitools/manager/ErrorReportCollectorTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ErrorReportCollectorTest.java
@@ -641,7 +641,7 @@ class ErrorReportCollectorTest {
     /**
      * Set a private field via reflection.
      */
-    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+    @SuppressWarnings({"PMD.AvoidAccessibilityAlteration", "PMD.AvoidThrowingRawExceptionTypes"})
     private void setField(Object obj, String fieldName, Object value) {
         try {
             Field field = obj.getClass().getDeclaredField(fieldName);
@@ -655,7 +655,7 @@ class ErrorReportCollectorTest {
     /**
      * Clear the dedup map (simulates window reset).
      */
-    @SuppressWarnings({"PMD.AvoidAccessibilityAlteration", "unchecked"})
+    @SuppressWarnings({"PMD.AvoidAccessibilityAlteration", "unchecked", "PMD.AvoidThrowingRawExceptionTypes"})
     private void clearDedupMap(ErrorReportCollector collector) {
         try {
             Field field = ErrorReportCollector.class.getDeclaredField("dedupMap");

--- a/src/test/java/com/ultikits/ultitools/manager/LogStreamManagerCommandCaptureTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/LogStreamManagerCommandCaptureTest.java
@@ -108,6 +108,7 @@ class LogStreamManagerCommandCaptureTest {
         logStreamManager = LogStreamManager.getInstance();
     }
 
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     private void resetSingleton() throws Exception {
         Field instanceField = LogStreamManager.class.getDeclaredField("instance");
         instanceField.setAccessible(true);

--- a/src/test/java/com/ultikits/ultitools/manager/PlayerCacheManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PlayerCacheManagerTest.java
@@ -183,6 +183,7 @@ class PlayerCacheManagerTest {
 
         @Test
         @DisplayName("Should clean both parent and child @PlayerCache fields when shadowed by same name")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void shouldCleanBothShadowedFields() throws NoSuchFieldException, IllegalAccessException {
             PlayerCacheManager testManager = new PlayerCacheManager();
             ShadowChild bean = new ShadowChild();

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerAopWiringTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerAopWiringTest.java
@@ -205,6 +205,7 @@ class PluginManagerAopWiringTest {
         }
 
         @Transactional
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         public void writeThenFail() {
             operator.insert(new JsonTestEntity("json-tx-fail", "before-rollback"));
             throw new RuntimeException("boom - json backend");

--- a/src/test/java/com/ultikits/ultitools/manager/TransactionalRollbackEndToEndTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/TransactionalRollbackEndToEndTest.java
@@ -139,6 +139,7 @@ class TransactionalRollbackEndToEndTest {
         }
 
         @Transactional
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         public void writeThenFail() {
             insert(1);
             throw new RuntimeException("boom - external call");
@@ -155,11 +156,13 @@ class TransactionalRollbackEndToEndTest {
         }
 
         @Transactional
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         public void innerWriteThenFail() {
             insert(3);
             throw new RuntimeException("boom - self-invocation");
         }
 
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         private void insert(int id) {
             try (Statement st = txManager.getConnection().createStatement()) {
                 st.execute("INSERT INTO tx_test (id) VALUES (" + id + ")");

--- a/src/test/java/com/ultikits/ultitools/services/impl/DefaultEmailServiceTest.java
+++ b/src/test/java/com/ultikits/ultitools/services/impl/DefaultEmailServiceTest.java
@@ -179,6 +179,7 @@ class DefaultEmailServiceTest {
 
         @Test
         @DisplayName("有效邮箱地址应通过验证")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void shouldValidateCorrectEmails() throws Exception {
             Method isValidEmail = DefaultEmailService.class.getDeclaredMethod("isValidEmail", String.class);
             isValidEmail.setAccessible(true);
@@ -273,6 +274,7 @@ class DefaultEmailServiceTest {
 
         @Test
         @DisplayName("验证码邮件模板应包含验证码")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void shouldContainVerificationCode() throws Exception {
             Method buildTemplate = DefaultEmailService.class.getDeclaredMethod(
                 "buildVerificationEmailTemplate", String.class, String.class, int.class);
@@ -288,6 +290,7 @@ class DefaultEmailServiceTest {
 
         @Test
         @DisplayName("模板应正确转义 HTML 特殊字符")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void shouldEscapeHtmlCharacters() throws Exception {
             Method escapeHtml = DefaultEmailService.class.getDeclaredMethod("escapeHtml", String.class);
             escapeHtml.setAccessible(true);

--- a/src/test/java/com/ultikits/ultitools/services/impl/InMemeryTeleportServiceTest.java
+++ b/src/test/java/com/ultikits/ultitools/services/impl/InMemeryTeleportServiceTest.java
@@ -71,7 +71,7 @@ class InMemeryTeleportServiceTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.safeUnmock();
     }
     
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "PMD.AvoidAccessibilityAlteration"})
     private void clearStaticMaps() {
         try {
             Field teleportingPlayersField = InMemeryTeleportService.class.getDeclaredField("teleportingPlayers");
@@ -302,7 +302,7 @@ class InMemeryTeleportServiceTest {
 
         @Test
         @DisplayName("应该将玩家添加到传送中列表")
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings({"unchecked", "PMD.AvoidAccessibilityAlteration"})
         void shouldAddPlayerToTeleportingList() throws Exception {
             // Arrange
             PlayerMock player = server.addPlayer();

--- a/src/test/java/com/ultikits/ultitools/services/impl/InMemoryNotificationServiceTest.java
+++ b/src/test/java/com/ultikits/ultitools/services/impl/InMemoryNotificationServiceTest.java
@@ -70,7 +70,7 @@ class InMemoryNotificationServiceTest {
         com.ultikits.ultitools.utils.MockBukkitHelper.safeUnmock();
     }
     
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "PMD.AvoidAccessibilityAlteration"})
     private void clearStaticMaps() {
         try {
             Field atedPlayerField = InMemoryNotificationService.class.getDeclaredField("atedPlayer");
@@ -353,7 +353,7 @@ class InMemoryNotificationServiceTest {
 
         @Test
         @DisplayName("同一玩家多次发送应该复用 BossBar")
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings({"unchecked", "PMD.AvoidAccessibilityAlteration"})
         void shouldReuseBossBarForSamePlayer() throws Exception {
             // Arrange
             PlayerMock player = server.addPlayer();

--- a/src/test/java/com/ultikits/ultitools/utils/BasicTypeUtilTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/BasicTypeUtilTest.java
@@ -159,6 +159,7 @@ class BasicTypeUtilTest {
 
         @Test
         @DisplayName("私有构造函数应该抛出 UnsupportedOperationException")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void privateConstructorShouldThrowException() throws Exception {
             Constructor<BasicTypeUtil> constructor = BasicTypeUtil.class.getDeclaredConstructor();
             constructor.setAccessible(true);

--- a/src/test/java/com/ultikits/ultitools/utils/CloudAuthManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/CloudAuthManagerTest.java
@@ -37,6 +37,7 @@ class CloudAuthManagerTest {
     /**
      * Read the value of a private static field from CloudAuthManager via reflection.
      */
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     private static Object getStaticField(String name) throws Exception {
         Field field = CloudAuthManager.class.getDeclaredField(name);
         field.setAccessible(true);

--- a/src/test/java/com/ultikits/ultitools/utils/ConfigEditorUtilsTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/ConfigEditorUtilsTest.java
@@ -163,6 +163,7 @@ class ConfigEditorUtilsTest {
 
         @Test
         @DisplayName("getConfigMapString 应该调用 ConfigManager.toJson()")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void getConfigMapStringShouldCallToJson() throws Exception {
             String expectedJson = "{\"plugin\":{\"config.yml\":{\"key\":\"value\"}}}";
             when(mockConfigManager.toJson()).thenReturn(expectedJson);

--- a/src/test/java/com/ultikits/ultitools/utils/FileUtilsTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/FileUtilsTest.java
@@ -359,6 +359,7 @@ class FileUtilsTest {
 
         @Test
         @DisplayName("私有构造函数应该抛出 UnsupportedOperationException")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void privateConstructorShouldThrowException() throws Exception {
             Constructor<FileUtils> constructor = FileUtils.class.getDeclaredConstructor();
             constructor.setAccessible(true);

--- a/src/test/java/com/ultikits/ultitools/utils/VersionComparatorUtilTest.java
+++ b/src/test/java/com/ultikits/ultitools/utils/VersionComparatorUtilTest.java
@@ -202,6 +202,7 @@ class VersionComparatorUtilTest {
 
         @Test
         @DisplayName("私有构造函数应该抛出 UnsupportedOperationException")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void privateConstructorShouldThrowException() throws Exception {
             Constructor<VersionComparatorUtil> constructor = VersionComparatorUtil.class.getDeclaredConstructor();
             constructor.setAccessible(true);

--- a/src/test/java/com/ultikits/ultitools/websocket/MessageHandlerRegistryTest.java
+++ b/src/test/java/com/ultikits/ultitools/websocket/MessageHandlerRegistryTest.java
@@ -76,6 +76,7 @@ class MessageHandlerRegistryTest {
         }
 
         @Override
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         public void handle(JsonObject message) {
             throw new RuntimeException("Test exception");
         }

--- a/src/test/java/com/ultikits/ultitools/widgets/HologramTest.java
+++ b/src/test/java/com/ultikits/ultitools/widgets/HologramTest.java
@@ -71,6 +71,7 @@ class HologramTest {
 
         @Test
         @DisplayName("构造函数应该正确初始化 lines 字段")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void constructorShouldInitializeLinesField() throws Exception {
             String[] lines = {"Line 1", "Line 2", "Line 3"};
             Hologram hologram = new Hologram(lines);

--- a/src/test/java/com/ultikits/ultitools/widgets/impl/InventoryConfirmTest.java
+++ b/src/test/java/com/ultikits/ultitools/widgets/impl/InventoryConfirmTest.java
@@ -98,6 +98,7 @@ class InventoryConfirmTest {
 
         @Test
         @DisplayName("GUI_ID 应该是 confirm_gui")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void guiIdShouldBeConfirmGui() throws Exception {
             Field field = InventoryConfirm.class.getDeclaredField("GUI_ID");
             field.setAccessible(true);


### PR DESCRIPTION
Annotates 101 of 114 flagged sites in `src/test` with `@SuppressWarnings`, so Codacy's PMD gate stops reporting findings that are structural to how this framework has to be tested. **13 sites were refused** — they turned out to be real test gaps and are tracked separately.

Targets `alpha`. No production code is touched: `git diff --name-only` lists zero files under `src/main/`.

## Why annotation rather than excluding the path

Codacy cannot scope a single rule to a path — `exclude_paths` works at the global and engine level only, so `engines.pmd.exclude_paths: ['src/test/**']` would disable *all* of PMD on tests. That was measured and rejected: it would have hidden the 19 genuine findings fixed in #342 (redundant fully-qualified names, uncommented empty method bodies, naming-convention breaches, a singular field).

PMD's own documentation recommends this route for `AvoidAccessibilityAlteration`: *"deliberate access alteration should be suppressed using the usual suppression methods (e.g. by using `@SuppressWarnings` annotation)."*

## The four rules and why tests trip them

| Rule | Sites | Why |
|---|---|---|
| `PMD.AvoidAccessibilityAlteration` | 54 | `setAccessible(true)` to reach the package-private `DataScope` factories, `PluginManager`'s private fields, `wireAop`, and the IoC/AOP internals under test. This framework's security model *is* its visibility boundaries — verifying them requires reaching through them. |
| `PMD.AvoidThrowingRawExceptionTypes` | 40 | `throw new RuntimeException("force rollback")` — driving the rollback path is the test's purpose. |
| `PMD.JUnitTestsShouldIncludeAssert` | 18 | 9 false positives (assertions in the shared `testutil/PoolStateAssertions.java` helper, or Mockito `verify()`, neither of which PMD recognises syntactically). The other 9 are real — see below. |
| `PMD.AvoidThrowingNullPointerException` | 2 | The NPE is the specimen proving `@Transactional`'s additive `rollbackFor` semantics. |

Annotations sit on the tightest enclosing annotatable element and merge into any existing `@SuppressWarnings` as an array. Where a flagged line sits inside a lambda — which has no annotation position — the enclosing test method carries it instead.

## 13 sites refused, because a suppression is a claim

A suppression asserts the site is deliberate. Thirteen could not be defended, so they were left flagged:

| File | Line(s) | What is actually wrong |
|---|---|---|
| `abstracts/guis/OkCancelPageTest.java` | 150 | `testCloseAfterAction()` body is two comment lines and nothing else |
| `abstracts/guis/PagingPageTest.java` | 110, 117, 125 | three test bodies commented out entirely |
| `api/ExternalPluginIntegrationTest.java` | 224, 235 | call the method under test with no assertion; sibling tests in the same file use `assertThatCode(...).doesNotThrowAnyException()` |
| `interfaces/ConfigurableTest.java` | 242 | `shouldNotThrowException()` calls `saveConfig` with no `assertDoesNotThrow` and no assertion |
| `interfaces/impl/data/json/SimpleJsonDataOperatorTest.java` | 746 | `testGCEmptyDirectory()` — comment only |
| `manager/ConfigManagerTest.java` | 394 | `nullPluginShouldNotCrash()` swallows the expected exception without asserting; the sibling directly above it does `assertThat(e).isNotNull()`. It also passes when nothing is thrown. |
| `manager/DataStoreManagerTest.java` | 463 | `concurrentReadWriteShouldBeSafe()` spawns threads and awaits a latch with no assert or verify — it cannot detect the race it is named after |
| `manager/PlayerEventManagerTest.java` | 249 | no assertion, no verify |
| `utils/SimpleHttpClientTest.java` | 53 | comment only |
| `websocket/handlers/LogStreamHandlerTest.java` | 161 | comment only |

Taking the linter seriously instead of excluding the path is what surfaced these.

## Verification

- `mvn -B -o test` → **4718 tests, 0 failures, 0 errors** — identical to the baseline. Annotations cannot change behaviour, so a changed count would mean something else happened.
- `mvn -B -o package javadoc:javadoc -DskipTests` → exit 0
- `BugEvidenceTest` 15/15
- 48 files changed, 92 insertions / 8 deletions — no whole-file rewrites; line endings verified per file before and after
- Zero files under `src/main/`

## Out of scope

`src/main` carries 45 occurrences of the first two rules. They are deliberately untouched and tracked in #343: the 18 `setAccessible` calls are structural to a reflective DI container, but the 27 raw `RuntimeException` throws are **not** presumed deliberate — this repository has a typed hierarchy (`UltiToolsException` + `ErrorCode`) and several of those sites likely want a domain exception rather than a suppression.

The convention is recorded in the repository's control document so future tests carry the annotation rather than re-tripping the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQ8annckTbswRvUEZrkNYj