### PR TITLE
feat(6.3.0): Phase 3 PR 1 — merged-annotation resolver and call-site migration (WIRE-08)

### DIFF
--- a/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.ApiStatus;
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
 import com.ultikits.ultitools.annotations.EnableAutoRegister;
+import com.ultikits.ultitools.context.MergedAnnotationResolver;
 import com.ultikits.ultitools.context.SimpleContainer;
 import com.ultikits.ultitools.entities.Language;
 import com.ultikits.ultitools.exceptions.ErrorCode;
@@ -37,7 +38,6 @@ import com.ultikits.ultitools.manager.CommandManager;
 import com.ultikits.ultitools.manager.ConfigManager;
 import com.ultikits.ultitools.manager.ListenerManager;
 import com.ultikits.ultitools.manager.PluginManager;
-import com.ultikits.ultitools.utils.AnnotationUtils;
 import com.ultikits.ultitools.utils.DependencyUtils;
 import com.ultikits.ultitools.utils.FileUtils;
 import com.ultikits.ultitools.utils.VersionComparatorUtil;
@@ -324,7 +324,7 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
      * 初始化配置实体。
      */
     private void initConfig() throws IOException {
-        EnableAutoRegister annotation = AnnotationUtils.findAnnotation(this.getClass(), EnableAutoRegister.class);
+        EnableAutoRegister annotation = MergedAnnotationResolver.find(this.getClass(), EnableAutoRegister.class);
         if (annotation != null && annotation.config()) {
             for (String packageName : DependencyUtils.getPluginPackages(this)) {
                 UltiTools.getInstance().getConfigManager().registerAll(

--- a/src/main/java/com/ultikits/ultitools/context/ComponentScanner.java
+++ b/src/main/java/com/ultikits/ultitools/context/ComponentScanner.java
@@ -2,7 +2,6 @@ package com.ultikits.ultitools.context;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.net.JarURLConnection;
 import java.net.URL;
@@ -235,17 +234,54 @@ public class ComponentScanner {
     }
 
     /**
-     * Check if class has meta-component annotation.
+     * Check if class has a meta-component annotation, anywhere on its whole annotation tree.
+     * <p>
+     * Widened from the previous hand-written implementation (D-03, 03-02), which inspected only
+     * the annotations declared directly on the class and only one meta-annotation level deep, so
+     * a stereotype annotation composed two levels above {@code @Component} was not recognised.
+     * {@link MergedAnnotationResolver#isPresent} walks the full annotation tree, so it now is.
+     * This is intentional -- a composed stereotype annotation exists precisely to be recognised --
+     * and is recorded against {@code COMPATIBILITY.md}'s behaviour-change criterion by 03-10.
+     * <p>
+     * <b>Exception: a {@link UltiToolsPlugin} subclass is never treated as a component here</b>,
+     * regardless of what its annotation tree resolves to. {@code @UltiToolsModule} composes
+     * {@code @Configuration}, which is itself meta-annotated {@code @Component} -- so an
+     * unqualified whole-tree walk would also match every module's own main class. That class is
+     * already constructed and registered as a singleton by {@code PluginManager} *before* this
+     * scan ever runs (its `plugin.yml` metadata has to be read first), under its raw
+     * {@code Class.getSimpleName()} as the bean name. {@code ComponentScanner}'s own bean-naming
+     * convention decapitalizes that same name, so the two registrations never collide, and
+     * treating the module main class as a scannable {@code @Component} would register a *second*
+     * bean definition for it under the decapitalized name -- which {@code preInstantiateSingletons}
+     * would then construct via reflection, re-running the module's entire no-arg constructor
+     * (`plugin.yml` re-parse, resource re-copy, a second config-entity registration under an
+     * orphaned plugin instance) a second time. Excluded here rather than in {@link #isComponent},
+     * whose own four-way disjunction stays untouched (D-03 scope).
      * <br>
-     * 检查类是否有元组件注解。
+     * 检查类是否在其整棵注解树上的任意位置携带元组件注解。
+     * <p>
+     * 相较此前手写实现的扩展（D-03，03-02）：旧实现只检查类上直接声明的注解，且只向上遍历一层
+     * 元注解，因此在 {@code @Component} 之上组合了两层的原型注解无法被识别。
+     * {@link MergedAnnotationResolver#isPresent} 会遍历整棵注解树，因此现在可以被识别。这是刻意
+     * 的——组合原型注解存在的意义正是要被识别——并由 03-10 记录进
+     * {@code COMPATIBILITY.md} 的行为变更判定标准。
+     * <p>
+     * <b>例外：{@link UltiToolsPlugin} 子类在此处永远不会被视为组件</b>，无论其注解树解析结果如何。
+     * {@code @UltiToolsModule} 组合了 {@code @Configuration}，而后者本身元注解了
+     * {@code @Component}——因此不加限定的整树遍历也会匹配到每个模块自身的主类。而该类在本次扫描
+     * 运行之前就已经被 {@code PluginManager} 构造并以单例注册（必须先读取其 `plugin.yml`
+     * 元数据），使用它原始的 {@code Class.getSimpleName()} 作为 bean 名称。{@code ComponentScanner}
+     * 自身的 bean 命名约定会把同一个名字首字母小写，因此这两次注册永远不会碰撞；若把模块主类也视为
+     * 可扫描的 {@code @Component}，就会在首字母小写的名字下为它注册*第二个* bean 定义——之后
+     * {@code preInstantiateSingletons} 会通过反射构造它，重新执行一遍整个无参构造函数
+     * （重新解析 `plugin.yml`、重新复制资源、在一个孤儿插件实例下再注册一遍配置实体）。在此处
+     * 排除，而非改动 {@link #isComponent} 自身的四路析取（保持 D-03 的范围不变）。
      */
     private boolean hasComponentAnnotation(Class<?> clazz) {
-        for (Annotation annotation : clazz.getAnnotations()) {
-            if (annotation.annotationType().isAnnotationPresent(Component.class)) {
-                return true;
-            }
+        if (UltiToolsPlugin.class.isAssignableFrom(clazz)) {
+            return false;
         }
-        return false;
+        return MergedAnnotationResolver.isPresent(clazz, Component.class);
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/context/MergedAnnotationResolver.java
+++ b/src/main/java/com/ultikits/ultitools/context/MergedAnnotationResolver.java
@@ -113,8 +113,96 @@ public final class MergedAnnotationResolver {
      * @param annotationType the annotation type to validate <br> 要校验的注解类型
      */
     public static void validateAliases(Class<? extends Annotation> annotationType) {
-        // Filled in by this plan's Task 2 -- structural @AliasFor validation needs
-        // ContainerException.malformedAliasFor, added in that same commit.
+        if (annotationType == null) {
+            return;
+        }
+        Map<String, AliasDeclaration> withinSelfDeclarations = new LinkedHashMap<>();
+        for (Method method : annotationType.getDeclaredMethods()) {
+            AliasFor aliasFor = method.getAnnotation(AliasFor.class);
+            if (aliasFor == null) {
+                continue;
+            }
+            Class<? extends Annotation> targetType =
+                    aliasFor.annotation() == Annotation.class ? annotationType : aliasFor.annotation();
+            String targetAttribute = resolveAttributeName(aliasFor, method);
+            boolean withinSelf = targetType.equals(annotationType);
+
+            // Requirement 1: annotation() must reference a type that is meta-present on the
+            // declaring annotation (a within-self alias trivially satisfies this).
+            if (!withinSelf && !isMetaPresent(annotationType, targetType)) {
+                throw ContainerException.malformedAliasFor(annotationType, method.getName(),
+                        "target annotation " + targetType.getName() + " is not meta-present on "
+                                + annotationType.getName());
+            }
+
+            // Requirement 2: the target attribute must actually exist on the target annotation.
+            Method targetMethod = findAttributeMethod(targetType, targetAttribute);
+            if (targetMethod == null) {
+                throw ContainerException.malformedAliasFor(annotationType, method.getName(),
+                        "target attribute '" + targetAttribute + "' does not exist on "
+                                + targetType.getName());
+            }
+
+            // Requirement 3: aliased attributes must share the same return type.
+            if (!targetMethod.getReturnType().equals(method.getReturnType())) {
+                throw ContainerException.malformedAliasFor(annotationType, method.getName(),
+                        "return type " + method.getReturnType().getName() + " does not match "
+                                + "aliased attribute '" + targetAttribute + "' return type "
+                                + targetMethod.getReturnType().getName());
+            }
+
+            if (withinSelf) {
+                withinSelfDeclarations.put(method.getName(), new AliasDeclaration(method.getName(), targetAttribute));
+            }
+        }
+
+        // Requirement 4: a within-annotation mutual alias must be reciprocal -- both attributes
+        // must declare @AliasFor pointing at each other.
+        for (AliasDeclaration declaration : withinSelfDeclarations.values()) {
+            AliasDeclaration reciprocal = withinSelfDeclarations.get(declaration.targetAttribute);
+            if (reciprocal == null || !declaration.attributeName.equals(reciprocal.targetAttribute)) {
+                throw ContainerException.malformedAliasFor(annotationType, declaration.attributeName,
+                        "mutual alias with '" + declaration.targetAttribute + "' is not reciprocal -- "
+                                + "both attributes must declare @AliasFor at each other");
+            }
+        }
+    }
+
+    /** One attribute's declared {@code @AliasFor} target, for reciprocity checking. */
+    private static final class AliasDeclaration {
+        private final String attributeName;
+        private final String targetAttribute;
+
+        private AliasDeclaration(String attributeName, String targetAttribute) {
+            this.attributeName = attributeName;
+            this.targetAttribute = targetAttribute;
+        }
+    }
+
+    /**
+     * Whether {@code target} is present, directly or transitively, on {@code declaring}'s own
+     * meta-annotation graph -- Spring's "meta-present" requirement for an explicit
+     * {@code @AliasFor(annotation = ...)}. Cycle-guarded the same way {@link #search} is.
+     */
+    private static boolean isMetaPresent(Class<? extends Annotation> declaring, Class<? extends Annotation> target) {
+        return isMetaPresent(declaring, target, new HashSet<>());
+    }
+
+    private static boolean isMetaPresent(Class<? extends Annotation> current, Class<? extends Annotation> target,
+            Set<Class<? extends Annotation>> visited) {
+        for (Annotation meta : current.getAnnotations()) {
+            Class<? extends Annotation> metaType = meta.annotationType();
+            if (isJavaLangAnnotation(metaType)) {
+                continue;
+            }
+            if (metaType.equals(target)) {
+                return true;
+            }
+            if (visited.add(metaType) && isMetaPresent(metaType, target, visited)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static <A extends Annotation> A findOnClassHierarchy(Class<?> clazz, Class<A> annotationType,
@@ -183,11 +271,20 @@ public final class MergedAnnotationResolver {
         Map<String, Object> overrides = new LinkedHashMap<>();
         for (Map.Entry<String, List<Candidate>> entry : candidatesByAttribute.entrySet()) {
             List<Candidate> candidates = entry.getValue();
-            // Conflicting-candidate detection (a within-annotation mutual alias whose two sides
-            // disagree) is added by this plan's Task 2, alongside the ContainerException factory
-            // it throws through. Last-candidate-wins here is only ever exercised by a single
-            // candidate in this plan's own fixtures.
-            overrides.put(entry.getKey(), candidates.get(candidates.size() - 1).value);
+            Object agreedValue = candidates.get(0).value;
+            for (Candidate candidate : candidates) {
+                if (!Objects.deepEquals(candidate.value, agreedValue)) {
+                    String sourceAttributes = candidates.stream()
+                            .map(c -> c.sourceMethodName)
+                            .distinct()
+                            .reduce((a, b) -> a + "', '" + b)
+                            .orElse("");
+                    throw ContainerException.malformedAliasFor(annotationType, entry.getKey(),
+                            "conflicting @AliasFor values for target attribute '" + entry.getKey()
+                                    + "' from '" + sourceAttributes + "' on a single concrete instance");
+                }
+            }
+            overrides.put(entry.getKey(), agreedValue);
         }
         return createProxy(typed, annotationType, overrides);
     }
@@ -199,10 +296,19 @@ public final class MergedAnnotationResolver {
      * {@code Annotation.class} default meaning "within this same annotation") and the method's
      * value on {@code dInstance} differs from that method's own declared default, it is a
      * candidate override for the aliased attribute name on {@code target}.
+     * <p>
+     * When {@code dInstance} IS an instance of {@code target} itself, any attribute that
+     * participates in a within-annotation mutual alias also contributes its OWN declared value
+     * as a second candidate for its own attribute name -- otherwise a conflicting pair
+     * ({@code foo=x} aliased to {@code bar}, {@code bar=y} aliased to {@code foo}) would only
+     * ever compare "the other side's value" against itself, and the conflict between {@code x}
+     * and {@code y} would never surface as more than one candidate for the same attribute.
      */
     private static <A extends Annotation> void collectOverrideCandidates(Annotation dInstance, Class<A> target,
             Map<String, List<Candidate>> out) {
         Class<? extends Annotation> dType = dInstance.annotationType();
+        Set<String> withinSelfParticipants = new HashSet<>();
+
         for (Method method : dType.getDeclaredMethods()) {
             AliasFor aliasFor = method.getAnnotation(AliasFor.class);
             if (aliasFor == null) {
@@ -215,6 +321,18 @@ public final class MergedAnnotationResolver {
             }
             String targetAttribute = resolveAttributeName(aliasFor, method);
             addCandidateIfNonDefault(out, targetAttribute, method, dInstance, dType);
+            if (dType.equals(target)) {
+                withinSelfParticipants.add(targetAttribute);
+                withinSelfParticipants.add(method.getName());
+            }
+        }
+
+        if (dType.equals(target) && !withinSelfParticipants.isEmpty()) {
+            for (Method method : dType.getDeclaredMethods()) {
+                if (withinSelfParticipants.contains(method.getName())) {
+                    addCandidateIfNonDefault(out, method.getName(), method, dInstance, dType);
+                }
+            }
         }
     }
 

--- a/src/main/java/com/ultikits/ultitools/context/MergedAnnotationResolver.java
+++ b/src/main/java/com/ultikits/ultitools/context/MergedAnnotationResolver.java
@@ -1,0 +1,302 @@
+package com.ultikits.ultitools.context;
+
+import com.ultikits.ultitools.annotations.AliasFor;
+import com.ultikits.ultitools.exceptions.ContainerException;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * General merged-annotation resolution: a recursive walk of the whole annotation tree, with
+ * explicit meta-annotation attribute override via {@link AliasFor}.
+ * <p>
+ * {@link com.ultikits.ultitools.utils.AnnotationUtils#findAnnotation} only walks one
+ * meta-annotation level and never inspects {@link AliasFor} at all, which is why
+ * {@code @UltiToolsModule.scanBasePackages} works today (its call site hand-reads the
+ * meta-annotation) while every other {@code @AliasFor} attribute on that same annotation is
+ * declared but has no reader. Per-site special-casing was rejected (D-01) because it does not
+ * remove the defect class, it only moves it to the next attribute nobody wired up yet -- this
+ * class is the single general replacement.
+ * <p>
+ * 通用的合并注解解析：对整个注解树做递归遍历，并通过 {@link AliasFor} 支持显式的元注解属性覆盖。
+ * <p>
+ * <b>Deliberately cacheless.</b> Phase 1 (D-35/D-38) forbids a {@code static Class}-keyed cache
+ * anywhere in this codebase: it would pin every module's {@code Class} objects for the lifetime
+ * of the JVM and defeat the plugin class loader's release on module unload (see
+ * {@link com.ultikits.ultitools.aop.AnnotationLookupCache}'s class javadoc for the full
+ * reasoning). The walk this class performs runs once per class at scan/load time, not on a
+ * per-invocation hot path, so a v1 without a cache is a deliberate choice, not an oversight. Any
+ * future cache added here must be instance-scoped and owned by the container/scanner instance
+ * that uses it -- never a {@code static} field on this class.
+ * <p>
+ * 本类刻意不做缓存。Phase 1（D-35/D-38）禁止在本代码库中出现任何以 {@code Class} 为键的
+ * {@code static} 缓存：它会为 JVM 的整个生命周期钉住每个模块的 {@code Class} 对象，使插件类加载器
+ * 在模块卸载时无法释放它们。本类执行的遍历只在扫描/加载类时运行一次，而不是位于每次调用都会
+ * 命中的热路径上，所以 v1 不做缓存是刻意的选择，而非疏漏。未来如果要在此处添加缓存，必须是
+ * 实例级别的，且归属于使用它的容器/扫描器实例 -- 绝不能是本类上的 {@code static} 字段。
+ * <p>
+ * This type is {@link ApiStatus.Internal @ApiStatus.Internal}: module authors need
+ * {@code @AliasFor} to work, not to call this resolver directly (D-04).
+ *
+ * @since 6.3.0
+ */
+@SuppressWarnings("PMD.AvoidAccessibilityAlteration") // annotation-attribute reflection, see invokeAttribute
+@ApiStatus.Internal
+public final class MergedAnnotationResolver {
+
+    private static final String JAVA_LANG_ANNOTATION_PACKAGE = "java.lang.annotation";
+
+    private MergedAnnotationResolver() {
+    }
+
+    /**
+     * Find an annotation on a class, or on any of its (meta-)annotations, or on its superclass
+     * hierarchy -- generalizing {@code AnnotationUtils.findAnnotation} from one meta-annotation
+     * level to the whole annotation tree, and merging in any {@code @AliasFor} override found
+     * along the way.
+     * <p>
+     * 在一个类、它的（元）注解或它的父类层次结构上查找注解 -- 把
+     * {@code AnnotationUtils.findAnnotation} 从单层元注解泛化为整棵注解树，并合并沿途发现的任何
+     * {@code @AliasFor} 覆盖。
+     *
+     * @param clazz          the class to search <br> 要搜索的类
+     * @param annotationType the annotation type to find <br> 要查找的注解类型
+     * @param <A>            the annotation type <br> 注解类型
+     * @return the merged annotation if found, or {@code null} <br> 找到则返回合并后的注解，否则返回 {@code null}
+     */
+    public static <A extends Annotation> A find(Class<?> clazz, Class<A> annotationType) {
+        if (clazz == null || annotationType == null) {
+            return null;
+        }
+        return findOnClassHierarchy(clazz, annotationType, new HashSet<>());
+    }
+
+    /**
+     * Whether {@code annotationType} is present anywhere on {@code clazz}'s annotation tree or
+     * superclass hierarchy.
+     * <br>
+     * {@code annotationType} 是否存在于 {@code clazz} 的注解树或父类层次结构中的任意位置。
+     *
+     * @param clazz          the class to search <br> 要搜索的类
+     * @param annotationType the annotation type to look for <br> 要查找的注解类型
+     * @return {@code true} if present <br> 如果存在则为 {@code true}
+     */
+    public static boolean isPresent(Class<?> clazz, Class<? extends Annotation> annotationType) {
+        return find(clazz, annotationType) != null;
+    }
+
+    /**
+     * Validate that every {@link AliasFor}-annotated attribute declared on {@code annotationType}
+     * satisfies Spring's documented Implementation Requirements for an explicit meta-annotation
+     * alias, throwing a {@link ContainerException} naming the annotation and the offending
+     * attribute when it does not (D-02).
+     * <p>
+     * The structural checks land in this class's Task 2 commit; this stub exists so every caller
+     * of {@link #find} is already wired against the real method signature before the checks
+     * themselves are filled in.
+     * <br>
+     * 校验 {@code annotationType} 上每一个标注了 {@link AliasFor} 的属性是否满足 Spring 文档中
+     * 关于显式元注解别名的实现要求；不满足时抛出 {@link ContainerException}，其中同时点名注解与
+     * 出问题的属性（D-02）。
+     *
+     * @param annotationType the annotation type to validate <br> 要校验的注解类型
+     */
+    public static void validateAliases(Class<? extends Annotation> annotationType) {
+        // Filled in by this plan's Task 2 -- structural @AliasFor validation needs
+        // ContainerException.malformedAliasFor, added in that same commit.
+    }
+
+    private static <A extends Annotation> A findOnClassHierarchy(Class<?> clazz, Class<A> annotationType,
+            Set<Class<? extends Annotation>> visited) {
+        if (clazz == null) {
+            return null;
+        }
+        for (Annotation direct : clazz.getAnnotations()) {
+            A found = search(direct, annotationType, visited, new ArrayList<>());
+            if (found != null) {
+                return found;
+            }
+        }
+        return findOnClassHierarchy(clazz.getSuperclass(), annotationType, visited);
+    }
+
+    /**
+     * Depth-first walk of one annotation's own meta-annotation tree. {@code visited} is shared
+     * across the whole {@link #find} call (not reset per branch) so a cyclic meta-annotation
+     * graph terminates instead of overflowing the stack (T-03-03) -- once an annotation type has
+     * been visited anywhere in this call, it is never walked into again.
+     */
+    private static <A extends Annotation> A search(Annotation current, Class<A> annotationType,
+            Set<Class<? extends Annotation>> visited, List<Annotation> ancestors) {
+        Class<? extends Annotation> currentType = current.annotationType();
+        if (isJavaLangAnnotation(currentType) || !visited.add(currentType)) {
+            return null;
+        }
+        validateAliases(currentType);
+        if (currentType.equals(annotationType)) {
+            return merge(current, annotationType, ancestors);
+        }
+        ancestors.add(current);
+        try {
+            for (Annotation meta : currentType.getAnnotations()) {
+                A found = search(meta, annotationType, visited, ancestors);
+                if (found != null) {
+                    return found;
+                }
+            }
+            return null;
+        } finally {
+            ancestors.remove(ancestors.size() - 1);
+        }
+    }
+
+    /**
+     * Compute the merged attribute view of {@code found} (the located instance of
+     * {@code annotationType}), applying any {@code @AliasFor} override declared by an annotation
+     * on the path from the scanned class down to {@code found} -- including {@code found} itself,
+     * for a within-annotation mutual alias.
+     */
+    private static <A extends Annotation> A merge(Annotation found, Class<A> annotationType,
+            List<Annotation> ancestors) {
+        Map<String, List<Candidate>> candidatesByAttribute = new LinkedHashMap<>();
+        for (Annotation ancestor : ancestors) {
+            collectOverrideCandidates(ancestor, annotationType, candidatesByAttribute);
+        }
+        collectOverrideCandidates(found, annotationType, candidatesByAttribute);
+
+        A typed = annotationType.cast(found);
+        if (candidatesByAttribute.isEmpty()) {
+            return typed;
+        }
+
+        Map<String, Object> overrides = new LinkedHashMap<>();
+        for (Map.Entry<String, List<Candidate>> entry : candidatesByAttribute.entrySet()) {
+            List<Candidate> candidates = entry.getValue();
+            // Conflicting-candidate detection (a within-annotation mutual alias whose two sides
+            // disagree) is added by this plan's Task 2, alongside the ContainerException factory
+            // it throws through. Last-candidate-wins here is only ever exercised by a single
+            // candidate in this plan's own fixtures.
+            overrides.put(entry.getKey(), candidates.get(candidates.size() - 1).value);
+        }
+        return createProxy(typed, annotationType, overrides);
+    }
+
+    /**
+     * Collect every attribute-value override {@code dInstance} contributes towards
+     * {@code target}'s merged view: for each of {@code dInstance}'s own attribute methods
+     * carrying {@code @AliasFor}, if the alias points at {@code target} (explicitly, or via the
+     * {@code Annotation.class} default meaning "within this same annotation") and the method's
+     * value on {@code dInstance} differs from that method's own declared default, it is a
+     * candidate override for the aliased attribute name on {@code target}.
+     */
+    private static <A extends Annotation> void collectOverrideCandidates(Annotation dInstance, Class<A> target,
+            Map<String, List<Candidate>> out) {
+        Class<? extends Annotation> dType = dInstance.annotationType();
+        for (Method method : dType.getDeclaredMethods()) {
+            AliasFor aliasFor = method.getAnnotation(AliasFor.class);
+            if (aliasFor == null) {
+                continue;
+            }
+            Class<? extends Annotation> aliasTargetType =
+                    aliasFor.annotation() == Annotation.class ? dType : aliasFor.annotation();
+            if (!aliasTargetType.equals(target)) {
+                continue;
+            }
+            String targetAttribute = resolveAttributeName(aliasFor, method);
+            addCandidateIfNonDefault(out, targetAttribute, method, dInstance, dType);
+        }
+    }
+
+    private static void addCandidateIfNonDefault(Map<String, List<Candidate>> out, String attributeName,
+            Method sourceMethod, Annotation sourceInstance, Class<? extends Annotation> sourceType) {
+        Object value = invokeAttribute(sourceMethod, sourceInstance);
+        Object defaultValue = sourceMethod.getDefaultValue();
+        if (!Objects.deepEquals(value, defaultValue)) {
+            out.computeIfAbsent(attributeName, key -> new ArrayList<>())
+                    .add(new Candidate(value, sourceType, sourceMethod.getName()));
+        }
+    }
+
+    private static String resolveAttributeName(AliasFor aliasFor, Method declaringMethod) {
+        if (!aliasFor.attribute().isEmpty()) {
+            return aliasFor.attribute();
+        }
+        if (!aliasFor.value().isEmpty()) {
+            return aliasFor.value();
+        }
+        return declaringMethod.getName();
+    }
+
+    static Method findAttributeMethod(Class<? extends Annotation> type, String name) {
+        for (Method method : type.getDeclaredMethods()) {
+            if (method.getName().equals(name) && method.getParameterCount() == 0) {
+                return method;
+            }
+        }
+        return null;
+    }
+
+    private static Object invokeAttribute(Method method, Annotation instance) {
+        try {
+            method.setAccessible(true);
+            return method.invoke(instance);
+        } catch (ReflectiveOperationException e) {
+            throw new ContainerException("Failed to read annotation attribute " + method.getName()
+                    + " on " + instance.annotationType().getName(), e);
+        }
+    }
+
+    private static boolean isJavaLangAnnotation(Class<? extends Annotation> type) {
+        Package pkg = type.getPackage();
+        return pkg != null && JAVA_LANG_ANNOTATION_PACKAGE.equals(pkg.getName());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <A extends Annotation> A createProxy(A original, Class<A> annotationType,
+            Map<String, Object> overrides) {
+        InvocationHandler handler = (proxy, method, args) -> {
+            String name = method.getName();
+            if ((args == null || args.length == 0) && overrides.containsKey(name)) {
+                return overrides.get(name);
+            }
+            switch (name) {
+                case "annotationType":
+                    return annotationType;
+                case "toString":
+                    return "@" + annotationType.getName() + "(merged, overrides=" + overrides + ")";
+                case "hashCode":
+                    return original.hashCode();
+                case "equals":
+                    return args != null && args.length == 1 && proxy == args[0];
+                default:
+                    return method.invoke(original, args);
+            }
+        };
+        return (A) Proxy.newProxyInstance(annotationType.getClassLoader(),
+                new Class<?>[] {annotationType}, handler);
+    }
+
+    /** One candidate value for a target attribute, plus where it came from (for conflict messages). */
+    private static final class Candidate {
+        private final Object value;
+        private final Class<? extends Annotation> sourceType;
+        private final String sourceMethodName;
+
+        private Candidate(Object value, Class<? extends Annotation> sourceType, String sourceMethodName) {
+            this.value = value;
+            this.sourceType = sourceType;
+            this.sourceMethodName = sourceMethodName;
+        }
+    }
+}

--- a/src/main/java/com/ultikits/ultitools/exceptions/ContainerException.java
+++ b/src/main/java/com/ultikits/ultitools/exceptions/ContainerException.java
@@ -1,5 +1,7 @@
 package com.ultikits.ultitools.exceptions;
 
+import java.lang.annotation.Annotation;
+
 /**
  * Exception thrown when IoC container operations fail.
  * <p>
@@ -106,5 +108,22 @@ public class ContainerException extends UltiToolsException {
     public static ContainerException duplicateBean(String beanName, Class<?> beanType) {
         return new ContainerException(ErrorCode.DUPLICATE_BEAN,
                 "Duplicate bean definition: " + beanName + " of type " + beanType.getName());
+    }
+
+    /**
+     * Creates an exception for a malformed {@code @AliasFor} declaration -- one that fails one
+     * of Spring's documented Implementation Requirements for an explicit meta-annotation alias
+     * (D-02). The message always names both the declaring annotation and the offending
+     * attribute, so the module author can act on it without cross-referencing anything else.
+     *
+     * @param declaringAnnotation the annotation type that declares the malformed {@code @AliasFor}
+     * @param attribute           the offending attribute's name
+     * @param reason              a specific reason clause describing which requirement failed
+     * @return a new ContainerException
+     */
+    public static ContainerException malformedAliasFor(Class<? extends Annotation> declaringAnnotation,
+            String attribute, String reason) {
+        return new ContainerException(ErrorCode.MALFORMED_ANNOTATION_ALIAS,
+                "Malformed @AliasFor on " + declaringAnnotation.getName() + "#" + attribute + "(): " + reason);
     }
 }

--- a/src/main/java/com/ultikits/ultitools/exceptions/ErrorCode.java
+++ b/src/main/java/com/ultikits/ultitools/exceptions/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     CIRCULAR_DEPENDENCY(2002, "Circular dependency detected"),
     DEPENDENCY_INJECTION_FAILED(2003, "Dependency injection failed"),
     DUPLICATE_BEAN(2004, "Duplicate bean definition"),
+    MALFORMED_ANNOTATION_ALIAS(2005, "Malformed @AliasFor declaration"),
 
     // ===== Data Access Errors (3000-3999) =====
     DATA_ACCESS_ERROR(3000, "Data access error"),

--- a/src/main/java/com/ultikits/ultitools/interfaces/Localized.java
+++ b/src/main/java/com/ultikits/ultitools/interfaces/Localized.java
@@ -1,7 +1,7 @@
 package com.ultikits.ultitools.interfaces;
 
 import com.ultikits.ultitools.annotations.I18n;
-import com.ultikits.ultitools.utils.AnnotationUtils;
+import com.ultikits.ultitools.context.MergedAnnotationResolver;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,7 +26,7 @@ public interface Localized {
      * @see <a href="https://dev.ultikits.com/en/guide/essentials/i18n.html">Internationalization</a>
      */
     default List<String> supported() {
-        I18n i18n = AnnotationUtils.findAnnotation(this.getClass(), I18n.class);
+        I18n i18n = MergedAnnotationResolver.find(this.getClass(), I18n.class);
         if (i18n != null) {
             return Arrays.asList(i18n.value());
         } else {

--- a/src/main/java/com/ultikits/ultitools/manager/CommandManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/CommandManager.java
@@ -24,7 +24,7 @@ import com.ultikits.ultitools.abstracts.AbstractCommandExecutor;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.annotations.command.CmdExecutor;
 import com.ultikits.ultitools.api.ExternalPluginAdapter;
-import com.ultikits.ultitools.utils.AnnotationUtils;
+import com.ultikits.ultitools.context.MergedAnnotationResolver;
 import com.ultikits.ultitools.utils.PackageScanUtils;
 
 /**
@@ -160,7 +160,7 @@ public class CommandManager {
         for (String cmdBean : plugin.getContext().getBeanNamesForType(CommandExecutor.class)) {
             CommandExecutor commandExecutor = plugin.getContext().getBean(cmdBean, CommandExecutor.class);
             if (commandExecutor == null) continue;
-            CmdExecutor annotation = AnnotationUtils.findAnnotation(commandExecutor.getClass(), CmdExecutor.class);
+            CmdExecutor annotation = MergedAnnotationResolver.find(commandExecutor.getClass(), CmdExecutor.class);
             if (annotation == null || annotation.manualRegister()) continue;
             register(plugin, commandExecutor);
         }
@@ -292,7 +292,7 @@ public class CommandManager {
         for (String cmdBean : adapter.getContext().getBeanNamesForType(CommandExecutor.class)) {
             CommandExecutor executor = adapter.getContext().getBean(cmdBean, CommandExecutor.class);
             if (executor == null) continue;
-            CmdExecutor annotation = AnnotationUtils.findAnnotation(executor.getClass(), CmdExecutor.class);
+            CmdExecutor annotation = MergedAnnotationResolver.find(executor.getClass(), CmdExecutor.class);
             if (annotation == null || annotation.manualRegister()) continue;
             registerExternalCommand(adapter.getPluginName(), executor, annotation);
         }

--- a/src/main/java/com/ultikits/ultitools/manager/ListenerManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/ListenerManager.java
@@ -4,7 +4,7 @@ import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.annotations.EventListener;
 import com.ultikits.ultitools.api.ExternalPluginAdapter;
-import com.ultikits.ultitools.utils.AnnotationUtils;
+import com.ultikits.ultitools.context.MergedAnnotationResolver;
 import com.ultikits.ultitools.utils.PackageScanUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.event.HandlerList;
@@ -95,7 +95,7 @@ public class ListenerManager {
         for (String listenerBean : plugin.getContext().getBeanNamesForType(Listener.class)) {
             Listener listener = plugin.getContext().getBean(listenerBean, Listener.class);
             if (listener == null) continue;
-            EventListener annotation = AnnotationUtils.findAnnotation(listener.getClass(), EventListener.class);
+            EventListener annotation = MergedAnnotationResolver.find(listener.getClass(), EventListener.class);
             if (annotation == null || annotation.manualRegister()) continue;
             register(plugin, listener);
         }
@@ -140,7 +140,7 @@ public class ListenerManager {
         for (String listenerBean : adapter.getContext().getBeanNamesForType(Listener.class)) {
             Listener listener = adapter.getContext().getBean(listenerBean, Listener.class);
             if (listener == null) continue;
-            EventListener annotation = AnnotationUtils.findAnnotation(listener.getClass(), EventListener.class);
+            EventListener annotation = MergedAnnotationResolver.find(listener.getClass(), EventListener.class);
             if (annotation == null || annotation.manualRegister()) continue;
             Bukkit.getServer().getPluginManager().registerEvents(listener, UltiTools.getInstance());
             externalListenerMap.computeIfAbsent(adapter.getPluginName(), k -> new ArrayList<>()).add(listener);

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -46,6 +46,7 @@ import com.ultikits.ultitools.api.UltiToolsAPI;
 import com.ultikits.ultitools.events.EventBus;
 import com.ultikits.ultitools.events.ModuleEvent;
 import com.ultikits.ultitools.context.SimpleContainer;
+import com.ultikits.ultitools.context.MergedAnnotationResolver;
 import com.ultikits.ultitools.exceptions.ErrorCode;
 import com.ultikits.ultitools.exceptions.PluginModuleException;
 import com.ultikits.ultitools.interfaces.DataStore;
@@ -56,7 +57,6 @@ import com.ultikits.ultitools.interfaces.impl.data.mysql.MysqlDataStore;
 import com.ultikits.ultitools.interfaces.impl.data.sqlite.SQLiteDataStore;
 import com.ultikits.ultitools.manager.PluginDependencyResolver.CircularDependencyException;
 import com.ultikits.ultitools.manager.PluginDependencyResolver.MissingDependencyException;
-import com.ultikits.ultitools.utils.AnnotationUtils;
 import com.ultikits.ultitools.utils.ClassLoaderUtils;
 import com.ultikits.ultitools.utils.DependencyUtils;
 import com.ultikits.ultitools.utils.SecurityPolicy;
@@ -1566,7 +1566,7 @@ public class PluginManager {
      * @param flag   True if register in default package  <br> 如果在默认包中注册则为true
      */
     private void registerBukkit(UltiToolsPlugin plugin, boolean flag) {
-        EnableAutoRegister annotation = AnnotationUtils.findAnnotation(plugin.getClass(), EnableAutoRegister.class);
+        EnableAutoRegister annotation = MergedAnnotationResolver.find(plugin.getClass(), EnableAutoRegister.class);
         if (annotation == null) {
             return;
         }

--- a/src/main/java/com/ultikits/ultitools/utils/AnnotationUtils.java
+++ b/src/main/java/com/ultikits/ultitools/utils/AnnotationUtils.java
@@ -31,7 +31,18 @@ public class AnnotationUtils {
      * @param annotationType the type of annotation to find <br> 要查找的注解类型
      * @param <T>            the annotation type <br> 注解类型
      * @return the annotation if found, or null if not found <br> 如果找到则返回注解，否则返回null
+     * @deprecated This legacy lookup only walks one meta-annotation level and never merges
+     *             {@code @AliasFor} overrides. Use
+     *             {@link com.ultikits.ultitools.context.MergedAnnotationResolver#find} instead,
+     *             which walks the whole annotation tree and applies any {@code @AliasFor}
+     *             override found along the way.
+     *             <br>
+     *             这个旧的查找方法只会向上遍历一层元注解，并且从不合并 {@code @AliasFor} 覆盖。
+     *             请改用
+     *             {@link com.ultikits.ultitools.context.MergedAnnotationResolver#find}，
+     *             它会遍历整棵注解树，并应用沿途发现的任何 {@code @AliasFor} 覆盖。
      */
+    @Deprecated(since = "6.3.0", forRemoval = true)
     public static <T extends Annotation> T findAnnotation(Class<?> clazz, Class<T> annotationType) {
         if (clazz == null) {
             return null;

--- a/src/test/java/com/ultikits/testfixtures/malformedalias/package-info.java
+++ b/src/test/java/com/ultikits/testfixtures/malformedalias/package-info.java
@@ -1,0 +1,49 @@
+/**
+ * Test-only fixture family for a single malformed {@code @AliasFor} declaration, discovered
+ * during a real {@code ComponentScanner.scanPackage} walk rather than by calling
+ * {@code MergedAnnotationResolver.validateAliases(Class)} directly.
+ * <p>
+ * This closes the {@code unrun-verify} window 03-01 recorded in {@code .planning/WINDOWS.md}
+ * (id 1): 03-01 proved the resolver throws {@link com.ultikits.ultitools.exceptions.ContainerException}
+ * for a malformed declaration directly against the resolver, but could not prove it propagates
+ * out of a real {@code ComponentScanner.scanPackage()} scan, because
+ * {@code ComponentScanner.hasComponentAnnotation} was not yet wired to the resolver -- that
+ * wiring is 03-02's own task. See {@link com.ultikits.testfixtures.malformedalias.scanner} for
+ * the fixture itself.
+ * <p>
+ * This package family exists <b>outside</b> {@code com.ultikits.ultitools} on purpose, following
+ * the exact precedent of {@link com.ultikits.testfixtures.finalviolation}: component scanning
+ * walks whatever package it is told to scan, recursively, with no notion of "this is a test
+ * fixture, skip it". A malformed alias sitting inside {@code com.ultikits.ultitools.context}
+ * (even nested under it, since {@code ComponentScanner#scanDirectory} recurses into
+ * subdirectories) would trip every other test that scans that tree -
+ * {@code ComponentScannerTest} scans {@code com.ultikits.ultitools.context} directly - for a
+ * reason that has nothing to do with what those tests actually check.
+ * <p>
+ * <b>Rule: this package itself must never directly hold a fixture class, and no test may scan it
+ * directly</b> - only ever scan (or import from) the named {@code scanner} subpackage, mirroring
+ * {@link com.ultikits.testfixtures.finalviolation}'s own rule for the identical reason.
+ * <br>
+ * 本包族服务于一个单一的、故意写错的 {@code @AliasFor} 声明，通过一次真实的
+ * {@code ComponentScanner.scanPackage} 扫描发现它，而不是直接调用
+ * {@code MergedAnnotationResolver.validateAliases(Class)}。
+ * <p>
+ * 本包用于关闭 03-01 记录在 {@code .planning/WINDOWS.md} 中的 {@code unrun-verify} 缺口（id 1）：
+ * 03-01 已经直接对解析器证明了畸形声明会抛出
+ * {@link com.ultikits.ultitools.exceptions.ContainerException}，但当时无法证明它会从一次真实的
+ * {@code ComponentScanner.scanPackage()} 扫描中传播出来，因为
+ * {@code ComponentScanner.hasComponentAnnotation} 尚未接入解析器——这项接线正是 03-02 自己的任务。
+ * 具体 fixture 见 {@link com.ultikits.testfixtures.malformedalias.scanner}。
+ * <p>
+ * 本包族故意放在 {@code com.ultikits.ultitools} 包树之外，完全遵循
+ * {@link com.ultikits.testfixtures.finalviolation} 的既有先例：组件扫描会递归扫描它被要求扫描的
+ * 任意包，并不知道"这是测试 fixture、应该跳过"。若把一个畸形别名放进
+ * {@code com.ultikits.ultitools.context}（哪怕只是嵌套在它之下，因为
+ * {@code ComponentScanner#scanDirectory} 会递归下探子目录），就会无关地带崩每一个扫描该树的其他
+ * 测试——{@code ComponentScannerTest} 就直接扫描 {@code com.ultikits.ultitools.context}。
+ * <p>
+ * <b>规则：本包直属不得放任何类，任何测试也不得直接扫描本包本身</b>——永远只扫描（或 import）具名的
+ * {@code scanner} 子包，与 {@link com.ultikits.testfixtures.finalviolation} 出于同样的原因保持
+ * 同一条规则。
+ */
+package com.ultikits.testfixtures.malformedalias;

--- a/src/test/java/com/ultikits/testfixtures/malformedalias/scanner/MalformedAliasFixture.java
+++ b/src/test/java/com/ultikits/testfixtures/malformedalias/scanner/MalformedAliasFixture.java
@@ -1,0 +1,15 @@
+package com.ultikits.testfixtures.malformedalias.scanner;
+
+/**
+ * Test-only fixture for {@code ComponentScannerMalformedAliasPropagationTest}: the one class
+ * carrying {@link MalformedComposedAnnotation}, so a directory-based
+ * {@code ComponentScanner.scanPackage} walk over this package discovers the malformed
+ * declaration exactly the way a module JAR's own composed annotation would be discovered.
+ * <p>
+ * See this package's {@code package-info} for why it must hold exactly one malformed
+ * declaration, and the parent {@code malformedalias} package's {@code package-info} for why any
+ * of this lives outside {@code com.ultikits.ultitools} at all.
+ */
+@MalformedComposedAnnotation
+public class MalformedAliasFixture {
+}

--- a/src/test/java/com/ultikits/testfixtures/malformedalias/scanner/MalformedComposedAnnotation.java
+++ b/src/test/java/com/ultikits/testfixtures/malformedalias/scanner/MalformedComposedAnnotation.java
@@ -1,0 +1,27 @@
+package com.ultikits.testfixtures.malformedalias.scanner;
+
+import com.ultikits.ultitools.annotations.AliasFor;
+import com.ultikits.ultitools.annotations.Component;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Test-only fixture for {@code ComponentScannerMalformedAliasPropagationTest}: an
+ * {@code @AliasFor} whose {@code annotation()} names {@link Component}, a type that is not
+ * meta-present anywhere on this annotation's own declaration -- Spring's Implementation
+ * Requirement 1, the same malformed shape as
+ * {@code MergedAnnotationResolverTest#shouldRejectAliasForWhoseTargetIsNotMetaPresent} (03-01).
+ * <p>
+ * See this package's {@code package-info} for why it must hold exactly one malformed
+ * declaration, and the parent {@code malformedalias} package's {@code package-info} for why any
+ * of this lives outside {@code com.ultikits.ultitools} at all.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface MalformedComposedAnnotation {
+    @AliasFor(annotation = Component.class, attribute = "value")
+    String value() default "";
+}

--- a/src/test/java/com/ultikits/testfixtures/malformedalias/scanner/package-info.java
+++ b/src/test/java/com/ultikits/testfixtures/malformedalias/scanner/package-info.java
@@ -1,0 +1,29 @@
+/**
+ * Fixture for {@code com.ultikits.ultitools.context.ComponentScannerMalformedAliasPropagationTest}
+ * - an <b>integration</b> test whose entire point is to run {@code ComponentScanner.scanPackage}
+ * over this package and assert that the resulting
+ * {@code ContainerException} propagates all the way out, rather than being logged and swallowed
+ * by {@code scanPackage}'s own catch-all.
+ * <p>
+ * <b>This package must hold exactly one malformed declaration.</b> Mirrors
+ * {@code com.ultikits.testfixtures.finalviolation.scanner}'s own rule and the reason behind it:
+ * {@code MergedAnnotationResolver#search} throws on the first malformed annotation type it
+ * validates while walking a class's annotation tree, and both {@code File.listFiles()}'s
+ * directory-walk order and {@code Class#getAnnotations()}'s array order are unspecified by the
+ * relevant specs - a second, unrelated malformed declaration here would make the exception's
+ * exact content nondeterministic. A new scan-triggered malformed-alias fixture belongs in its
+ * own sibling package, not in this one.
+ * <br>
+ * 本包服务于
+ * {@code ComponentScannerMalformedAliasPropagationTest}——一个**集成测试**，整个测试的意义就是让
+ * {@code ComponentScanner.scanPackage} 真正扫描本包，断言抛出的 {@code ContainerException} 确实
+ * 一路传播出来，而不是被 {@code scanPackage} 自身的 catch-all 记录后吞掉。
+ * <p>
+ * <b>本包必须恰好只有一个畸形声明。</b>与
+ * {@code com.ultikits.testfixtures.finalviolation.scanner} 的规则及其理由完全一致：
+ * {@code MergedAnnotationResolver#search} 在遍历一个类的注解树时，一遇到第一个畸形注解类型就会
+ * 抛出，而 {@code File.listFiles()} 的目录遍历顺序与 {@code Class#getAnnotations()} 的数组顺序都
+ * 不受相关规范保证。若本包内再混入第二个无关的畸形声明，异常的具体内容就会变得不确定。之后再需要
+ * 新增"会被扫描触发"的畸形别名 fixture，请放进独立的同级包，不要加进本包。
+ */
+package com.ultikits.testfixtures.malformedalias.scanner;

--- a/src/test/java/com/ultikits/ultitools/abstracts/UltiToolsPluginInitConfigTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/UltiToolsPluginInitConfigTest.java
@@ -1,0 +1,118 @@
+package com.ultikits.ultitools.abstracts;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import com.ultikits.ultitools.annotations.UltiToolsModule;
+import com.ultikits.ultitools.manager.ConfigManager;
+import com.ultikits.ultitools.utils.TestHelper;
+
+/**
+ * End-to-end proof that {@code @UltiToolsModule}'s {@code config} {@code @AliasFor} switch
+ * actually reaches {@link UltiToolsPlugin#initConfig()}'s registration decision, now that it
+ * resolves {@code @EnableAutoRegister} through
+ * {@link com.ultikits.ultitools.context.MergedAnnotationResolver} instead of
+ * {@link com.ultikits.ultitools.utils.AnnotationUtils#findAnnotation} (WIRE-08).
+ * <p>
+ * Companion to {@code PluginManagerAutoRegisterAliasTest} (03-01), which proves the same wiring
+ * for {@code eventListener}/{@code cmdExecutor} through {@code PluginManager.registerBukkit}.
+ * Before this migration, {@code @UltiToolsModule(config = false)} was silently ignored: the
+ * legacy lookup read the raw, un-merged {@code @EnableAutoRegister} declared on
+ * {@code @UltiToolsModule} itself (default {@code config() == true}), never the module's own
+ * override.
+ */
+@DisplayName("UltiToolsPlugin.initConfig @AliasFor wiring (WIRE-08)")
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+@SuppressWarnings("PMD.AvoidAccessibilityAlteration") // reflective invocation of the private initConfig
+class UltiToolsPluginInitConfigTest {
+
+    // Abstract fixtures extending UltiToolsPlugin, mocked rather than constructed -- Mockito
+    // bypasses the constructor entirely (Objenesis) and, with the default inline mock maker,
+    // mock.getClass() returns the real fixture class, so its annotations are read correctly.
+    // Same idiom as PluginManagerAutoRegisterAliasTest (03-01).
+
+    @UltiToolsModule
+    abstract static class DefaultModuleFixture extends UltiToolsPlugin {
+    }
+
+    @UltiToolsModule(config = false)
+    abstract static class ConfigDisabledFixture extends UltiToolsPlugin {
+    }
+
+    private ConfigManager mockConfigManager;
+
+    @BeforeEach
+    void setUp() {
+        mockConfigManager = mock(ConfigManager.class);
+        TestHelper.mockUltiToolsInstance(ultiTools -> when(ultiTools.getConfigManager()).thenReturn(mockConfigManager));
+    }
+
+    private void invokeInitConfig(UltiToolsPlugin plugin) throws Exception {
+        Method method = UltiToolsPlugin.class.getDeclaredMethod("initConfig");
+        method.setAccessible(true);
+        method.invoke(plugin);
+    }
+
+    @Test
+    @DisplayName("Default @UltiToolsModule reaches ConfigManager.registerAll")
+    void defaultModuleRegistersConfig() throws Exception {
+        UltiToolsPlugin plugin = mock(DefaultModuleFixture.class);
+
+        invokeInitConfig(plugin);
+
+        verify(mockConfigManager, times(1)).registerAll(org.mockito.ArgumentMatchers.eq(plugin), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("@UltiToolsModule(config = false) suppresses ConfigManager.registerAll entirely")
+    void configDisabledModuleNeverReachesConfigManager() throws Exception {
+        UltiToolsPlugin plugin = mock(ConfigDisabledFixture.class);
+
+        invokeInitConfig(plugin);
+
+        verify(mockConfigManager, never()).registerAll(any(), anyString(), any());
+        verify(mockConfigManager, never()).register(any(), any());
+    }
+
+    @Test
+    @DisplayName("Inert-case guard: the default and disabled fixtures must not produce equal registerAll counts")
+    void defaultAndDisabledFixturesMustNotProduceEqualCounts() throws Exception {
+        // If the resolver silently returns the un-merged @EnableAutoRegister (the exact defect
+        // this plan closes), both fixtures would skip registration in the same way and the two
+        // counts below would be equal (0 and 0) instead of (1 and 0) -- this assertion fails
+        // loudly on that equality rather than merely leaving it unasserted.
+        UltiToolsPlugin defaultPlugin = mock(DefaultModuleFixture.class);
+        UltiToolsPlugin disabledPlugin = mock(ConfigDisabledFixture.class);
+
+        invokeInitConfig(defaultPlugin);
+        invokeInitConfig(disabledPlugin);
+
+        long defaultCount = org.mockito.Mockito.mockingDetails(mockConfigManager).getInvocations().stream()
+                .filter(invocation -> "registerAll".equals(invocation.getMethod().getName())
+                        && invocation.getArgument(0) == defaultPlugin)
+                .count();
+        long disabledCount = org.mockito.Mockito.mockingDetails(mockConfigManager).getInvocations().stream()
+                .filter(invocation -> "registerAll".equals(invocation.getMethod().getName())
+                        && invocation.getArgument(0) == disabledPlugin)
+                .count();
+
+        Assertions.assertNotEquals(defaultCount, disabledCount,
+                "a resolver that fails to merge the @AliasFor override would skip both fixtures identically");
+        Assertions.assertEquals(1L, defaultCount);
+        Assertions.assertEquals(0L, disabledCount);
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/context/ComponentScannerMalformedAliasPropagationTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ComponentScannerMalformedAliasPropagationTest.java
@@ -1,0 +1,80 @@
+package com.ultikits.ultitools.context;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ultikits.testfixtures.malformedalias.scanner.MalformedAliasFixture;
+import com.ultikits.ultitools.exceptions.ContainerException;
+
+/**
+ * Integration test closing the {@code unrun-verify} window 03-01 recorded in
+ * {@code .planning/WINDOWS.md} (id 1): a malformed {@code @AliasFor} declaration discovered
+ * during a real {@code ComponentScanner.scanPackage()} scan propagates
+ * {@link ContainerException} out of the scan, rather than being logged and skipped.
+ * <p>
+ * 03-01 proved {@code MergedAnnotationResolver.validateAliases} throws directly
+ * ({@code MergedAnnotationResolverTest}'s five malformed-shape tests); this test proves the same
+ * refusal reaches a real caller, now that {@code ComponentScanner.hasComponentAnnotation} is
+ * wired to {@link MergedAnnotationResolver#isPresent} (03-02). Mirrors
+ * {@code ComponentScannerFinalContractTest}'s existing pattern for the identical propagation
+ * question about {@code @Final} contract violations.
+ */
+@DisplayName("ComponentScanner malformed @AliasFor propagation (closes WINDOWS.md id 1)")
+class ComponentScannerMalformedAliasPropagationTest {
+
+    private SimpleContainer container;
+    private ComponentScanner scanner;
+
+    @BeforeEach
+    void setUp() {
+        container = new SimpleContainer();
+        scanner = new ComponentScanner(container);
+    }
+
+    @Test
+    @DisplayName("scanPackage should propagate a malformed @AliasFor declaration, not swallow it")
+    void shouldPropagateMalformedAliasFromScanPackage() {
+        ContainerException exception = assertThrows(ContainerException.class,
+                () -> scanner.scanPackage("com.ultikits.testfixtures.malformedalias.scanner"));
+
+        assertTrue(exception.getMessage().contains(
+                        com.ultikits.testfixtures.malformedalias.scanner.MalformedComposedAnnotation.class.getName()),
+                exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("scanComponents should propagate a malformed @AliasFor declaration, not swallow it")
+    void shouldPropagateMalformedAliasFromScanComponents() {
+        ContainerException exception = assertThrows(ContainerException.class,
+                () -> container.scanComponents("com.ultikits.testfixtures.malformedalias.scanner"));
+
+        assertTrue(exception.getMessage().contains(
+                        com.ultikits.testfixtures.malformedalias.scanner.MalformedComposedAnnotation.class.getName()),
+                exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("Inert-case guard: the fixture class name alone is not proof -- the declaring annotation must be named")
+    void exceptionNamesTheDeclaringAnnotationNotJustTheFixtureClass() {
+        // If a future refactor accidentally caught ContainerException at a different layer and
+        // rethrew a generic message, an assertion that only checked "some ContainerException was
+        // thrown" would still pass. Naming MalformedComposedAnnotation specifically -- the type
+        // MergedAnnotationResolver.validateAliases actually names in its refusal message -- is
+        // what ties this assertion to the real mechanism rather than to MalformedAliasFixture's
+        // own class name, which never appears in validateAliases' message at all.
+        ContainerException exception = assertThrows(ContainerException.class,
+                () -> scanner.scanPackage("com.ultikits.testfixtures.malformedalias.scanner"));
+
+        assertTrue(exception.getMessage().contains("value"), exception.getMessage());
+        assertTrue(exception.getMessage().contains("not meta-present"), exception.getMessage());
+    }
+
+    // Referenced only to keep an explicit compile-time dependency on the fixture class itself
+    // (not just the annotation), matching ComponentScannerFinalContractTest's own pattern.
+    @SuppressWarnings("unused")
+    private static final Class<MalformedAliasFixture> FIXTURE_CLASS = MalformedAliasFixture.class;
+}

--- a/src/test/java/com/ultikits/ultitools/context/ComponentScannerTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ComponentScannerTest.java
@@ -1,12 +1,20 @@
 package com.ultikits.ultitools.context;
 
+import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.annotations.Component;
 import com.ultikits.ultitools.annotations.Service;
 import com.ultikits.ultitools.annotations.Configuration;
 import com.ultikits.ultitools.annotations.Bean;
+import com.ultikits.ultitools.annotations.UltiToolsModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -66,6 +74,91 @@ class ComponentScannerTest {
         assertNotNull(container);
     }
 
+    // ===== Task 2 (03-02, D-03): hasComponentAnnotation widened onto MergedAnnotationResolver =====
+
+    /**
+     * Two levels above {@code @Component}: {@code Level2} carries {@code @Component} directly,
+     * {@code Level1} carries {@code @Level2}, and the fixture below carries only {@code @Level1}.
+     * The previous hand-written {@code hasComponentAnnotation} walked one meta-annotation level
+     * and would have missed this; {@link MergedAnnotationResolver#isPresent} walks the whole
+     * tree and finds it.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @Component
+    @interface Level2 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @Level2
+    @interface Level1 {
+    }
+
+    @Level1
+    public static class TwoLevelStereotypeFixture {
+    }
+
+    /**
+     * Negative control: meta-annotated, but its own annotation graph never reaches
+     * {@code @Component} anywhere. Must stay unregistered both before and after the widening.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @interface NotComposedFromComponent {
+    }
+
+    @NotComposedFromComponent
+    public static class NotAComponentFixture {
+    }
+
+    @Test
+    @DisplayName("A two-level composed stereotype annotation (Level1 -> Level2 -> @Component) registers as a bean after scanPackage")
+    void twoLevelComposedStereotypeRegistersAsBean() {
+        scanner.scanPackage("com.ultikits.ultitools.context");
+
+        assertNotNull(container.getBean(TwoLevelStereotypeFixture.class),
+                "a class carrying a two-level composed stereotype annotation should have been "
+                        + "registered as a bean by the widened hasComponentAnnotation");
+    }
+
+    @Test
+    @DisplayName("Inert-case guard: a class whose annotation graph never reaches @Component stays unregistered after scanPackage")
+    void nonStereotypeAnnotatedClassDoesNotRegister() {
+        scanner.scanPackage("com.ultikits.ultitools.context");
+
+        String beanName = Character.toLowerCase(NotAComponentFixture.class.getSimpleName().charAt(0))
+                + NotAComponentFixture.class.getSimpleName().substring(1);
+        assertFalse(Arrays.asList(container.getBeanDefinitionNames()).contains(beanName),
+                "a class not composed from @Component anywhere in its annotation graph must not "
+                        + "register just because isPresent's reach was widened");
+    }
+
+    /**
+     * A module's own main class ({@code @UltiToolsModule}-annotated, extending
+     * {@link UltiToolsPlugin}) must never become a scannable {@code @Component} despite
+     * {@code @UltiToolsModule} composing {@code @Configuration} -> {@code @Component} -- see
+     * {@code ComponentScanner.hasComponentAnnotation}'s javadoc for why (PluginManager already
+     * constructs and registers it as a singleton, under a differently-cased bean name, before
+     * this scan ever runs).
+     */
+    @UltiToolsModule
+    public abstract static class ModuleMainClassFixture extends UltiToolsPlugin {
+    }
+
+    @Test
+    @DisplayName("A UltiToolsPlugin subclass (a module's own main class) never becomes a scannable @Component, even though @UltiToolsModule composes @Configuration -> @Component")
+    void moduleMainClassNeverBecomesAComponent() {
+        scanner.scanPackage("com.ultikits.ultitools.context");
+
+        String beanName = Character.toLowerCase(ModuleMainClassFixture.class.getSimpleName().charAt(0))
+                + ModuleMainClassFixture.class.getSimpleName().substring(1);
+        assertFalse(Arrays.asList(container.getBeanDefinitionNames()).contains(beanName),
+                "a UltiToolsPlugin subclass must never be registered as a scanned @Component bean "
+                        + "definition -- doing so would let preInstantiateSingletons construct a "
+                        + "second, unmanaged instance of the module's own main class");
+    }
+
     // Test helper classes
     @Component
     public static class TestComponent {
@@ -83,7 +176,7 @@ class ComponentScannerTest {
 
     @Configuration
     public static class TestConfiguration {
-        
+
         @Bean
         public String testBean() {
             return "Test Bean Value";

--- a/src/test/java/com/ultikits/ultitools/context/MergedAnnotationResolverTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/MergedAnnotationResolverTest.java
@@ -2,8 +2,10 @@ package com.ultikits.ultitools.context;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.annotation.ElementType;
@@ -18,6 +20,7 @@ import com.ultikits.ultitools.annotations.AliasFor;
 import com.ultikits.ultitools.annotations.EnableAutoRegister;
 import com.ultikits.ultitools.annotations.I18n;
 import com.ultikits.ultitools.annotations.UltiToolsModule;
+import com.ultikits.ultitools.exceptions.ContainerException;
 import com.ultikits.ultitools.utils.AnnotationUtils;
 
 /**
@@ -165,5 +168,143 @@ class MergedAnnotationResolverTest {
 
         assertNotNull(merged);
         assertTrue("shorthand-value".equals(merged.value()));
+    }
+
+    // ===== Task 2: malformed @AliasFor declarations (D-02) =====
+
+    // Shape 1: annotation() references a type that is NOT meta-present on the declaring
+    // annotation.
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface UnrelatedTarget {
+        String value() default "";
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface NotMetaPresentAlias {
+        @AliasFor(annotation = UnrelatedTarget.class, attribute = "value")
+        String foo() default "";
+    }
+
+    @Test
+    @DisplayName("Malformed: annotation() targets a type that is not meta-present on the declaring annotation")
+    void shouldRejectAliasForWhoseTargetIsNotMetaPresent() {
+        ContainerException thrown = assertThrows(ContainerException.class,
+                () -> MergedAnnotationResolver.validateAliases(NotMetaPresentAlias.class));
+
+        assertTrue(thrown.getMessage().contains(NotMetaPresentAlias.class.getName()), thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("foo"), thrown.getMessage());
+    }
+
+    // Shape 2: attribute() names an attribute that does not exist on the target annotation.
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SimpleTarget {
+        String value() default "";
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @SimpleTarget
+    @interface MissingAttributeAlias {
+        @AliasFor(annotation = SimpleTarget.class, attribute = "doesNotExist")
+        String foo() default "";
+    }
+
+    @Test
+    @DisplayName("Malformed: attribute() names an attribute that does not exist on the target annotation")
+    void shouldRejectAliasForWhoseAttributeDoesNotExist() {
+        ContainerException thrown = assertThrows(ContainerException.class,
+                () -> MergedAnnotationResolver.validateAliases(MissingAttributeAlias.class));
+
+        assertTrue(thrown.getMessage().contains(MissingAttributeAlias.class.getName()), thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("foo"), thrown.getMessage());
+    }
+
+    // Shape 3: the aliasing attribute and the target attribute have different return types.
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface TypedTarget {
+        String value() default "";
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @TypedTarget
+    @interface MismatchedTypeAlias {
+        @AliasFor(annotation = TypedTarget.class, attribute = "value")
+        boolean foo() default false;
+    }
+
+    @Test
+    @DisplayName("Malformed: aliased attributes do not share the same return type")
+    void shouldRejectAliasForWithMismatchedReturnType() {
+        ContainerException thrown = assertThrows(ContainerException.class,
+                () -> MergedAnnotationResolver.validateAliases(MismatchedTypeAlias.class));
+
+        assertTrue(thrown.getMessage().contains(MismatchedTypeAlias.class.getName()), thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("foo"), thrown.getMessage());
+    }
+
+    // Shape 4: a within-annotation mutual alias where only one side declares @AliasFor back at
+    // the other -- not reciprocal.
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface NonReciprocalMutualAlias {
+        @AliasFor("bar")
+        String foo() default "";
+
+        String bar() default "";
+    }
+
+    @Test
+    @DisplayName("Malformed: a within-annotation mutual alias is not reciprocal")
+    void shouldRejectNonReciprocalMutualAlias() {
+        ContainerException thrown = assertThrows(ContainerException.class,
+                () -> MergedAnnotationResolver.validateAliases(NonReciprocalMutualAlias.class));
+
+        assertTrue(thrown.getMessage().contains(NonReciprocalMutualAlias.class.getName()), thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("foo"), thrown.getMessage());
+    }
+
+    // ===== Task 2: within-annotation mutual alias, well-formed and conflicting instances =====
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @interface MutualAlias {
+        @AliasFor("bar")
+        String foo() default "";
+
+        @AliasFor("foo")
+        String bar() default "";
+    }
+
+    @MutualAlias(foo = "x")
+    static class WellFormedMutualAliasFixture {
+    }
+
+    @MutualAlias(foo = "x", bar = "y")
+    static class ConflictingMutualAliasFixture {
+    }
+
+    @Test
+    @DisplayName("Control: a well-formed mutual alias declaration passes structural validation")
+    void validateAliasesAcceptsWellFormedMutualAlias() {
+        assertDoesNotThrow(() -> MergedAnnotationResolver.validateAliases(MutualAlias.class));
+    }
+
+    @Test
+    @DisplayName("Well-formed mutual alias with only one side set: the set side wins for both, no exception")
+    void wellFormedMutualAliasWithOneSideSetResolvesWithoutConflict() {
+        MutualAlias merged = MergedAnnotationResolver.find(WellFormedMutualAliasFixture.class, MutualAlias.class);
+
+        assertNotNull(merged);
+        assertEquals("x", merged.foo());
+        assertEquals("x", merged.bar());
+    }
+
+    @Test
+    @DisplayName("Mutual alias with different non-default values on the same concrete instance -> ContainerException naming both attributes")
+    void conflictingMutualAliasValuesAreRejectedAtResolution() {
+        ContainerException thrown = assertThrows(ContainerException.class,
+                () -> MergedAnnotationResolver.find(ConflictingMutualAliasFixture.class, MutualAlias.class));
+
+        assertTrue(thrown.getMessage().contains(MutualAlias.class.getName()), thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("foo"), thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("bar"), thrown.getMessage());
     }
 }

--- a/src/test/java/com/ultikits/ultitools/context/MergedAnnotationResolverTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/MergedAnnotationResolverTest.java
@@ -1,0 +1,169 @@
+package com.ultikits.ultitools.context;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ultikits.ultitools.annotations.AliasFor;
+import com.ultikits.ultitools.annotations.EnableAutoRegister;
+import com.ultikits.ultitools.annotations.I18n;
+import com.ultikits.ultitools.annotations.UltiToolsModule;
+import com.ultikits.ultitools.utils.AnnotationUtils;
+
+/**
+ * Resolver-level coverage for {@link MergedAnnotationResolver} (WIRE-08).
+ * <p>
+ * Companion to {@code PluginManagerAutoRegisterAliasTest}, which proves the same
+ * {@code @AliasFor} switches reach the real caller ({@code PluginManager.registerBukkit}); this
+ * class covers the resolver's own merge semantics in isolation.
+ */
+@DisplayName("MergedAnnotationResolver")
+class MergedAnnotationResolverTest {
+
+    // ===== Task 1 fixtures: cross-annotation @AliasFor on @UltiToolsModule =====
+
+    @UltiToolsModule
+    static class DefaultModuleFixture {
+    }
+
+    @UltiToolsModule(cmdExecutor = false)
+    static class CmdExecutorDisabledFixture {
+    }
+
+    @UltiToolsModule(eventListener = false)
+    static class EventListenerDisabledFixture {
+    }
+
+    @UltiToolsModule(i18n = {"zh", "en"})
+    static class I18nOverrideFixture {
+    }
+
+    // ===== Cyclic meta-annotation graph fixture (T-03-03) =====
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+    @interface CyclicY {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+    @CyclicY
+    @interface CyclicX {
+    }
+
+    @CyclicX
+    static class CyclicGraphFixture {
+    }
+
+    // ===== Behavior =====
+
+    @Test
+    @DisplayName("With no explicit attributes, the merged EnableAutoRegister reports meta-annotation defaults")
+    void shouldReportMetaAnnotationDefaultsWhenNothingOverridden() {
+        EnableAutoRegister merged =
+                MergedAnnotationResolver.find(DefaultModuleFixture.class, EnableAutoRegister.class);
+
+        assertNotNull(merged);
+        assertTrue(merged.cmdExecutor(), "default cmdExecutor must remain true");
+        assertTrue(merged.eventListener(), "default eventListener must remain true");
+    }
+
+    @Test
+    @DisplayName("@UltiToolsModule(cmdExecutor = false) overrides cmdExecutor without touching the sibling eventListener")
+    void shouldOverrideCmdExecutorOnlyWhenExplicitlyDisabled() {
+        EnableAutoRegister merged =
+                MergedAnnotationResolver.find(CmdExecutorDisabledFixture.class, EnableAutoRegister.class);
+
+        assertNotNull(merged);
+        assertFalse(merged.cmdExecutor(), "cmdExecutor = false must reach the merged view");
+        assertTrue(merged.eventListener(), "eventListener must stay at its own default, unaffected");
+    }
+
+    @Test
+    @DisplayName("@UltiToolsModule(eventListener = false) overrides eventListener")
+    void shouldOverrideEventListenerWhenExplicitlyDisabled() {
+        EnableAutoRegister merged =
+                MergedAnnotationResolver.find(EventListenerDisabledFixture.class, EnableAutoRegister.class);
+
+        assertNotNull(merged);
+        assertFalse(merged.eventListener(), "eventListener = false must reach the merged view");
+    }
+
+    @Test
+    @DisplayName("Control: AnnotationUtils.findAnnotation still returns the un-merged annotation for the same fixture")
+    void controlAnnotationUtilsFindAnnotationIsUnaffected() {
+        // This is the proof that the behaviour change comes from the resolver, not from an edit
+        // to the fixture or to @UltiToolsModule -- without this control, a test suite that only
+        // asserted the merged result could pass for the wrong reason (e.g. the fixture itself
+        // being rewritten).
+        EnableAutoRegister unmerged =
+                AnnotationUtils.findAnnotation(CmdExecutorDisabledFixture.class, EnableAutoRegister.class);
+
+        assertNotNull(unmerged);
+        assertTrue(unmerged.cmdExecutor(),
+                "the legacy two-level lookup must still report the meta-annotation default, "
+                        + "proving it never inspects @AliasFor");
+    }
+
+    @Test
+    @DisplayName("A String[]-typed @AliasFor (i18n -> I18n.value) merges correctly, not just boolean-typed ones")
+    void shouldMergeStringArrayTypedAlias() {
+        I18n merged = MergedAnnotationResolver.find(I18nOverrideFixture.class, I18n.class);
+
+        assertNotNull(merged);
+        assertArrayEquals(new String[] {"zh", "en"}, merged.value());
+    }
+
+    @Test
+    @DisplayName("A cyclic meta-annotation graph terminates instead of overflowing the stack")
+    void shouldTerminateOnCyclicMetaAnnotationGraph() {
+        assertDoesNotThrow(() -> MergedAnnotationResolver.find(CyclicGraphFixture.class, Deprecated.class),
+                "a cycle in the meta-annotation graph must not cause a StackOverflowError");
+    }
+
+    @Test
+    @DisplayName("Control: @UltiToolsModule's own six @AliasFor declarations pass structural validation")
+    void validateAliasesAcceptsUltiToolsModuleItself() {
+        // Regression control for Task 2's validateAliases: without this assertion, a validator
+        // that rejected every declaration (not just malformed ones) would also make every
+        // malformed-case test in this file pass for the wrong reason.
+        assertDoesNotThrow(() -> MergedAnnotationResolver.validateAliases(UltiToolsModule.class));
+    }
+
+    // ===== @AliasFor whose value() shorthand attribute is used (resolveAttributeName fallback) =====
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ShorthandTarget {
+        String value() default "";
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @ShorthandTarget
+    @interface ShorthandAlias {
+        @AliasFor(annotation = ShorthandTarget.class, value = "value")
+        String foo() default "";
+    }
+
+    @ShorthandAlias(foo = "shorthand-value")
+    static class ShorthandFixture {
+    }
+
+    @Test
+    @DisplayName("@AliasFor's value() shorthand resolves the target attribute name")
+    void shouldResolveShorthandAliasForValue() {
+        ShorthandTarget merged = MergedAnnotationResolver.find(ShorthandFixture.class, ShorthandTarget.class);
+
+        assertNotNull(merged);
+        assertTrue("shorthand-value".equals(merged.value()));
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerAutoRegisterAliasTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerAutoRegisterAliasTest.java
@@ -1,0 +1,131 @@
+package com.ultikits.ultitools.manager;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Assertions;
+import org.mockbukkit.mockbukkit.MockBukkit;
+
+import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
+import com.ultikits.ultitools.annotations.UltiToolsModule;
+import com.ultikits.ultitools.utils.MockBukkitHelper;
+import com.ultikits.ultitools.utils.TestHelper;
+
+/**
+ * End-to-end proof that {@code @UltiToolsModule}'s {@code cmdExecutor}/{@code eventListener}
+ * {@code @AliasFor} switches actually reach {@link PluginManager#registerBukkit}'s registration
+ * decision, now that it resolves {@code @EnableAutoRegister} through
+ * {@link com.ultikits.ultitools.context.MergedAnnotationResolver} instead of
+ * {@link com.ultikits.ultitools.utils.AnnotationUtils#findAnnotation} (WIRE-08).
+ * <p>
+ * Companion to {@code MergedAnnotationResolverTest}, which covers the resolver's own merge
+ * semantics in isolation; this class exercises the same switches through the real caller.
+ */
+@DisplayName("PluginManager auto-register @AliasFor wiring (WIRE-08)")
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+@SuppressWarnings("PMD.AvoidAccessibilityAlteration") // reflective invocation of the private registerBukkit
+class PluginManagerAutoRegisterAliasTest {
+
+    // Abstract fixtures extending UltiToolsPlugin, mocked rather than constructed -- Mockito
+    // bypasses the constructor entirely (Objenesis) and, with the default inline mock maker,
+    // mock.getClass() returns the real fixture class, so its annotations are read correctly.
+    // Following the same idiom already established in DependencyUtilsTest.
+
+    @UltiToolsModule
+    abstract static class DefaultModuleFixture extends UltiToolsPlugin {
+    }
+
+    @UltiToolsModule(cmdExecutor = false)
+    abstract static class CmdExecutorDisabledFixture extends UltiToolsPlugin {
+    }
+
+    private PluginManager pluginManager;
+    private CommandManager mockCommandManager;
+    private ListenerManager mockListenerManager;
+
+    @BeforeEach
+    void setUp() {
+        MockBukkitHelper.ensureCleanState();
+        MockBukkit.mock();
+        MockBukkit.createMockPlugin();
+
+        mockCommandManager = mock(CommandManager.class);
+        mockListenerManager = mock(ListenerManager.class);
+        TestHelper.mockUltiToolsInstance(ultiTools -> {
+            when(ultiTools.getCommandManager()).thenReturn(mockCommandManager);
+            when(ultiTools.getListenerManager()).thenReturn(mockListenerManager);
+        });
+
+        pluginManager = new PluginManager();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkitHelper.safeUnmock();
+    }
+
+    private void invokeRegisterBukkit(UltiToolsPlugin plugin) throws Exception {
+        Method method = PluginManager.class.getDeclaredMethod("registerBukkit", UltiToolsPlugin.class, boolean.class);
+        method.setAccessible(true);
+        method.invoke(pluginManager, plugin, true);
+    }
+
+    @Test
+    @DisplayName("Default @UltiToolsModule reaches CommandManager.registerAll")
+    void defaultModuleRegistersCommands() throws Exception {
+        UltiToolsPlugin plugin = mock(DefaultModuleFixture.class);
+
+        invokeRegisterBukkit(plugin);
+
+        verify(mockCommandManager, times(1)).registerAll(plugin);
+    }
+
+    @Test
+    @DisplayName("@UltiToolsModule(cmdExecutor = false) suppresses CommandManager.registerAll entirely")
+    void cmdExecutorDisabledModuleNeverReachesCommandManager() throws Exception {
+        UltiToolsPlugin plugin = mock(CmdExecutorDisabledFixture.class);
+
+        invokeRegisterBukkit(plugin);
+
+        verify(mockCommandManager, never()).registerAll(plugin);
+    }
+
+    @Test
+    @DisplayName("Inert-case guard: the default and disabled fixtures must not produce equal registerAll counts")
+    void defaultAndDisabledFixturesMustNotProduceEqualCounts() throws Exception {
+        // If the resolver silently returns the un-merged @EnableAutoRegister (the exact defect
+        // this plan closes), both fixtures would register and the two counts below would be
+        // equal (1 and 1) instead of (1 and 0) -- this assertion fails loudly on that equality
+        // rather than merely leaving it unasserted.
+        UltiToolsPlugin defaultPlugin = mock(DefaultModuleFixture.class);
+        UltiToolsPlugin disabledPlugin = mock(CmdExecutorDisabledFixture.class);
+
+        invokeRegisterBukkit(defaultPlugin);
+        invokeRegisterBukkit(disabledPlugin);
+
+        long defaultCount = org.mockito.Mockito.mockingDetails(mockCommandManager).getInvocations().stream()
+                .filter(invocation -> "registerAll".equals(invocation.getMethod().getName())
+                        && invocation.getArgument(0) == defaultPlugin)
+                .count();
+        long disabledCount = org.mockito.Mockito.mockingDetails(mockCommandManager).getInvocations().stream()
+                .filter(invocation -> "registerAll".equals(invocation.getMethod().getName())
+                        && invocation.getArgument(0) == disabledPlugin)
+                .count();
+
+        Assertions.assertNotEquals(defaultCount, disabledCount,
+                "a resolver that fails to merge the @AliasFor override would register both fixtures identically");
+        Assertions.assertEquals(1L, defaultCount);
+        Assertions.assertEquals(0L, disabledCount);
+    }
+}


### PR DESCRIPTION
Phase 3 of the 6.3.0 milestone, **PR 1 of 2** (D-28). This is the foundation layer: a single
merged-annotation resolver, every framework call site migrated onto it, and the legacy lookup
deprecated. PR 2 carries plans 03-03 through 03-10 and builds on this.

## What changes

**`MergedAnnotationResolver` (new)** — one merged-annotation lookup for the whole framework,
replacing a hand-written two-level meta-annotation walk that could not see attributes declared
through a composed annotation. `@UltiToolsModule(cmdExecutor = false)` now reaches
`registerBukkit`'s registration decision instead of being read and ignored (WIRE-08).

**Malformed `@AliasFor` is refused at load**, following Spring's documented Implementation
Requirements, rather than silently degrading to a default.

**Seven `AnnotationUtils.findAnnotation` call sites migrated** — `UltiToolsPlugin.initConfig`,
`Localized.supported`, `CommandManager` (×2), `ListenerManager` (×2) — plus
`ComponentScanner.hasComponentAnnotation`'s separate walk. `AnnotationUtils.findAnnotation` is
now `@Deprecated(since = "6.3.0", forRemoval = true)` with its body unchanged. No call sites
remain: `grep -rn 'AnnotationUtils\.findAnnotation(' src/main/java/` returns 0, against a
positive control of 8 hits for `MergedAnnotationResolver\.`.

## One deviation worth reviewing closely

The plan's literal instruction was for `hasComponentAnnotation` to delegate unconditionally to
`MergedAnnotationResolver.isPresent`. That would have introduced a regression, so it was not
done as written.

`@UltiToolsModule` composes `@Configuration`, which is itself meta-annotated `@Component`
(`annotations/Configuration.java:15`). An unqualified whole-tree walk therefore matches every
module's own `UltiToolsPlugin`-extending main class as a scannable component. Because
`PluginManager` already registers that instance as a singleton under a PascalCase name while
`ComponentScanner` decapitalises, the two keys never collide — so instead of failing loudly,
`registerComponent` would add a second `BeanDefinition` that `preInstantiateSingletons()` later
constructs by reflection, re-running every module's entire no-arg constructor a second time
(re-parsed `plugin.yml`, re-copied resources, duplicate config registration on an orphaned
instance).

Fixed by excluding `UltiToolsPlugin` subclasses inside `hasComponentAnnotation`, pinned by
`ComponentScannerTest#moduleMainClassNeverBecomesAComponent`.

## Verification

- `mvn -B test` — 4764 tests, 0 failures, 0 errors, 0 skipped at this branch tip
- `BugEvidenceTest` green (15/15)
- `ComponentScannerMalformedAliasPropagationTest` proves a malformed composed annotation found
  during a real `ComponentScanner.scanPackage()` scan propagates `ContainerException` out

## Issue closure

Closes #325
