### PR TITLE
ci: close declared issues when a pull request merges into alpha

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+## Summary
+
+<!-- What this pull request changes, and why. English-first, Chinese as a supplement. -->
+
+## Issue closure
+
+<!--
+REQUIRED - do not delete this section.
+
+List every issue this pull request closes, one per line, using a closing keyword:
+
+    Closes #1234
+
+Write `None` if it closes nothing, so that an empty section reads as a decision rather than
+an oversight.
+
+Why this section exists: feature pull requests here target `alpha`, not the default branch
+`main`. GitHub acts on closing keywords only for pull requests merged into the default branch,
+so `Closes #1234` on its own has never closed anything in this repository. After the merge,
+`.github/workflows/phase-closeout.yml` reads this section and performs the closure.
+
+The workflow ignores anything inside an HTML comment, a code fence, or backticks - which is why
+the example above closes nothing. Put real declarations outside this comment.
+-->
+
+## Verification
+
+<!-- The commands you ran and what they actually reported. Paste the counts, not "tests pass". -->
+
+## Checklist
+
+<!-- Delete any line that does not apply. -->
+
+- [ ] Targets `alpha`, unless this is an `alpha` -> `main` release promotion
+- [ ] Line endings preserved per file (`file <path>` before and after; this tree is mixed CRLF/LF)
+- [ ] New and modified comments are English-first
+- [ ] Documentation synced in `UltiTools-Dev-Doc` (branch `alpha`) if documented behaviour changed

--- a/.github/scripts/close_declared_issues.py
+++ b/.github/scripts/close_declared_issues.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Close the issues a merged pull request declares in its body."""
+
+# GitHub acts on closing keywords only for pull requests merged into the default branch. This
+# repository's feature pull requests target `alpha`, so that never fires and the declaration in
+# the body is inert. This script consumes it instead.
+#
+# Run from a workflow with GH_TOKEN, GH_REPO, PR_BODY, PR_NUMBER and BASE_REF in the environment.
+#
+# The docstrings here are deliberately single-line: Codacy runs pydocstyle with both D212
+# ("summary on the first line") and D213 ("summary on the second line") enabled, which are
+# mutually exclusive, so any multi-line docstring trips one of them whichever way it is written.
+
+import os
+import re
+import subprocess
+import sys
+
+# The nine keywords GitHub itself recognises. Anchored with \b on the left so `unfixes #1` and
+# `prefix #1` do not match, and requiring whitespace before `#` so a cross-repository reference
+# (`Closes owner/repo#12`) is left alone - closing an issue in another repository is not this
+# workflow's business.
+KEYWORDS = r"clos(?:e|es|ed)|fix(?:|es|ed)|resolv(?:e|es|ed)"
+SHORTHAND = re.compile(rf"\b(?:{KEYWORDS})\s+#(\d+)\b", re.IGNORECASE)
+
+
+def issue_url_pattern(repo: str) -> re.Pattern:
+    """Match `Closes https://github.com/<this repo>/issues/123`, which GitHub also accepts."""
+    return re.compile(
+        rf"\b(?:{KEYWORDS})\s+https://github\.com/{re.escape(repo)}/issues/(\d+)\b",
+        re.IGNORECASE,
+    )
+
+
+def strip_non_prose(body: str) -> str:
+    """Remove regions where an issue reference is not a declaration."""
+    # Order matters and all three are required:
+    #
+    # * HTML comments - the pull request template puts a worked `Closes #1234` example inside one.
+    #   An author who leaves it in place would otherwise close whatever that example names.
+    # * Fenced code blocks - bodies here routinely quote build output and configuration.
+    # * Inline code - a `Closes #12` quoted while discussing the convention is not a declaration.
+    body = re.sub(r"<!--.*?-->", " ", body, flags=re.DOTALL)
+    body = re.sub(r"```.*?```", " ", body, flags=re.DOTALL)
+    body = re.sub(r"~~~.*?~~~", " ", body, flags=re.DOTALL)
+    body = re.sub(r"`[^`\n]*`", " ", body)
+    return body
+
+
+def declared_issues(body: str, repo: str) -> list:
+    prose = strip_non_prose(body)
+    found = {int(n) for n in SHORTHAND.findall(prose)}
+    found |= {int(n) for n in issue_url_pattern(repo).findall(prose)}
+    return sorted(found)
+
+
+def gh(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["gh", *args], capture_output=True, text=True)
+
+
+def last_line(stream: str) -> str:
+    """The most specific line of a gh error. It is the only diagnostic a failed run leaves."""
+    lines = [line for line in (stream or "").strip().splitlines() if line.strip()]
+    return lines[-1] if lines else "no error output"
+
+
+def summary(line: str) -> None:
+    print(line)
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if path:
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+
+
+def main() -> int:
+    body = os.environ.get("PR_BODY") or ""
+    repo = os.environ["GH_REPO"]
+    pr = os.environ["PR_NUMBER"]
+    base = os.environ.get("BASE_REF", "")
+
+    numbers = declared_issues(body, repo)
+    if not numbers:
+        summary(f"No issue declared in #{pr}. Nothing to close.")
+        return 0
+
+    summary(f"#{pr} declares: {', '.join('#' + str(n) for n in numbers)}")
+
+    comment = (
+        f"Closed by #{pr}, merged into `{base}`.\n\n"
+        "This repository's feature pull requests target `alpha` rather than the default branch, "
+        "so GitHub's own closing keywords do not fire on merge. "
+        "`.github/workflows/phase-closeout.yml` reads the declaration in the pull request body "
+        "and performs the closure."
+    )
+
+    failed = []
+    for number in numbers:
+        state = gh("issue", "view", str(number), "--json", "state", "--jq", ".state")
+        if state.returncode != 0:
+            summary(f"  #{number}: SKIPPED - cannot read it ({last_line(state.stderr)})")
+            failed.append(number)
+            continue
+        if state.stdout.strip() == "CLOSED":
+            summary(f"  #{number}: already closed, left alone")
+            continue
+
+        closed = gh("issue", "close", str(number), "-r", "completed", "-c", comment)
+        if closed.returncode == 0:
+            summary(f"  #{number}: closed")
+        else:
+            summary(f"  #{number}: FAILED - {closed.stderr.strip()}")
+            failed.append(number)
+
+    if failed:
+        # Surface the failure rather than passing quietly: a silent miss here reproduces exactly
+        # the defect this workflow exists to prevent.
+        print(f"::error::Could not close: {', '.join('#' + str(n) for n in failed)}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/phase-closeout.yml
+++ b/.github/workflows/phase-closeout.yml
@@ -1,0 +1,44 @@
+name: Phase Closeout
+
+on:
+  pull_request_target:
+    types: [ closed ]
+    branches: [ "alpha", "main" ]
+
+# Feature pull requests here target `alpha`, not the default branch `main`. GitHub only acts on
+# closing keywords for pull requests merged into the *default* branch, so `Closes #123` in a pull
+# request body has never closed anything in this repository - those issues were closed by hand,
+# and a phase that forgot to do it left its entire issue set open behind a stale board.
+#
+# This job performs that closure: it reads the declaration out of the pull request body and closes
+# each issue with a comment pointing back at the pull request.
+#
+# Why `pull_request_target` and not `pull_request`: on a pull request from a fork, `pull_request`
+# hands the job a read-only GITHUB_TOKEN, which cannot close anything. The standard hazard of
+# `pull_request_target` is running the head branch's code with a privileged token. That does not
+# apply here - the checkout below takes the *base* branch (actions/checkout's default under this
+# event), never `github.event.pull_request.head.sha`, so the script executed is the one already
+# reviewed and merged into `alpha`. Do not add a `ref:` that points at the head.
+
+permissions:
+  issues: write
+
+jobs:
+  close-declared-issues:
+    name: Close issues declared in the PR body
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Close declared issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: python3 .github/scripts/close_declared_issues.py

--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ data.json
 # GSD planning artifacts (local-only, never published)
 .planning/
 .gsd/
+
+# Python bytecode from .github/scripts/
+__pycache__/


### PR DESCRIPTION
## Summary

Phase 1's ten issues stayed open behind a board that read `Done`; Phase 2's nine were closed
because someone remembered to. Nothing in this repository made the difference mechanical. This
adds that mechanism.

The chain had three independent breaks:

| # | Break | Fixed by |
|---|---|---|
| 1 | Pull request bodies carry no closing declaration at all — #340, #342 and #344 contain **zero** closing keywords | `.github/pull_request_template.md` |
| 2 | Even when written, `alpha` is not the default branch, so GitHub never acts on the keyword | `.github/workflows/phase-closeout.yml` |
| 3 | Project #4's built-in `Item closed` workflow is disabled, so a closed issue leaves the board stale | **not in this PR — see below** |
| 4 | Issues do not reach the board automatically at all — they are added by hand | **not in this PR — see below** |

Break 1 is why the workflow alone would not have helped: replayed against the real body of #340,
the parser returns an empty list. The template is what gives the workflow an input.

Break 4 was found by comparing each board item's `createdAt` against its issue's: #337/#338/#339
were created at 05:48 and reached the board at 09:10; #341 took 20 hours; #341, #343 and #345
landed 4 seconds apart, which is the signature of a manual batch add. Left as is, a phase can close
an issue that never reached the board, and the board will read green for a phase it never tracked.

## What is deliberately not here

**Board synchronisation.** `GITHUB_TOKEN` cannot write an org-level Project v2, and no
project-scoped PAT is configured. GitHub exposes `deleteProjectV2Workflow` but **no** mutation to
enable one, so the project's own built-in automation cannot be turned on from code either.

After merging, enable these once in the UI — Project #4 → `⋯` → **Workflows**:

- **Item closed** → set `Status` = `✅ Done` — closes break 3.
- **Auto-add to project** with filter `is:issue` — closes break 4.
- **Item reopened** → set `Status` = `🏗 In progress`, if offered, so a reopened issue does not
  sit on the board still reading Done.

Neither needs a token, and both are permanent once set.

## Design notes

**`pull_request_target`, not `pull_request`.** On a pull request from a fork, `pull_request` hands
the job a read-only `GITHUB_TOKEN` that cannot close anything. The usual hazard of
`pull_request_target` — running head-branch code with a privileged token — does not apply: the
checkout takes the base branch (the action's default under this event), never
`head.sha`, so the script that executes is one already reviewed and merged.

**Stripping order in the parser.** HTML comments → code fences → inline code, all three required.
The template carries a worked `Closes #1234` example inside an HTML comment; without that strip,
every pull request using the template would close issue #1234. This is verified by a test case,
and by running the parser over the committed template itself (result: `[]`).

Cross-repository references (`Closes owner/repo#12`) are ignored — closing an issue in another
repository is not this workflow's business.

## Verification

Parser replayed against 18 constructed cases and 6 real pull request bodies:

```
18/18 constructed cases pass
  positives: 9 keywords, issue-URL form, dedup, declaration surviving alongside noise
  negatives: HTML comments, ``` fences, ~~~ fences, inline code, cross-repo refs,
             cross-repo URLs, bare mentions, keyword-as-substring, missing separator, empty body

PASS PR #273 -> [184]        PASS PR #340 -> []
PASS PR #311 -> [190]        PASS PR #342 -> []
PASS PR #319 -> [309, 310]   PASS PR #344 -> []
```

`.gitignore` gained three lines for `__pycache__/`, appended with CRLF to match the file
(`git diff --numstat` reports `3 0`, not a whole-file rewrite).

This workflow does not run on its own merge: `pull_request_target` resolves the workflow from the
base branch, where it does not exist yet. Its first live run is the next pull request into `alpha`.

## Issue closure

None. This is process tooling; no tracked issue covers it.

## Checklist

- [x] Targets `alpha`
- [x] Line endings preserved per file (`.gitignore` stays CRLF; new files are LF, matching `pr-source-guard.yml`)
- [x] New comments are English-first
- [ ] Documentation sync — not applicable, no documented framework behaviour changed

