### PR TITLE
feat(6.3.0): Phase 3 PR 2 — container resolution, injection and annotation contracts

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -681,16 +681,197 @@ a fresh, correctly-scoped `.db` file — it does not automatically recover the o
 rows. Inspect `sqliteDB/unknown.db` yourself before upgrading if you are unsure whether any of your
 modules were affected.
 
-**Newly deprecated, not yet removal-eligible.** Two more `@Deprecated(since = "6.3.0", forRemoval =
-true)` additions land in this release but do not appear in the "Removal list for 6.3.0" table above
+### Recorded instance: an unresolvable required `@Autowired` dependency now fails module load (SILENT-05, 6.3.0)
+
+Before 6.3.0, `SimpleContainer.autowireBean` and the constructor-injection path logged a `WARNING`
+and injected `null` for an unresolvable `@Autowired(required = true)` field or constructor
+parameter, instead of the failure the `required = true` default promises. 6.3.0 throws
+`ContainerException`, naming the declaring class, the field (or constructor parameter position),
+and the unresolvable dependency type, and the module fails to load rather than continuing with a
+silently-null collaborator. `required = false` is unaffected — the field or parameter is still
+left `null` with no warning.
+
+This falls under "moving from silent degradation to failure," which normally needs a migration
+period — but that period has already run. Issue #182's one-shot `WARNING` on this exact path
+shipped in `v6.2.5`, giving downstream module authors one full release of notice before 6.3.0
+turns it into a load-time failure. That warning is the precondition D-08 relied on to treat 6.3.0
+as the "N+1" step rather than starting the two-step process over.
+
+Constructor injection carries the identical fix: an unresolvable required constructor dependency
+now throws `ContainerException` rather than a bare `RuntimeException`.
+
+### Recorded instance: same-type resolution now adjudicates by `@Service(priority)` and refuses an exact tie (SILENT-06, 6.3.0)
+
+Before 6.3.0, `SimpleContainer.getBean(Class)` resolving a type with more than one matching
+candidate returned whichever the internal map iteration reached first — an unspecified,
+implementation-dependent choice that this repository's own `@Service` javadoc did not document,
+even though it shipped a `priority` attribute. 6.3.0 makes `priority` load-bearing: candidates are
+ranked by `@Service(priority)`, **higher value wins** — the framework's own direction, chosen
+because it is what this codebase's javadoc already promised in 6.2.5, and deliberately not
+Spring's `@Priority`, where a lower value wins. An exact tie between the top two candidates
+(including the common case of both left at the default priority `0`) now throws
+`ContainerException` at the first `getBean(Class)` call that hits the ambiguity, naming both
+candidate classes and pointing at `@Service(priority = ...)` as the remedy.
+
+**Scope.** Candidates are collected from the resolving container only; the parent container is
+consulted solely on a total miss (no candidate found locally). A module that overrides a
+framework-provided default service by registering its own implementation in its own child
+container is unaffected by this change — the override is never compared against the framework's
+default, because the two never sit in the same candidate pool.
+
+This is "moving from silent degradation to failure": before 6.3.0, two same-priority
+implementations resolved silently to an unspecified one and that choice was cached for the
+container's lifetime; after 6.3.0, the same module fails to load until it disambiguates with
+`priority`.
+
+### Recorded instance: `registerSingleton` now fully assembles its argument and can refuse an AOP-annotated instance (SILENT-09, SILENT-10, 6.3.0)
+
+Before 6.3.0, `SimpleContainer.registerSingleton` stored whatever object it was given as-is: no
+`@Autowired` injection, no `@PostConstruct` invocation, and no `BeanPostProcessor` chain ran
+against it. 6.3.0 widens its contract from "register" to "register and fully assemble" — every
+object passed to `registerSingleton` now goes through the same
+`postProcessBeforeInitialization → autowireBean → @PostConstruct → postProcessAfterInitialization`
+sequence a container-constructed bean does. This reaches config entities, `@ContextEntry` beans,
+`@Configuration` instances, and `@Bean` products registered via this path, none of which were
+previously assembled.
+
+As part of the same widening, `registerSingleton` now **refuses** an instance whose class carries
+`@Transactional` or `@ExceptionCatch` at method or class level — `ContainerException`,
+`ErrorCode.UNPROXYABLE_SINGLETON` (2007) — because an object registered this way was never routed
+through AOP proxy generation and the annotation would otherwise silently do nothing. An
+already-generated proxy instance is exempt.
+
+Measured in-house impact: **0** occurrences of `@Transactional`/`@ExceptionCatch` on any object
+registered via `registerSingleton` across `Modules/`, `Plugins/`, and the framework's own
+`src/main` (control: `@Service` appears in 39 downstream files, confirming the search mechanism
+finds real matches). A module registering such an object for the first time in 6.3.0+ needs to
+declare it `@Service`/`@Component` instead, so the container constructs — and can proxy — it.
+
+**Blast radius when reached through `@Bean`/`@Configuration`.** `registerConfiguration` and
+`processBeanMethod` (the paths that call `registerSingleton` for `@Configuration` instances and
+`@Bean` products) previously caught any exception, logged it at `SEVERE`, and continued scanning
+the rest of the module. As of 6.3.0 (see the `@Bean` naming entry below) a `ContainerException` —
+whether from this refusal or from a malformed `@Bean` declaration — is no longer caught there: it
+escapes `processClass` and aborts the module's entire `scanPackage` call. A failure that was
+previously scoped to one bean is now scoped to the whole module.
+
+Both changes fall under "moving from silent degradation to failure": before 6.3.0, an unassembled
+singleton or an AOP-annotated one was accepted and silently non-functional; after 6.3.0, the
+module fails to load until it is fixed.
+
+### Recorded instance: `@Bean(name=)`/`@Bean(value=)` now determine the registered bean name (WIRE-09, 6.3.0)
+
+Before 6.3.0, `@Bean`'s `name` and `value` attributes were declared but read by nobody — every
+`@Bean` method registered under its own method name regardless of what `name()`/`value()` said.
+6.3.0 makes both attributes load-bearing: when either is declared, its first array element becomes
+the registered bean name, and any remaining elements register as aliases resolving to the same
+instance; with neither set, the method name is still used, unchanged. A module doing
+`getBean("<methodName>")` for a `@Bean` method that also declares a non-default `name()`/`value()`
+needs to change to `getBean("<declaredName>")` after upgrading — the method-name key no longer
+resolves once a custom name is declared.
+
+A malformed declaration — conflicting non-empty `name()` and `value()` content, or any blank
+declared name element — now fails module load with `ContainerException`, where before it silently
+registered under the method's own name (both attributes were previously read by nobody). See the
+entry above for the blast radius this failure carries as of 6.3.0.
+
+Measured in-house impact: **0** occurrences of `@Bean(name=` / `@Bean(value=` in `Modules/`,
+`Plugins/`, or the framework's own `src/main` — every existing `@Bean` method relies on the
+method-name default, unchanged by this release, so this is a forward-looking compatibility note
+rather than an observed break.
+
+### Recorded instance: `scanBasePackageClasses` now takes effect, and package-source resolution becomes additive (GEN-06, 6.3.0)
+
+Before 6.3.0, `scanBasePackageClasses()` on `@UltiToolsModule`/`@ComponentScan` was declared but
+read by nobody at either `PluginManager.getPluginScanPackages` or
+`SimpleContainer.processConfigurationClass`. 6.3.0 reads it at both sites, purely additively: any
+module that already declared the attribute (0 occurrences measured) sees no change, since a
+previously-inert declaration cannot regress by starting to work.
+
+The same change makes package-source resolution additive rather than first-match: a module
+declaring more than one of `scanBasePackages`, `scanBasePackageClasses`, or a directly-declared
+`@ComponentScan.basePackages` previously had every source after the first silently ignored; all
+now contribute. Measured in-house impact: **0** modules declare more than one source today, so no
+existing module's scanned-package set changes size. Falls under "correcting behaviour that plainly
+contradicts the documentation" — no migration period.
+
+### Recorded instance: the `eventListener`/`cmdExecutor`/`config` `@AliasFor` switches on `@UltiToolsModule` now take effect (WIRE-08, 6.3.0)
+
+Before 6.3.0, `@UltiToolsModule`'s `eventListener`, `cmdExecutor`, and `config` attributes were
+declared `@AliasFor`s onto `@EnableAutoRegister`'s corresponding attributes, but `registerBukkit`
+resolved `@EnableAutoRegister` by direct reflection, which never followed the alias — so setting
+any of the three to `false` on `@UltiToolsModule` had no effect at all; auto-registration ran
+regardless. 6.3.0 makes `registerBukkit` resolve `@EnableAutoRegister` through the same
+merged-annotation lookup the rest of this phase's work uses, which honours `@AliasFor`, so the
+three switches now do what their own annotation declared them to do since they were added.
+
+This is recorded under "correcting behaviour that plainly contradicts the documentation" — no
+migration period — because the previous behaviour was not merely an undocumented gap; it directly
+contradicted `@AliasFor`'s own stated contract on the same annotation. Measured in-house impact:
+**0** downstream modules set any of the three switches to a non-default value today, so no
+existing module's registered set of commands/listeners/configs changes as a result of this fix.
+
+### Recorded instance: `@ConditionalOnConfig` is now honoured on the listener package-scan path (WIRE-07, 6.3.0)
+
+Before 6.3.0, `ListenerManager.registerAll(plugin, packageName)` registered every discovered
+listener regardless of `@ConditionalOnConfig`, so a listener whose condition evaluated `false`
+still received events. 6.3.0 evaluates the condition on this path the same way the IoC component
+scan already does; a listener whose condition is false is registered with no events delivered.
+
+**Scope correction.** `@ConditionalOnConfig` on a `@CmdExecutor` class already worked before this
+release on the standard module-JAR path — that path resolves command classes as container beans,
+and a class whose condition is `false` was never constructed as a bean in the first place. This
+entry covers only the listener package-scan gap that was real. Falls under "correcting behaviour
+that plainly contradicts the documentation" — no migration period.
+
+### Recorded instance: `ComponentScanner`'s failure and skip diagnostics now carry a level and a stack trace (SILENT-07, 6.3.0)
+
+Before 6.3.0, `ComponentScanner` reported six distinct failure and skip conditions — an ambiguous
+`@CmdTarget` refusal, a component/configuration registration exception, a `@Bean` method
+invocation exception, an unresolvable package, and an unreadable JAR — with direct,
+stack-trace-free `System.err` writes that no log handler ever saw. 6.3.0 replaces all six with
+leveled `java.util.logging.Logger` calls carrying the original `Throwable` wherever one exists.
+Four registration-failure sites now log `Level.SEVERE`; because `SystemLogHandler` auto-forwards
+any `Level.SEVERE` record carrying a `Throwable` to `ErrorReportCollector` and on to the UltiPanel
+dashboard, these four failures — previously visible only on the server's own console — now reach
+the panel for any server with error reporting enabled. Two skip-and-continue sites log
+`Level.WARNING` and stay local.
+
+Separately, `scanJar` and `scanDirectory` now catch the identical `ClassNotFoundException |
+LinkageError` union per class, closing a mismatch where a class referencing an absent optional type
+skipped just that one class in production (JAR mode) but aborted the entire package's scan in
+development (directory mode); both modes now skip-and-continue identically.
+
+This falls under "changes in ... log wording" — no migration period — but the routing-to-panel
+fact is named explicitly because it changes what an existing server transmits off-box, not merely
+what it logs locally.
+
+### Recorded instance: composed stereotype annotations more than one meta-level above `@Component` are now recognised (6.3.0)
+
+Before 6.3.0, `ComponentScanner.hasComponentAnnotation` walked only one level of meta-annotation
+composition by hand. 6.3.0 collapses this onto the same `MergedAnnotationResolver` used across the
+rest of this phase's `AnnotationUtils.findAnnotation` migration (see the deprecation entry below),
+which walks the full composition graph — a stereotype annotation composed two or more levels above
+`@Component` is now recognised as a component where it previously was not. `UltiToolsPlugin`
+subclasses are excluded from this widened reach so that a module's own main class (which composes
+`@Configuration` → `@Component` through `@UltiToolsModule`) is not accidentally registered a
+second time as a component bean.
+
+Recorded honestly: the set of downstream classes this newly registers across `Modules/` and
+`Plugins/` was **not** measured — this is an absence of evidence, not a measured zero, unlike the
+other entries above.
+
+**Newly deprecated, not yet removal-eligible.** Three more `@Deprecated(since = "6.3.0", forRemoval =
+true)` additions land in this release but do not appear in the "Removal list for 6.3.0" table
 above, because condition 2 of [eligibility](#when-a-public-api-becomes-eligible-for-removal) — one
-MINOR since the *first* release carrying the annotation — is not yet satisfied by either: 6.3.0 is
-that first release, so neither is eligible for removal before 6.4.0 at the earliest.
+MINOR since the *first* release carrying the annotation — is not yet satisfied by any of the three:
+6.3.0 is that first release, so none is eligible for removal before 6.4.0 at the earliest.
 
 | Type / member | Replacement | Downstream references (informational) |
 |---|---|---|
 | `interfaces.TransactionManager.getConnection()` / `setIsolationLevel(int)` / `setReadOnly(boolean)` | `interfaces.JdbcTransactionManager`, which carries the same three as real abstract methods | 0 — `TransactionManager` appears in no published-jar signature of `DataStore`/`DataOperator`/`UltiToolsPlugin`/`UltiTools`; a module can only reach it today by downcasting `DataOperator` to `AbstractRelationalDataOperator` and supplying its own `DataSource` |
 | `interfaces.DataStore.getOperator(UltiToolsPlugin, Class)` and `getOperator(File, Class)` | `getOperator(DataScope, Class)` | Not separately measured — the documented, correct entry point for module authors is `getDataOperator(Class)` (94 downstream hits across 17 repositories, per the survey above), which still calls the deprecated overloads on your behalf and is unaffected by this deprecation |
+| `utils.AnnotationUtils.findAnnotation` | `context.MergedAnnotationResolver.find` | 0 — no occurrences of `AnnotationUtils` across `Modules/` and `Plugins/`; the method body is unchanged, serving only as the compatibility fallback for anything not yet migrated to the resolver |
 
 On `TransactionManager`, turning three previously-abstract methods into `@Deprecated` `default`
 methods that throw `UnsupportedOperationException` is, per `japicmp` 0.26.1's own
@@ -1586,8 +1767,162 @@ public final class MyService extends GuardedBase { }   // 6.2.5：能加载。6.
 全新的、正确归属的 `.db` 文件——不会自动找回旧共享文件里的行。升级前如果拿不准哪些模块受影响，
 请自行检查 `sqliteDB/unknown.db`。
 
-**新增废弃、尚未到可移除的时候。** 本版本还带来两处新增的 `@Deprecated(since = "6.3.0",
-forRemoval = true)`，但都没有出现在上面「6.3.0 的移除清单」表里，因为二者都不满足
+### 已记录的实例：无法解析的必需 `@Autowired` 依赖现在会导致模块加载失败（SILENT-05，6.3.0）
+
+6.3.0 之前，对于一个无法解析的 `@Autowired(required = true)` 字段或构造器参数，
+`SimpleContainer.autowireBean` 与构造器注入路径只会记一条 `WARNING` 并注入 `null`，
+而不是 `required = true` 这个默认值本该承诺的失败。6.3.0 改为抛出 `ContainerException`，
+点名声明该依赖的类、字段（或构造器参数位置）以及无法解析的依赖类型，模块直接加载失败，
+而不是带着一个静默为 `null` 的协作对象继续跑下去。`required = false` 不受影响——字段或参数
+仍然是 `null`，也不会有任何警告。
+
+这属于「从静默降级变为失败」，通常需要一个迁移期——但这个迁移期已经跑完了。issue #182
+在这条路径上加的一次性 `WARNING` 已经在 `v6.2.5` 里发布，给了下游模块作者整整一个发布周期
+的提前通知，6.3.0 才把它变成加载期失败。这条警告正是 D-08 依赖的前提条件，让 6.3.0 可以
+被当作两步流程里的「N+1」步，而不必重新走一遍两步流程。
+
+构造器注入携带完全相同的修法：一个无法解析的必需构造器依赖现在抛出的是 `ContainerException`，
+而不是裸的 `RuntimeException`。
+
+### 已记录的实例：同类型解析现在按 `@Service(priority)` 裁决，并对精确并列直接拒绝（SILENT-06，6.3.0）
+
+6.3.0 之前，`SimpleContainer.getBean(Class)` 在解析一个有多个匹配候选者的类型时，会返回
+内部 map 迭代先碰到的那一个——这是一个未指定、依赖具体实现的选择，尽管本仓库自己的
+`@Service` javadoc 从未这样文档化过，即便它早就带了一个 `priority` 属性。6.3.0 让 `priority`
+真正起作用：候选者按 `@Service(priority)` 排序，**数值更高者胜出**——这是框架自己选定的方向，
+之所以这样选，是因为这正是本代码库 6.2.5 版 javadoc 早已承诺的方向，刻意不采用 Spring 的
+`@Priority`（那里是数值更低者胜出）。排名前两位候选者精确并列时（包括两者都留在默认优先级
+`0` 这种常见情况），现在会在第一次触发该歧义的 `getBean(Class)` 调用上抛出
+`ContainerException`，点名两个候选类，并指向 `@Service(priority = ...)` 作为解决办法。
+
+**范围。** 候选者只从发起解析的那个容器里收集；父容器只在本地完全没有候选者命中时才会被
+查询。一个模块如果在自己的子容器里注册了自己的实现，用来覆盖框架提供的默认服务，这次
+改动不会影响它——这个覆盖压根不会和框架的默认实现放在同一个候选池里比较。
+
+这是「从静默降级变为失败」：6.3.0 之前，两个优先级相同的实现会静默解析成某个未指定的一个，
+并且这个选择会在容器的整个生命周期内被缓存；6.3.0 之后，同一个模块在用 `priority` 消除歧义
+之前会直接加载失败。
+
+### 已记录的实例：`registerSingleton` 现在会完整装配它的参数，并可能拒绝携带 AOP 注解的实例（SILENT-09、SILENT-10，6.3.0）
+
+6.3.0 之前，`SimpleContainer.registerSingleton` 会原样存下传给它的任何对象：不会执行
+`@Autowired` 注入，不会调用 `@PostConstruct`，也不会跑 `BeanPostProcessor` 链。6.3.0 把它的
+契约从「注册」拓宽为「注册并完整装配」——现在，传给 `registerSingleton` 的每个对象都会经过
+和容器自己构造的 bean 完全相同的
+`postProcessBeforeInitialization → autowireBean → @PostConstruct → postProcessAfterInitialization`
+流程。这会波及通过这条路径注册的配置实体、`@ContextEntry` bean、`@Configuration` 实例，
+以及 `@Bean` 产物——此前它们都没有被装配过。
+
+作为同一次拓宽的一部分，`registerSingleton` 现在会**拒绝**一个类上带有方法级或类级
+`@Transactional`/`@ExceptionCatch` 的实例——抛出 `ContainerException`，
+`ErrorCode.UNPROXYABLE_SINGLETON`（2007）——因为以这种方式注册的对象从未走过 AOP
+代理生成，否则这些注解只会静默地什么都不做。一个已经生成好的代理实例不受此限制。
+
+内部实测影响：在 `Modules/`、`Plugins/` 以及框架自己的 `src/main` 里，**0** 个通过
+`registerSingleton` 注册的对象带有 `@Transactional`/`@ExceptionCatch`（对照组：`@Service`
+在下游 39 个文件里出现，确认了这个搜索机制本身能找到真实命中）。一个模块如果要在 6.3.0+
+第一次注册这样一个对象，需要改成声明它为 `@Service`/`@Component`，这样容器才会构造它——
+并且能够代理它。
+
+**通过 `@Bean`/`@Configuration` 触发时的影响范围。** `registerConfiguration` 与
+`processBeanMethod`（分别为 `@Configuration` 实例和 `@Bean` 产物调用 `registerSingleton`
+的路径）此前会捕获任何异常，以 `SEVERE` 级别记录日志，然后继续扫描模块的其余部分。
+从 6.3.0 起（见下面 `@Bean` 命名那条实例），一个 `ContainerException`——无论是来自这个
+拒绝，还是来自一个格式错误的 `@Bean` 声明——不再在那里被捕获：它会逃出 `processClass`，
+中止整个模块的 `scanPackage` 调用。此前局限在单个 bean 上的失败，现在会波及整个模块。
+
+这两处改动都属于「从静默降级变为失败」：6.3.0 之前，一个未装配的单例或一个带 AOP 注解的
+单例会被接受，然后静默地不起作用；6.3.0 之后，模块在问题修好之前都会加载失败。
+
+### 已记录的实例：`@Bean(name=)`/`@Bean(value=)` 现在决定注册的 bean 名称（WIRE-09，6.3.0）
+
+6.3.0 之前，`@Bean` 的 `name` 和 `value` 属性只是声明了，从来没人读过——不管
+`name()`/`value()` 写了什么，每个 `@Bean` 方法都用自己的方法名注册。6.3.0 让这两个属性
+真正起作用：只要声明了任意一个，其数组的第一个元素就成为注册的 bean 名称，其余元素则
+注册为解析到同一实例的别名；两者都没设置时，仍然用方法名，行为不变。一个模块如果对某个
+同时声明了非默认 `name()`/`value()` 的 `@Bean` 方法写 `getBean("<方法名>")`，升级后需要改成
+`getBean("<声明的名称>")`——一旦声明了自定义名称，方法名这个 key 就不再能解析了。
+
+一个格式错误的声明——`name()` 与 `value()` 内容冲突且都非空，或声明的名称元素中有任何一个
+是空白——现在会以 `ContainerException` 使模块加载失败，而此前会静默地用方法自己的名称注册
+（两个属性此前都没人读）。这个失败带来的波及范围见上一条实例。
+
+内部实测影响：在 `Modules/`、`Plugins/` 以及框架自己的 `src/main` 里，**0** 处出现
+`@Bean(name=`/`@Bean(value=`——现存的每一个 `@Bean` 方法都依赖方法名默认值，本版本不改变
+这一点，所以这是一条前瞻性的兼容性说明，而不是一个已观测到的破坏。
+
+### 已记录的实例：`scanBasePackageClasses` 现在真正生效，包扫描来源解析变为累加而非首个命中（GEN-06，6.3.0）
+
+6.3.0 之前，`@UltiToolsModule`/`@ComponentScan` 上的 `scanBasePackageClasses()` 只是声明了，
+在 `PluginManager.getPluginScanPackages` 和 `SimpleContainer.processConfigurationClass` 这
+两个读取点都没人读它。6.3.0 在这两处都读取它，纯粹是增量式的：任何已经声明了这个属性的模块
+（实测 0 例）都不会有任何变化，因为一个此前静默失效的声明，开始生效并不会造成回归。
+
+同一次改动也让包来源的解析从「首个命中」变为「累加」：一个同时声明了 `scanBasePackages`、
+`scanBasePackageClasses`，或直接声明 `@ComponentScan.basePackages` 中一个以上的模块，此前
+第一个之后的来源都会被静默忽略；现在全部都会生效。内部实测影响：**0** 个模块今天同时声明
+了一个以上的来源，所以现存模块被扫描的包集合大小都不会改变。属于「修正与文档明显矛盾的
+行为」——不需要迁移期。
+
+### 已记录的实例：`@UltiToolsModule` 上 `eventListener`/`cmdExecutor`/`config` 的 `@AliasFor` 开关现在真正生效（WIRE-08，6.3.0）
+
+6.3.0 之前，`@UltiToolsModule` 的 `eventListener`、`cmdExecutor`、`config` 属性都被声明为
+指向 `@EnableAutoRegister` 对应属性的 `@AliasFor`，但 `registerBukkit` 是通过直接反射来解析
+`@EnableAutoRegister` 的，从不跟随别名——所以在 `@UltiToolsModule` 上把这三个属性中任意一个
+设为 `false` 完全没有效果；自动注册照常进行。6.3.0 让 `registerBukkit` 改用本阶段其余工作
+统一使用的合并注解查找来解析 `@EnableAutoRegister`，这个查找会遵循 `@AliasFor`，于是这三个
+开关现在终于做到了它们自己那个注解从被加上那天起就声明要做的事。
+
+这条被记在「修正与文档明显矛盾的行为」下——不需要迁移期——因为此前的行为不只是一个未文档化
+的缺口，而是直接和同一个注解上 `@AliasFor` 自己声明的契约相矛盾。内部实测影响：今天**没有**
+任何下游模块把这三个开关中的任何一个设为非默认值，所以现存模块注册的命令/监听器/配置集合
+不会因为这个修复而改变。
+
+### 已记录的实例：`@ConditionalOnConfig` 现在在监听器包扫描路径上生效（WIRE-07，6.3.0）
+
+6.3.0 之前，`ListenerManager.registerAll(plugin, packageName)` 会不管 `@ConditionalOnConfig`
+一律注册所有发现的监听器，所以一个条件求值为 `false` 的监听器仍然会收到事件。6.3.0 在这条
+路径上按 IoC 组件扫描早已使用的同样方式求值该条件；一个条件为假的监听器会被注册，但不会
+收到任何事件。
+
+**范围纠正。** `@ConditionalOnConfig` 在 `@CmdExecutor` 类上，在标准模块 JAR 路径上其实
+在本版本之前就已经生效了——那条路径把命令类当作容器 bean 解析，一个条件为 `false` 的类
+从一开始就不会被构造成 bean。这条记录只覆盖真实存在的监听器包扫描缺口。属于「修正与文档
+明显矛盾的行为」——不需要迁移期。
+
+### 已记录的实例：`ComponentScanner` 的失败与跳过诊断现在带有级别和堆栈（SILENT-07，6.3.0）
+
+6.3.0 之前，`ComponentScanner` 报告六种不同的失败与跳过情形——一次歧义 `@CmdTarget` 拒绝、
+一次组件/配置注册异常、一次 `@Bean` 方法调用异常、一个无法解析的包、一个无法读取的
+JAR——全部直接写到 `System.err`，没有堆栈，也没有任何日志处理器看得到。6.3.0 把这六处全部
+换成带级别的 `java.util.logging.Logger` 调用，在有 `Throwable` 的地方都带上原始异常。四个
+注册失败点现在以 `Level.SEVERE` 记录；由于 `SystemLogHandler` 会自动把任何携带
+`Throwable` 的 `Level.SEVERE` 记录转发给 `ErrorReportCollector` 并进一步转发到 UltiPanel
+控制台，这四个此前只在服务器自己控制台可见的失败，现在会送达面板——对任何开启了错误报告的
+服务器都是如此。两个「跳过并继续」的位置以 `Level.WARNING` 记录，且只留在本地。
+
+另外，`scanJar` 和 `scanDirectory` 现在对每个类都捕获完全相同的
+`ClassNotFoundException | LinkageError` 联合类型，弥合了此前的一个不一致：一个引用了缺失
+可选类型的类，在生产环境（JAR 模式）下只会跳过那一个类，但在开发环境（目录模式）下会中止
+整个包的扫描；现在两种模式的「跳过并继续」行为完全一致。
+
+这属于「日志措辞……的变化」——不需要迁移期——但转发到面板这个事实被明确记下来，因为它改变
+了一台现有服务器向外发送的内容，而不只是它本地记录了什么。
+
+### 已记录的实例：组合层级超过 `@Component` 一层的元注解现在也能被识别（6.3.0）
+
+6.3.0 之前，`ComponentScanner.hasComponentAnnotation` 只手写遍历了一层元注解组合。6.3.0
+把它收拢到本阶段其余工作（`AnnotationUtils.findAnnotation` 迁移，见下面的废弃条目）统一
+使用的同一个 `MergedAnnotationResolver` 上，它会遍历完整的组合图——一个组合层级在
+`@Component` 之上两层或更多层的原型注解，现在会被识别为组件，此前不会。`UltiToolsPlugin`
+的子类被排除在这次拓宽之外，这样一个模块自己的主类（通过 `@UltiToolsModule` 组合了
+`@Configuration` → `@Component`）就不会被意外地当作组件 bean 二次注册。
+
+如实记录：这次改动在 `Modules/` 和 `Plugins/` 里新登记的下游类集合**没有**被实测过——这是
+证据缺失，不是一个实测出来的零，和上面其他条目不同。
+
+**新增废弃、尚未到可移除的时候。** 本版本还带来三处新增的 `@Deprecated(since = "6.3.0",
+forRemoval = true)`，但都没有出现在上面「6.3.0 的移除清单」表里，因为三者都不满足
 [可移除性](#一个公开-api-何时可以被移除)的第 2 条——从**首个**带上该标注的发布起算已跨过一个
 MINOR：6.3.0 正是那个首个发布，所以最早也要到 6.4.0 才有资格被移除。
 
@@ -1595,6 +1930,7 @@ MINOR：6.3.0 正是那个首个发布，所以最早也要到 6.4.0 才有资�
 |---|---|---|
 | `interfaces.TransactionManager.getConnection()` / `setIsolationLevel(int)` / `setReadOnly(boolean)` | `interfaces.JdbcTransactionManager`，把同样这三个方法作为真正的抽象方法保留 | 0——`TransactionManager` 不出现在已发布 jar 里 `DataStore`/`DataOperator`/`UltiToolsPlugin`/`UltiTools` 的任何签名中；今天一个模块只能通过把 `DataOperator` 强转成 `AbstractRelationalDataOperator` 并自带 `DataSource` 才能碰到它 |
 | `interfaces.DataStore.getOperator(UltiToolsPlugin, Class)` 与 `getOperator(File, Class)` | `getOperator(DataScope, Class)` | 未单独实测——模块作者应当使用、也是文档承诺的正确入口是 `getDataOperator(Class)`（按上面的调查，17 个仓库里下游命中 94 次），它仍然会替你调用这两个已废弃的重载，不受这次废弃影响 |
+| `utils.AnnotationUtils.findAnnotation` | `context.MergedAnnotationResolver.find` | 0——`Modules/` 和 `Plugins/` 里没有任何 `AnnotationUtils` 出现；方法体本身未改动，只作为尚未迁移到该解析器的下游代码的兼容性兜底 |
 
 在 `TransactionManager` 上，把三个原本抽象的方法改成会抛 `UnsupportedOperationException` 的
 `@Deprecated` `default` 方法，按 `japicmp` 0.26.1 自己的 `METHOD_ABSTRACT_NOW_DEFAULT` 分类，

--- a/src/main/java/com/ultikits/ultitools/annotations/Bean.java
+++ b/src/main/java/com/ultikits/ultitools/annotations/Bean.java
@@ -7,8 +7,34 @@ import java.lang.annotation.Target;
 
 /**
  * Bean annotation to replace Spring's @Bean.
+ * <p>
+ * {@code name()} and {@code value()} are mutual aliases (D-06): declaring both with different
+ * content is a malformed declaration and fails the module's load, naming the declaring method
+ * and both declared values; declaring both with identical content is legal. An empty or absent
+ * {@code name()}/{@code value()} falls back to the factory method's own name, exactly as before
+ * this attribute took effect. When more than one name is declared, the <b>first</b> element is
+ * the bean's registered name and the rest are aliases sharing the same fully-assembled
+ * instance -- Spring's own {@code @Bean} convention. A declared element that is blank or
+ * whitespace-only also fails the module's load, naming the offending method: a name that cannot
+ * name anything is not a usable third state between "declared" and "absent".
+ * <p>
+ * {@code @Target} also includes {@link ElementType#ANNOTATION_TYPE}, but no code path in this
+ * framework acts on a {@code @Bean} placed there -- that gap is tracked as a separate issue
+ * (03-CONTEXT.md &sect; Deferred Ideas) and is not implemented by this attribute's own fix.
  * <br>
  * Bean注解，用于替换Spring的@Bean。
+ * <p>
+ * {@code name()} 与 {@code value()} 互为别名（D-06）：两者都非空且内容不同即为畸形声明，会导致
+ * 模块加载失败，错误信息同时指出声明该属性的方法与两个已声明的值；两者内容相同则合法。
+ * {@code name()}/{@code value()} 为空或缺省时回退到工厂方法自身的名称，与该属性生效前的行为一致。
+ * 声明多个名称时，<b>第一个</b>元素是该 Bean 的注册名，其余元素是共享同一个完整装配实例的别名——
+ * 这是 Spring 自身 {@code @Bean} 的约定。已声明的元素若为空白或仅由空白字符组成，同样会导致
+ * 模块加载失败，并指出出问题的方法：一个无法命名任何东西的名称，不是"已声明"与"缺省"之间可用的
+ * 第三种状态。
+ * <p>
+ * {@code @Target} 中还包含 {@link ElementType#ANNOTATION_TYPE}，但本框架中没有任何代码路径会
+ * 处理放置在那里的 {@code @Bean}——该缺口作为独立 issue 追踪（见 03-CONTEXT.md 的
+ * "Deferred Ideas" 一节），本属性自身的修复不实现它。
  */
 @Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/com/ultikits/ultitools/context/AutowireFactory.java
+++ b/src/main/java/com/ultikits/ultitools/context/AutowireFactory.java
@@ -1,10 +1,9 @@
 package com.ultikits.ultitools.context;
 
 import com.ultikits.ultitools.annotations.Autowired;
+import com.ultikits.ultitools.exceptions.ContainerException;
 
 import java.lang.reflect.Field;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
@@ -15,7 +14,6 @@ import org.jetbrains.annotations.ApiStatus;
 @SuppressWarnings("PMD.AvoidAccessibilityAlteration") // Autowiring requires reflection
 @ApiStatus.Internal
 public class AutowireFactory {
-    private static final Logger LOGGER = Logger.getLogger(AutowireFactory.class.getName());
 
     private final SimpleContainer container;
 
@@ -27,16 +25,30 @@ public class AutowireFactory {
      * Autowire bean dependencies.
      * <br>
      * 自动装配Bean依赖。
+     * <p>
+     * An unresolvable {@code @Autowired(required = true)} dependency aborts the owning module:
+     * this method throws {@link ContainerException} instead of leaving the field {@code null}.
+     * Other modules are unaffected, because each module owns its own {@link SimpleContainer}.
+     * {@code @Autowired(required = false)} is the documented escape for a genuinely optional
+     * dependency, which still resolves to {@code null} silently. Autowiring stops at the first
+     * unresolvable required field rather than continuing and reporting only the last one. See
+     * issue #201 (D-08).
+     * <p>
+     * 一个无法解析的 {@code @Autowired(required = true)} 依赖会让所属模块中止加载：本方法会抛出
+     * {@link ContainerException}，而不是把字段留成 {@code null}。其他模块不受影响，因为每个模块
+     * 都拥有自己的 {@link SimpleContainer}。{@code @Autowired(required = false)} 是为真正可选的
+     * 依赖提供的文档化退出方式，那种情况仍会静默解析为 {@code null}。
      *
      * @param bean the bean to autowire <br> 要自动装配的Bean
+     * @throws ContainerException if a {@code required = true} dependency cannot be resolved
      */
     public void autowireBean(Object bean) {
         Class<?> clazz = bean.getClass();
-        
+
         // Process fields from current class and all superclasses
         while (clazz != null && clazz != Object.class) {
             Field[] fields = clazz.getDeclaredFields();
-            
+
             for (Field field : fields) {
                 Autowired autowired = field.getAnnotation(Autowired.class);
                 if (autowired != null) {
@@ -46,7 +58,7 @@ public class AutowireFactory {
                         if (dependency != null) {
                             field.set(bean, dependency);
                         } else if (autowired.required()) {
-                            warnUnresolvedRequiredDependency(field);
+                            throw ContainerException.requiredDependencyUnresolved(field);
                         }
                     } catch (IllegalAccessException e) {
                         throw new IllegalStateException("Failed to autowire field: " + field.getName(), e);
@@ -56,35 +68,5 @@ public class AutowireFactory {
 
             clazz = clazz.getSuperclass();
         }
-    }
-
-    /**
-     * Warn that a {@code required = true} dependency could not be resolved.
-     * <br>
-     * 一个 {@code required = true} 的依赖没解析出来时发出警告。
-     * <p>
-     * 在此之前 {@code required()} 从来没被读过：解析不到就把字段留成 null，插件照常启动，
-     * NPE 在之后某处才炸，而模块作者分不清是「bean 没注册」「不在扫描范围」「宿主是 new 出来
-     * 的所以根本没走注入」还是「自己忘了写注解」——四种原因同一个症状。见 issue #182。
-     * <p>
-     * 本版只警告，不抛。可能已经有下游模块正带着 null 字段跑在生产上，需要一个版本的观察期；
-     * 改抛留给 6.3.0。构造器注入路径（{@code SimpleContainer#createBeanWithConstructorInjection}）
-     * 一直是直接抛的，两者的不一致也留到那时一起收。
-     *
-     * @param field the unresolved field <br> 没解析出来的字段
-     */
-    private void warnUnresolvedRequiredDependency(Field field) {
-        // 这个 Throwable 不是被抛出来的，它只负责把「哪条路径触发了这次注入」记进日志：
-        // 容器建 bean、命令注册、监听器注册、插件对象注入是四个不同的入口，
-        // 而模块作者拿到 NPE 的时候现场早就离开这里了。
-        Throwable site = new Throwable("@Autowired injection site (not a thrown exception; "
-                + "the stack below shows which code path triggered this injection)");
-        LOGGER.log(Level.WARNING, "[UltiTools-API] @Autowired could not resolve "
-                + field.getType().getName() + " for field " + field.getDeclaringClass().getName()
-                + "." + field.getName() + " - the field stays null, so the NullPointerException will "
-                + "surface somewhere else, not here. Check that the target class is annotated with "
-                + "@Service/@Component, that it is inside the module's scanBasePackages, and that the "
-                + "owning object was created by the container rather than with 'new'. "
-                + "Use @Autowired(required = false) if the dependency really is optional.", site);
     }
 }

--- a/src/main/java/com/ultikits/ultitools/context/BeanPostProcessor.java
+++ b/src/main/java/com/ultikits/ultitools/context/BeanPostProcessor.java
@@ -1,10 +1,13 @@
 package com.ultikits.ultitools.context;
 
+import org.jetbrains.annotations.ApiStatus;
+
 /**
  * Bean post processor interface to customize bean initialization.
  * <br>
  * Bean后处理器接口，用于自定义Bean初始化。
  */
+@ApiStatus.Internal
 public interface BeanPostProcessor {
     
     /**

--- a/src/main/java/com/ultikits/ultitools/context/ComponentScanner.java
+++ b/src/main/java/com/ultikits/ultitools/context/ComponentScanner.java
@@ -15,7 +15,6 @@ import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.abstracts.command.validation.CmdTargetComposition;
 import com.ultikits.ultitools.annotations.Bean;
 import com.ultikits.ultitools.annotations.Component;
-import com.ultikits.ultitools.annotations.ConditionalOnConfig;
 import com.ultikits.ultitools.annotations.Configuration;
 import com.ultikits.ultitools.annotations.EventListener;
 import com.ultikits.ultitools.annotations.Service;
@@ -23,7 +22,6 @@ import com.ultikits.ultitools.annotations.command.CmdExecutor;
 import com.ultikits.ultitools.exceptions.ContainerException;
 import com.ultikits.ultitools.exceptions.ErrorCode;
 
-import org.bukkit.configuration.file.YamlConfiguration;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
@@ -184,41 +182,21 @@ public class ComponentScanner {
 
     /**
      * Check if a class should be registered based on @ConditionalOnConfig.
+     * <p>
+     * Delegates to {@link ConditionalRegistrationEvaluator}, the single shared implementation
+     * of this decision (D-17) -- also consulted by {@code ListenerManager}'s package-scan
+     * overload, so the annotation is honoured identically on both reflection paths.
      * <br>
      * 根据 @ConditionalOnConfig 检查类是否应被注册。
+     * <p>
+     * 委托给 {@link ConditionalRegistrationEvaluator}——该判定逻辑唯一的共享实现（D-17），
+     * 同时也被 {@code ListenerManager} 的包扫描重载调用，从而使该注解在两条反射路径上表现一致。
      *
      * @param clazz the class to check
      * @return true if the class should be registered
      */
     private boolean shouldRegister(Class<?> clazz) {
-        ConditionalOnConfig condition = clazz.getAnnotation(ConditionalOnConfig.class);
-        if (condition == null) {
-            return true;
-        }
-
-        // Retrieve the plugin from the container
-        UltiToolsPlugin plugin = null;
-        try {
-            plugin = container.getBean(UltiToolsPlugin.class);
-        } catch (Exception e) {
-            // No plugin in container — skip conditional (register by default)
-            return true;
-        }
-
-        if (plugin == null || plugin.getResourceFolderPath() == null) {
-            return true;
-        }
-
-        // Load the referenced config file from the plugin's config folder
-        File configFile = new File(plugin.getResourceFolderPath(), condition.value());
-        if (!configFile.exists()) {
-            // Config file doesn't exist yet — feature disabled
-            return condition.negate();
-        }
-
-        YamlConfiguration yaml = YamlConfiguration.loadConfiguration(configFile);
-        boolean value = yaml.getBoolean(condition.path(), false);
-        return condition.negate() ? !value : value;
+        return ConditionalRegistrationEvaluator.shouldRegister(clazz, container);
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/context/ComponentScanner.java
+++ b/src/main/java/com/ultikits/ultitools/context/ComponentScanner.java
@@ -9,6 +9,8 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
@@ -31,6 +33,8 @@ import org.jetbrains.annotations.ApiStatus;
  */
 @ApiStatus.Internal
 public class ComponentScanner {
+    private static final Logger LOGGER = Logger.getLogger(ComponentScanner.class.getName());
+
     private final SimpleContainer container;
 
     public ComponentScanner(SimpleContainer container) {
@@ -84,8 +88,11 @@ public class ComponentScanner {
             // happened. See issue #190.
             throw e;
         } catch (Exception e) {
-            // Log warning and continue
-            System.err.println("Failed to scan package: " + basePackage + ", " + e.getMessage());
+            // Skip-and-continue: the scan moves on to the next package, so this is an
+            // expected-shape event (a missing/unreadable package), not a registration
+            // failure - logged at WARNING and never forwarded to the UltiPanel dashboard
+            // (D-24).
+            LOGGER.log(Level.WARNING, "Failed to scan package: " + basePackage, e);
         }
     }
 
@@ -118,7 +125,8 @@ public class ComponentScanner {
                 }
             }
         } catch (IOException e) {
-            System.err.println("Failed to scan JAR for package: " + basePackage + ", " + e.getMessage());
+            // Skip-and-continue: the scan moves on to the next package (D-24).
+            LOGGER.log(Level.WARNING, "Failed to scan JAR for package: " + basePackage, e);
         }
     }
 
@@ -287,8 +295,10 @@ public class ComponentScanner {
                 List<String> violations = CmdTargetComposition.check(clazz);
                 if (!violations.isEmpty()) {
                     for (String violation : violations) {
-                        System.err.println("Refused to register command class due to ambiguous "
-                                + "@CmdTarget composition: " + violation);
+                        // A refusal is a registration failure (SEVERE), even though there is no
+                        // exception object to attach - the class was refused, not merely skipped.
+                        LOGGER.log(Level.SEVERE, "Refused to register command class due to "
+                                + "ambiguous @CmdTarget composition: " + violation);
                     }
                     return;
                 }
@@ -297,7 +307,8 @@ public class ComponentScanner {
             BeanDefinition definition = new BeanDefinition(clazz, beanName);
             container.registerBeanDefinition(beanName, definition);
         } catch (Exception e) {
-            System.err.println("Failed to register component: " + clazz.getName() + ", " + e.getMessage());
+            // A registration failure, not a skip - reported to the panel (D-24).
+            LOGGER.log(Level.SEVERE, "Failed to register component: " + clazz.getName(), e);
         }
     }
 
@@ -319,7 +330,8 @@ public class ComponentScanner {
                 }
             }
         } catch (Exception e) {
-            System.err.println("Failed to register configuration: " + clazz.getName() + ", " + e.getMessage());
+            // A registration failure, not a skip - reported to the panel (D-24).
+            LOGGER.log(Level.SEVERE, "Failed to register configuration: " + clazz.getName(), e);
         }
     }
 
@@ -335,7 +347,8 @@ public class ComponentScanner {
             String beanName = method.getName();
             container.registerSingleton(beanName, bean);
         } catch (Exception e) {
-            System.err.println("Failed to process bean method: " + method.getName() + ", " + e.getMessage());
+            // A registration failure, not a skip - reported to the panel (D-24).
+            LOGGER.log(Level.SEVERE, "Failed to process bean method: " + method.getName(), e);
         }
     }
 

--- a/src/main/java/com/ultikits/ultitools/context/ComponentScanner.java
+++ b/src/main/java/com/ultikits/ultitools/context/ComponentScanner.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.JarURLConnection;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.jar.JarEntry;
@@ -356,6 +357,13 @@ public class ComponentScanner {
                     processBeanMethod(configInstance, method);
                 }
             }
+        } catch (ContainerException e) {
+            // A malformed @Bean name/value declaration (D-02/D-06) or a hard failure inside
+            // registerSingleton (an unresolvable required @Autowired dependency, D-08, or an AOP
+            // annotation registerSingleton can never honour, D-15) must abort the module's scan
+            // like every other ContainerException (D-25) -- not be caught here and demoted to an
+            // ordinary logged-and-skipped registration failure.
+            throw e;
         } catch (Exception e) {
             // A registration failure, not a skip - reported to the panel (D-24).
             LOGGER.log(Level.SEVERE, "Failed to register configuration: " + clazz.getName(), e);
@@ -364,19 +372,114 @@ public class ComponentScanner {
 
     /**
      * Process @Bean method.
+     * <p>
+     * The bean name is derived from {@code @Bean}'s {@code name()}/{@code value()} (D-06) via
+     * {@link #resolveBeanNames(Method)}, falling back to the method's own name exactly as before
+     * this attribute took effect. The <b>first</b> resolved name is registered through
+     * {@link SimpleContainer#registerSingleton(String, Object)}, which fully assembles the
+     * instance (D-14); any remaining names are bound as aliases to that <em>same, already
+     * assembled</em> reference via the package-visible
+     * {@link SimpleContainer#addSingleton(String, Object)} -- deliberately not a second
+     * {@code registerSingleton} call per name, which after D-14 would re-run autowiring and
+     * {@code @PostConstruct} once per alias on what should be one bean.
      * <br>
      * 处理@Bean方法。
+     * <p>
+     * Bean 名称通过 {@link #resolveBeanNames(Method)} 从 {@code @Bean} 的 {@code name()}/
+     * {@code value()} 派生（D-06），缺省时回退到方法自身的名称，与该属性生效前的行为一致。解析出的
+     * <b>第一个</b>名称通过 {@link SimpleContainer#registerSingleton(String, Object)} 注册，
+     * 该方法会完整装配实例（D-14）；其余名称则通过包内可见的
+     * {@link SimpleContainer#addSingleton(String, Object)} 绑定到<em>同一个已装配完成</em>的引用
+     * 上——刻意不对每个名称都调用一次 {@code registerSingleton}，因为在 D-14 之后那样做会让一个
+     * Bean 的自动装配与 {@code @PostConstruct} 按别名数量重复执行。
      */
     private void processBeanMethod(Object configInstance, Method method) {
         try {
             method.setAccessible(true);
             Object bean = method.invoke(configInstance);
-            String beanName = method.getName();
-            container.registerSingleton(beanName, bean);
+            String[] beanNames = resolveBeanNames(method);
+            String primaryName = beanNames[0];
+            container.registerSingleton(primaryName, bean);
+            if (beanNames.length > 1) {
+                Object assembled = container.getBean(primaryName);
+                for (int i = 1; i < beanNames.length; i++) {
+                    container.addSingleton(beanNames[i], assembled);
+                }
+            }
+        } catch (ContainerException e) {
+            // A malformed @Bean name/value declaration (D-02/D-06) or a hard failure inside
+            // registerSingleton (D-08/D-15) must abort the module's scan, not be demoted to an
+            // ordinary registration failure (D-25).
+            throw e;
         } catch (Exception e) {
             // A registration failure, not a skip - reported to the panel (D-24).
             LOGGER.log(Level.SEVERE, "Failed to process bean method: " + method.getName(), e);
         }
+    }
+
+    /**
+     * Resolve the effective bean-name array for a {@code @Bean} method (D-06): {@code name()} if
+     * non-empty, else {@code value()} if non-empty, else the method's own name as a
+     * single-element array. {@code name()} and {@code value()} are mutual aliases -- declaring
+     * both with different content is a malformed declaration and hard-fails naming the method
+     * and both declared values, reusing the same {@link ContainerException#malformedAliasFor}
+     * factory (and therefore the same message shape) plan 03-01 built for malformed
+     * {@code @AliasFor} declarations, even though {@code @Bean} itself deliberately does not
+     * declare a real {@code @AliasFor} between its two attributes (see this method's own class's
+     * scope boundary). Declaring both with identical content is legal. Every resolved element
+     * must be non-blank -- a blank or whitespace-only element is also a malformed declaration,
+     * because a name that cannot name anything is not a usable third state between "declared" and
+     * "absent" (D-02). No element is normalized: two names differing only by Unicode
+     * normalization form are two distinct declared names, decided purely by
+     * {@code String.equals}.
+     * <br>
+     * 为一个 {@code @Bean} 方法解析有效的 Bean 名称数组（D-06）：{@code name()} 非空则使用它，
+     * 否则 {@code value()} 非空则使用它，否则回退到方法自身的名称作为单元素数组。{@code name()}
+     * 与 {@code value()} 互为别名——两者都非空且内容不同即为畸形声明，会导致加载失败，错误信息
+     * 同时指出该方法与两个已声明的值，复用了 03-01 为畸形 {@code @AliasFor}
+     * 声明构建的同一个 {@link ContainerException#malformedAliasFor} 工厂（因此消息形态一致），
+     * 尽管 {@code @Bean} 自身刻意不在两个属性之间声明真正的 {@code @AliasFor}
+     * （见本方法所在类的 scope boundary）。两者内容相同则合法。解析出的每个元素都必须非空白——
+     * 空白或仅由空白字符组成的元素同样是畸形声明，因为一个无法命名任何东西的名称，不是"已声明"
+     * 与"缺省"之间可用的第三种状态（D-02）。不对任何元素做归一化：两个仅在 Unicode
+     * 规范化形式上不同的名称，是两个不同的已声明名称，纯粹由 {@code String.equals} 决定。
+     *
+     * @param method the {@code @Bean}-annotated factory method <br> 携带 {@code @Bean} 的工厂方法
+     * @return the resolved name array; index 0 is the registered bean name, the rest are aliases
+     *         <br> 解析出的名称数组；索引 0 是注册的 Bean 名称，其余是别名
+     */
+    private String[] resolveBeanNames(Method method) {
+        Bean beanAnnotation = method.getAnnotation(Bean.class);
+        String[] name = beanAnnotation.name();
+        String[] value = beanAnnotation.value();
+
+        if (name.length > 0 && value.length > 0 && !Arrays.equals(name, value)) {
+            throw ContainerException.malformedAliasFor(Bean.class, "name",
+                    "@Bean method '" + method.getName() + "' declares both name=" + Arrays.toString(name)
+                            + " and value=" + Arrays.toString(value) + " with different content -- "
+                            + "name() and value() are mutual aliases and must agree, or only one "
+                            + "should be declared");
+        }
+
+        String[] resolved;
+        if (name.length > 0) {
+            resolved = name;
+        } else if (value.length > 0) {
+            resolved = value;
+        } else {
+            resolved = new String[]{method.getName()};
+        }
+
+        for (int i = 0; i < resolved.length; i++) {
+            String candidate = resolved[i];
+            if (candidate == null || candidate.trim().isEmpty()) {
+                throw ContainerException.malformedAliasFor(Bean.class, "name",
+                        "@Bean method '" + method.getName() + "' declares a blank or whitespace-only "
+                                + "name element at index " + i + " of " + Arrays.toString(resolved));
+            }
+        }
+
+        return resolved;
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/context/ComponentScanner.java
+++ b/src/main/java/com/ultikits/ultitools/context/ComponentScanner.java
@@ -119,8 +119,13 @@ public class ComponentScanner {
                     try {
                         Class<?> clazz = classLoader.loadClass(className);
                         processClass(clazz);
-                    } catch (ClassNotFoundException | NoClassDefFoundError e) {
-                        // Ignore and continue
+                    } catch (ClassNotFoundException | LinkageError e) {
+                        // Skip-and-continue: the rest of the package still registers (D-25,
+                        // D-26). LinkageError covers NoClassDefFoundError,
+                        // UnsupportedClassVersionError and ExceptionInInitializerError with one
+                        // clause - the same union scanDirectory uses below, so the same missing
+                        // class behaves identically on both scan modes.
+                        LOGGER.log(Level.WARNING, "Failed to load scanned class: " + className, e);
                     }
                 }
             }
@@ -146,8 +151,12 @@ public class ComponentScanner {
                     try {
                         Class<?> clazz = classLoader.loadClass(className);
                         processClass(clazz);
-                    } catch (ClassNotFoundException e) {
-                        // Ignore and continue
+                    } catch (ClassNotFoundException | LinkageError e) {
+                        // Skip-and-continue: the rest of the package still registers (D-25,
+                        // D-26). Same union as scanJar's per-class catch above - the same
+                        // missing/unlinkable class must behave identically on both scan modes,
+                        // rather than one skipping a class and the other killing the package.
+                        LOGGER.log(Level.WARNING, "Failed to load scanned class: " + className, e);
                     }
                 }
             }
@@ -156,8 +165,26 @@ public class ComponentScanner {
 
     /**
      * Process a class for component annotations.
+     * <p>
+     * Propagation rule (D-25), stated once here rather than duplicated at each per-class call
+     * site in {@code scanJar}/{@code scanDirectory}: {@link ContainerException} is the single
+     * type that propagates unconditionally out of this method and aborts the module's scan --
+     * every other exception thrown while registering an individual class is logged and that one
+     * class is skipped, and the rest of the package still registers. One type name is the whole
+     * rule, so no allowlist has to be kept in sync. The two deliberate {@code ContainerException}
+     * throws today are the {@code @Final} contract violation below and a malformed
+     * {@code @AliasFor} declaration surfaced by {@link MergedAnnotationResolver} during the same
+     * scan; neither may ever be caught by a blanket handler.
      * <br>
      * 处理类的组件注解。
+     * <p>
+     * 传播规则（D-25），在此统一声明一次，而不是在 {@code scanJar}/{@code scanDirectory}
+     * 各自的逐类调用点重复：{@link ContainerException} 是唯一会无条件穿透本方法、中止模块扫描的
+     * 类型；注册单个类时抛出的其他任何异常都会被记录，仅跳过该类，包内其余类照常注册。规则就是
+     * 这一个类型名，因此无需维护任何白名单。当前两处刻意抛出 {@code ContainerException}
+     * 的地方分别是下方的 {@code @Final} 契约违规检查，以及同一次扫描中由
+     * {@link MergedAnnotationResolver} 发现的畸形 {@code @AliasFor} 声明；两者都绝不能被任何
+     * 万能捕获吞掉。
      */
     private void processClass(Class<?> clazz) {
         // The @Final contract is checked before anything else, including @ConditionalOnConfig:

--- a/src/main/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluator.java
+++ b/src/main/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluator.java
@@ -1,0 +1,98 @@
+package com.ultikits.ultitools.context;
+
+import java.io.File;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
+import com.ultikits.ultitools.annotations.ConditionalOnConfig;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * The single shared {@code @ConditionalOnConfig} registration decision (D-17).
+ * <p>
+ * Both {@link ComponentScanner} (the IoC-scan path) and {@code ListenerManager}'s
+ * reflective package-scan overload consult this evaluator, so the annotation is honoured
+ * identically wherever it is read instead of each caller carrying its own copy of the
+ * decision that can drift out of sync with the other.
+ * <br>
+ * 唯一共享的 {@code @ConditionalOnConfig} 注册判定逻辑（D-17）。{@link ComponentScanner}
+ * （IoC 扫描路径）与 {@code ListenerManager} 的反射式包扫描重载都调用此判定器，从而在所有读取该
+ * 注解的地方保持一致的行为，而不是让每个调用方各自维护一份可能逐渐产生差异的逻辑副本。
+ *
+ * @since 6.3.0
+ */
+@ApiStatus.Internal
+public final class ConditionalRegistrationEvaluator {
+
+    private static final Logger LOGGER =
+            Logger.getLogger(ConditionalRegistrationEvaluator.class.getName());
+
+    private ConditionalRegistrationEvaluator() {
+    }
+
+    /**
+     * Check if a class should be registered based on {@code @ConditionalOnConfig}.
+     * <p>
+     * The two "the decision cannot be determined" branches stay fail-open -- a component
+     * that should have been enabled but was not is harder to diagnose than the reverse --
+     * but each now emits a {@code Level.WARNING} record naming the evaluated class and the
+     * reason, rather than silently registering by default (D-20). The config-file-missing
+     * branch is unaffected: it returns {@code condition.negate()}, i.e. missing means
+     * disabled, which already matches the annotation's own javadoc.
+     * <br>
+     * 根据 {@code @ConditionalOnConfig} 检查类是否应被注册。
+     * <p>
+     * 两条"无法判定"分支仍然保持放行（fail-open）——一个本应启用却被静默禁用的组件，比反过来更
+     * 难排查——但现在各自会发出一条命名了被判定类与原因的 {@code Level.WARNING} 记录，而不是
+     * 悄悄按默认值注册（D-20）。配置文件缺失分支不受影响：仍然返回 {@code condition.negate()}，
+     * 即"缺失即禁用"，这与该注解自身的 javadoc 已经一致。
+     *
+     * @param clazz     the class to check <br> 待检查的类
+     * @param container the container used to resolve the owning {@link UltiToolsPlugin} <br>
+     *                  用于解析所属插件的容器
+     * @return true if the class should be registered <br> 若应注册该类则返回 true
+     */
+    public static boolean shouldRegister(Class<?> clazz, SimpleContainer container) {
+        ConditionalOnConfig condition = clazz.getAnnotation(ConditionalOnConfig.class);
+        if (condition == null) {
+            return true;
+        }
+
+        // Retrieve the plugin from the container
+        UltiToolsPlugin plugin = null;
+        try {
+            plugin = container.getBean(UltiToolsPlugin.class);
+        } catch (Exception e) {
+            // No plugin in container — skip conditional (register by default), but say so:
+            // a component that should have been enabled and was silently skipped is harder to
+            // diagnose than the reverse (D-20).
+            LOGGER.log(Level.WARNING, "@ConditionalOnConfig on " + clazz.getName()
+                    + " could not be evaluated: no UltiToolsPlugin could be resolved from the "
+                    + "container (" + e.getMessage() + "). Registering by default (fail-open).");
+            return true;
+        }
+
+        if (plugin == null || plugin.getResourceFolderPath() == null) {
+            LOGGER.log(Level.WARNING, "@ConditionalOnConfig on " + clazz.getName()
+                    + " could not be evaluated: " + (plugin == null
+                    ? "no UltiToolsPlugin instance was resolved from the container"
+                    : "the plugin's resource folder path is null")
+                    + ". Registering by default (fail-open).");
+            return true;
+        }
+
+        // Load the referenced config file from the plugin's config folder
+        File configFile = new File(plugin.getResourceFolderPath(), condition.value());
+        if (!configFile.exists()) {
+            // Config file doesn't exist yet — feature disabled
+            return condition.negate();
+        }
+
+        YamlConfiguration yaml = YamlConfiguration.loadConfiguration(configFile);
+        boolean value = yaml.getBoolean(condition.path(), false);
+        return condition.negate() ? !value : value;
+    }
+}

--- a/src/main/java/com/ultikits/ultitools/context/ContextConfig.java
+++ b/src/main/java/com/ultikits/ultitools/context/ContextConfig.java
@@ -1,11 +1,18 @@
 package com.ultikits.ultitools.context;
 
-import com.ultikits.ultitools.annotations.ComponentScan;
 import com.ultikits.ultitools.annotations.Configuration;
 import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * Marker configuration class for the framework's own context. It no longer declares a scan:
+ * the scan declaration this class used to carry was removed in 6.3.0 because nothing ever
+ * invoked {@link SimpleContainer#processConfigurationClass} against it in production - only
+ * tests did (see {@code FinalContractValidator}'s "Known gaps" javadoc for the full story).
+ * <br>
+ * 框架自身上下文的标记配置类，不再声明扫描：本类曾经携带的扫描声明已在 6.3.0 移除，因为生产环境
+ * 中从未有代码对它调用过 {@link SimpleContainer#processConfigurationClass}——只有测试会调用它。
+ */
 @Configuration
-@ComponentScan("com.ultikits.ultitools")
 @ApiStatus.Internal
 public class ContextConfig {
 }

--- a/src/main/java/com/ultikits/ultitools/context/ContextHolder.java
+++ b/src/main/java/com/ultikits/ultitools/context/ContextHolder.java
@@ -1,5 +1,7 @@
 package com.ultikits.ultitools.context;
 
+import org.jetbrains.annotations.ApiStatus;
+
 /**
  * Static holder for accessing the current IoC container context.
  * <p>
@@ -12,6 +14,7 @@ package com.ultikits.ultitools.context;
  * @author wisdomme
  * @since 6.2.0
  */
+@ApiStatus.Internal
 public class ContextHolder {
 
     private static volatile SimpleContainer context;

--- a/src/main/java/com/ultikits/ultitools/context/FinalContractValidator.java
+++ b/src/main/java/com/ultikits/ultitools/context/FinalContractValidator.java
@@ -4,9 +4,16 @@ import com.ultikits.ultitools.annotations.Final;
 import com.ultikits.ultitools.aop.ProxyFactory;
 import com.ultikits.ultitools.utils.ReflectionUtil;
 
+import org.jetbrains.annotations.ApiStatus;
+
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -24,54 +31,44 @@ import java.util.logging.Logger;
  * module's declared {@code @UltiToolsModule(scanBasePackages)}, else a {@code @ComponentScan} on
  * the plugin class, else the plugin class's own package. A module that declares neither annotation
  * is still checked - it falls back to its own package rather than dropping out of scanning
- * entirely. The framework's own classes are <b>not</b> checked in production: {@code ContextConfig}
- * declares {@code @ComponentScan("com.ultikits.ultitools")}, but the only thing that acts on that
- * declaration, {@link SimpleContainer#processConfigurationClass(Class)}, has no caller anywhere in
+ * entirely. The framework's own classes are <b>not</b> checked in production: nothing ever invokes
+ * {@link ComponentScanner} against {@code com.ultikits.ultitools} itself. {@code ContextConfig}
+ * used to declare {@code @ComponentScan("com.ultikits.ultitools")} for exactly that purpose, but
+ * the declaration was removed in 6.3.0 because the only thing that would have acted on it,
+ * {@link SimpleContainer#processConfigurationClass(Class)}, had no caller anywhere in
  * {@code src/main} - it is invoked only from tests ({@code ContextConfigTest}, {@code ScanTest}).
  * A plugin module's class is unchecked if it sits outside whichever package that module's own scan
  * actually reaches; a framework class is unchecked unconditionally today.
  * <p>
- * The method-level check is also deliberately <b>non-transitive</b>: it walks from {@code clazz}
- * straight to each ancestor's own declaration and stops at the first ancestor whose declaration is
- * {@code @Final}, so a widening override interposed between them can defeat it. Concretely, if
- * {@code x.A} declares a package-private {@code @Final m()}, a same-package {@code x.B} widens it
- * to {@code public m()} (a genuine override), and {@code y.C} overrides {@code B.m()}, then
- * {@code validate(C)} walks past {@code B.m()} - it is not {@code @Final} - reaches {@code A.m()},
- * and {@code ReflectionUtil.overrides(C.m(), A.m())} is {@code false} because {@code C} and
- * {@code A} are in different packages, so no violation is reported for {@code C}. This is
- * acceptable because the gap can only exist once {@code @Final} has already been bypassed one class
- * earlier: for {@code B} to widen {@code A}'s method at all, {@code B} must sit in {@code A}'s own
- * package, and {@code validate(B)} - run whenever {@code B} is inside the scanned package set -
- * already catches that direct override, since {@code B} and {@code A} share a package and
- * {@code ReflectionUtil.overrides(B.m(), A.m())} is {@code true} there. {@code C} is only ever
- * downstream of a bypass that {@code validate(B)} already reported.
+ * The method-level check is transitive: it accumulates the chain of declarations that actually
+ * override one another - per {@link ReflectionUtil#overrides(Method, Method)}, the single
+ * implementation of JLS 8.4.8.1 this class shares with {@link ReflectionUtil#getAllMethods(Class)}
+ * - rather than comparing {@code clazz}'s own declaration directly against each ancestor. A
+ * widening override interposed between {@code clazz} and a {@code @Final} ancestor no longer
+ * defeats the check, and the walk also follows implemented interfaces, not only the superclass
+ * chain, so a {@code @Final} default method or a {@code @Final} interface is enforced too.
  * <p>
  * 该校验在类加载期恢复 {@code @Final} 的约束。框架加载全部模块，因此跨模块有效。
  * 但它不在编译期生效；覆盖范围严格等于组件扫描实际走到的类。对插件模块而言，这个范围来自
  * {@code PluginManager#getPluginScanPackages} 的三层回退：模块声明的
  * {@code @UltiToolsModule(scanBasePackages)}，其次插件类上的 {@code @ComponentScan}，都未声明
  * 则默认扫插件类自己所在的包——两个注解都不声明的模块依然会被检查，只是回退到自己的包，而不是
- * 完全跳出扫描。框架自身的类在生产环境中<b>不会</b>被检查：{@code ContextConfig} 虽然声明了
- * {@code @ComponentScan("com.ultikits.ultitools")}，但唯一会处理这个声明的
- * {@code SimpleContainer#processConfigurationClass}，在 {@code src/main} 里没有任何调用方——
- * 只有测试（{@code ContextConfigTest}、{@code ScanTest}）会调用它。对插件模块而言，类只要落在
- * 自己扫描实际到达的包之外就不受检查；而框架自身的类，目前无条件地不受检查。
+ * 完全跳出扫描。框架自身的类在生产环境中<b>不会</b>被检查：从未有代码对
+ * {@code com.ultikits.ultitools} 自身发起过 {@link ComponentScanner} 扫描。{@code ContextConfig}
+ * 曾经为此声明 {@code @ComponentScan("com.ultikits.ultitools")}，但唯一会处理这个声明的
+ * {@link SimpleContainer#processConfigurationClass(Class)} 在 {@code src/main} 里没有任何调用方，
+ * 该声明因此在 6.3.0 被移除——只有测试（{@code ContextConfigTest}、{@code ScanTest}）会调用它。
+ * 对插件模块而言，类只要落在自己扫描实际到达的包之外就不受检查；而框架自身的类，目前无条件地
+ * 不受检查。
  * <p>
- * 方法级检查同样刻意<b>不具备传递性</b>：它从 {@code clazz} 直接走到每一层祖先自己的声明，遇到
- * 第一个声明为 {@code @Final} 的祖先方法就停下，中间插入一次放宽访问权限的重写就能绕过它。具体
- * 来说：若 {@code x.A} 声明包私有的 {@code @Final m()}，同包的 {@code x.B} 把它放宽为
- * {@code public m()}（这是一次真正的重写），而 {@code y.C} 又重写了 {@code B.m()}，那么
- * {@code validate(C)} 会跳过非 {@code @Final} 的 {@code B.m()}，一路走到 {@code A.m()}，此时
- * {@code ReflectionUtil.overrides(C.m(), A.m())} 因为 {@code C} 与 {@code A} 不同包而返回
- * {@code false}，于是不会为 {@code C} 报告任何违规。这是可以接受的：这个空子只有在 {@code @Final}
- * 已经在上一层被绕过之后才存在——{@code B} 要放宽 {@code A} 的方法，前提就是 {@code B} 与
- * {@code A} 同包，而只要 {@code B} 落在被扫描的包范围内，{@code validate(B)} 就已经会直接抓到这次
- * 重写本身（{@code B} 与 {@code A} 同包，{@code ReflectionUtil.overrides(B.m(), A.m())} 为
- * {@code true}）。{@code C} 只是绕在一次早已被 {@code validate(B)} 报告过的违规下游而已。
+ * 方法级检查具备传递性：通过 {@link ReflectionUtil#overrides(Method, Method)} 累积真正构成覆盖链的
+ * 声明，而不是只拿 {@code clazz} 自身声明与每一层祖先直接比较；遍历同时沿接口向上走，因此
+ * {@code @Final} 默认方法与 {@code @Final} 接口也在检查范围内。
  *
  * @author wisdomme
  * @since 6.3.0
  */
+@ApiStatus.Internal
 public final class FinalContractValidator {
 
     private static final Logger LOGGER = Logger.getLogger(FinalContractValidator.class.getName());
@@ -88,7 +85,7 @@ public final class FinalContractValidator {
      */
     public static List<String> validate(Class<?> clazz) {
         List<String> violations = new ArrayList<>();
-        if (clazz == null || clazz.isInterface() || clazz.isAnnotation() || clazz.isEnum()) {
+        if (clazz == null || clazz.isAnnotation() || clazz.isEnum()) {
             return violations;
         }
         // Proxies are generated by the container itself. @Final constrains module authors, not
@@ -107,6 +104,25 @@ public final class FinalContractValidator {
                     + ", which is annotated @Final and must not be extended. "
                     + "Remove the 'extends' clause, or drop @Final from the parent if extension "
                     + "is intended.");
+        }
+
+        // A @Final interface is rejected the same way a @Final superclass is - the only
+        // difference is the relation word: two interfaces "extend" each other, a class
+        // "implements" an interface. Modifier.isInterface(clazz.getModifiers()) decides which
+        // applies; a class's getInterfaces() lists the interfaces it directly implements, an
+        // interface's lists the interfaces it directly extends, so one loop covers both relations.
+        boolean clazzIsInterface = Modifier.isInterface(clazz.getModifiers());
+        String relation = clazzIsInterface ? "extends" : "implements";
+        String participle = clazzIsInterface ? "extended" : "implemented";
+        for (Class<?> iface : clazz.getInterfaces()) {
+            if (iface.isAnnotationPresent(Final.class)) {
+                violations.add(clazz.getName() + " " + relation + " " + iface.getName()
+                        + ", which is annotated @Final and must not be " + participle + ". "
+                        + "Remove the '" + relation + "' clause, or drop @Final from the "
+                        + (clazzIsInterface ? "parent interface" : "interface")
+                        + " if " + (clazzIsInterface ? "extension" : "implementation")
+                        + " is intended.");
+            }
         }
 
         // getDeclaredMethods() resolves every parameter and return type of every method it
@@ -142,8 +158,8 @@ public final class FinalContractValidator {
     }
 
     /**
-     * Walks up the hierarchy looking for a {@code @Final} method that {@code method} actually
-     * overrides.
+     * Walks the hierarchy looking for a {@code @Final} method that {@code method} transitively
+     * overrides, following both superclasses and implemented interfaces.
      * <p>
      * Matching on name and parameter types alone is not enough: a {@code private}, {@code static},
      * or cross-package package-private method in {@code clazz} that merely shares a signature with
@@ -159,28 +175,72 @@ public final class FinalContractValidator {
      * checks agree by construction rather than by two people independently getting the same JLS
      * rule right. See issue #190.
      * <p>
+     * The walk accumulates every declaration proven to be part of the override chain, starting
+     * from {@code method} itself, and tests a newly-found candidate against <b>every</b> member of
+     * that chain rather than only the most recently added one. A same-package widening override
+     * interposed between {@code clazz} and a package-private {@code @Final} ancestor is exactly
+     * the shape that requires this: comparing {@code method} directly against the {@code @Final}
+     * declaration fails the package check, but comparing the widening override (already in the
+     * chain because it was found first, one level up) against it succeeds, because that override
+     * genuinely shares a package with the {@code @Final} declaration.
+     * <p>
      * 按名称加参数类型匹配是不够的：{@code clazz} 中与祖先类的 {@code @Final} 方法签名相同的
      * {@code private}、{@code static} 或跨包包私有方法，根据 JLS 8.4.8.1 根本不构成重写。比较对称
      * 的签名 key 同样不够：覆盖是有方向的，key 比较会漏掉镜像的那一半——同包子类把祖先的包私有
      * {@code @Final} 方法放宽为 {@code public}，那是真正的覆盖，也正是 {@code @Final} 要禁止的。
      * 这里改用 {@link ReflectionUtil#overrides(Method, Method)}——该规则的唯一实现，与
-     * {@link ReflectionUtil#getAllMethods(Class)} 共用，让两处检查天然一致。
+     * {@link ReflectionUtil#getAllMethods(Class)} 共用，让两处检查天然一致。遍历会累积链条中已确认
+     * 的每一条声明，新候选需要与链条中的<b>每一条</b>已有声明比较，而不只是最近加入的一条。
      */
     private static Method findOverriddenSealedMethod(Class<?> clazz, Method method) {
-        for (Class<?> current = clazz.getSuperclass();
-             current != null && current != Object.class;
-             current = current.getSuperclass()) {
+        List<Method> chain = new ArrayList<>();
+        chain.add(method);
+        Set<Class<?>> visited = new HashSet<>();
+        Deque<Class<?>> toVisit = new ArrayDeque<>();
+        enqueueSupertypes(clazz, toVisit);
+
+        while (!toVisit.isEmpty()) {
+            Class<?> current = toVisit.poll();
+            if (current == null || current == Object.class || !visited.add(current)) {
+                continue;
+            }
             try {
                 Method candidate = current.getDeclaredMethod(method.getName(),
                         method.getParameterTypes());
-                if (candidate.isAnnotationPresent(Final.class)
-                        && ReflectionUtil.overrides(method, candidate)) {
-                    return candidate;
+                boolean overridesChainMember = false;
+                for (Method chained : chain) {
+                    if (ReflectionUtil.overrides(chained, candidate)) {
+                        overridesChainMember = true;
+                        break;
+                    }
+                }
+                if (overridesChainMember) {
+                    chain.add(candidate);
+                    if (candidate.isAnnotationPresent(Final.class)) {
+                        return candidate;
+                    }
                 }
             } catch (NoSuchMethodException ignored) {
-                // Not declared at this level; keep walking up.
+                // Not declared at this level; keep walking.
             }
+            enqueueSupertypes(current, toVisit);
         }
         return null;
+    }
+
+    /**
+     * Adds {@code from}'s direct superclass and directly implemented/extended interfaces to
+     * {@code queue}, so a caller doing a breadth-first walk reaches a {@code @Final} method
+     * declared on an interface of a superclass, not only one reachable through the superclass
+     * chain alone.
+     */
+    private static void enqueueSupertypes(Class<?> from, Deque<Class<?>> queue) {
+        Class<?> superclass = from.getSuperclass();
+        if (superclass != null) {
+            queue.add(superclass);
+        }
+        for (Class<?> iface : from.getInterfaces()) {
+            queue.add(iface);
+        }
     }
 }

--- a/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
+++ b/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
@@ -20,6 +20,8 @@ import com.ultikits.ultitools.annotations.ComponentScan;
 import com.ultikits.ultitools.annotations.PostConstruct;
 import com.ultikits.ultitools.annotations.PreDestroy;
 import com.ultikits.ultitools.annotations.Service;
+import com.ultikits.ultitools.exceptions.ContainerException;
+import com.ultikits.ultitools.exceptions.ErrorCode;
 import com.ultikits.ultitools.utils.ReflectionUtil;
 
 /**
@@ -682,6 +684,18 @@ public class SimpleContainer {
 
             LOGGER.fine("Successfully created bean: " + name);
             return bean;
+        } catch (ContainerException e) {
+            // A ContainerException raised deeper in bean creation (e.g. an unresolvable
+            // @Autowired(required = true) dependency, or a constructor-injection failure) is
+            // already a deliberate, correctly-typed refusal -- rethrow it unchanged instead of
+            // letting the catch-all below downgrade it to an anonymous RuntimeException. Mirrors
+            // ComponentScanner.scanPackage's own catch (ContainerException e) { throw e; }
+            // rethrow for the same reason: a refusal that is swallowed or re-typed upstream is
+            // indistinguishable from the silent no-op it replaces (D-08, D-09).
+            singletonFactories.remove(name);
+            earlySingletonObjects.remove(name);
+            LOGGER.log(Level.SEVERE, "Failed to create bean: " + name, e);
+            throw e;
         } catch (Exception e) {
             // Clean up caches on failure
             singletonFactories.remove(name);
@@ -712,14 +726,16 @@ public class SimpleContainer {
             }
         }
         if (bestConstructor == null) {
-            throw new RuntimeException("No constructor found for: " + beanClass.getName());
+            throw new ContainerException(ErrorCode.BEAN_CREATION_FAILED,
+                    "No constructor found for: " + beanClass.getName());
         }
         Class<?>[] paramTypes = bestConstructor.getParameterTypes();
         Object[] args = new Object[paramTypes.length];
         for (int i = 0; i < paramTypes.length; i++) {
             args[i] = getBean(paramTypes[i]);
             if (args[i] == null) {
-                throw new RuntimeException("Cannot resolve constructor parameter " + paramTypes[i].getName() +
+                throw new ContainerException(ErrorCode.DEPENDENCY_INJECTION_FAILED,
+                        "Cannot resolve constructor parameter " + paramTypes[i].getName() +
                     " for bean: " + beanClass.getName());
             }
         }
@@ -727,7 +743,8 @@ public class SimpleContainer {
         try {
             return bestConstructor.newInstance(args);
         } catch (Exception e) {
-            throw new RuntimeException("Failed to instantiate via constructor injection: " + beanClass.getName(), e);
+            throw new ContainerException(ErrorCode.BEAN_CREATION_FAILED,
+                    "Failed to instantiate via constructor injection: " + beanClass.getName(), e);
         }
     }
 

--- a/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
+++ b/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
@@ -28,11 +28,14 @@ import com.ultikits.ultitools.exceptions.ContainerException;
 import com.ultikits.ultitools.exceptions.ErrorCode;
 import com.ultikits.ultitools.utils.ReflectionUtil;
 
+import org.jetbrains.annotations.ApiStatus;
+
 /**
  * Simple dependency injection container to replace Spring ApplicationContext.
  * <br>
  * 简单的依赖注入容器，用于替换Spring ApplicationContext。
  */
+@ApiStatus.Internal
 public class SimpleContainer {
     private static final Logger LOGGER = Logger.getLogger(SimpleContainer.class.getName());
     

--- a/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
+++ b/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
@@ -185,11 +185,41 @@ public class SimpleContainer {
      * already a generated proxy ({@link ProxyFactory#isProxyClass}) is exempt -- it already honours
      * its own annotations, copied onto the generated subclass by {@code ProxyFactory} itself.
      * <p>
+     * <b>No circular-dependency support between two {@code registerSingleton}-registered objects
+     * (WR-02).</b> Unlike {@link #createBean}, this method does not add an early reference to
+     * {@link #singletonFactories}/{@link #earlySingletonObjects} before autowiring -- and, unlike
+     * {@code createBean}, it structurally cannot benefit from doing so. {@code createBean}'s early
+     * exposure works because the container itself triggers a dependency's construction lazily,
+     * recursively, inside the same call stack that is still assembling the bean that depends on
+     * it -- so an early, not-yet-autowired self-reference can be handed back partway through. A
+     * {@code registerSingleton} caller, by contrast, hands in an object the caller already fully
+     * constructed <em>outside</em> the container; the container never constructs it and has no
+     * hook to trigger construction of a second, not-yet-registered object on the first one's
+     * behalf. Concretely: if object A and object B are registered via two separate, sequential
+     * {@code registerSingleton} calls and each has an {@code @Autowired} field pointing at the
+     * other, A's autowiring runs while B does not exist in this container in any form yet (no
+     * definition, no factory, nothing) -- there is nothing an early-reference mechanism could
+     * expose. A's field then either throws (if {@code required = true}) or stays {@code null} (if
+     * {@code required = false}); B, registered second, resolves normally since A already exists by
+     * then. This is reachable by an ordinary module author writing two {@code @Bean} methods (or a
+     * {@code @Configuration} class and one of its own {@code @Bean} products) that reference each
+     * other, since both paths register their product via this method. Workarounds: order the two
+     * registrations so the one with the {@code required = true} field is registered second, use
+     * {@code @Autowired(required = false)} plus manual post-registration wiring, or -- where
+     * possible -- register the pair through component scanning instead
+     * ({@code @Service}/{@code @Component}), where {@link #createBean}'s three-level cache does
+     * apply.
+     * <p>
      * 注册单例实例，在存储前完成完整装配。运行与 {@link #createBean} 为容器自行构造的 Bean
      * 所执行的同一套顺序——postProcessBeforeInitialization -> autowireBean -> @PostConstruct ->
      * postProcessAfterInitialization——且无条件执行，与 {@link #refresh()} 是否已调用无关。
      * 当 {@code instance} 的类携带其永远无法生效的 {@code @Transactional} 或
      * {@code @ExceptionCatch}（方法级或类级）时直接拒绝注册（D-15）。
+     * 两个通过 registerSingleton 注册的对象之间不支持循环依赖（WR-02）：与 createBean 不同，
+     * 本方法在自动装配前不会向三级缓存暴露早期引用，且结构上也无法从中受益——createBean
+     * 的早期暴露之所以有效，是因为容器自己在同一调用栈内递归地、惰性地触发了依赖对象的构造；
+     * 而 registerSingleton 的调用方传入的是一个已经在容器之外完全构造好的对象，容器从未构造过
+     * 第二个对象，也没有任何钩子能代替它去触发第二个（尚未注册的）对象的构造。
      *
      * @param name instance name <br> 实例名称
      * @param instance instance object <br> 实例对象

--- a/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
+++ b/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1269,24 +1270,49 @@ public class SimpleContainer {
 
     /**
      * Process configuration class.
+     * <p>
+     * Reads {@code @ComponentScan} through {@link MergedAnnotationResolver#find} rather than a
+     * bare {@code configClass.getAnnotation(ComponentScan.class)} -- a class meta-annotated with
+     * {@code @UltiToolsModule} carries its {@code scanBasePackages()}/{@code
+     * scanBasePackageClasses()} values onto the merged {@code @ComponentScan} view via their
+     * {@code @AliasFor} declarations (D-01), which a bare lookup would miss entirely. The result
+     * is additive across {@code value()}, {@code basePackages()} and the packages named by
+     * {@code basePackageClasses()} -- in that declaration order, with duplicates collapsed to
+     * their first occurrence (GEN-06) -- not a first-match choice among them.
      * <br>
      * 处理配置类。
+     * <p>
+     * 通过 {@link MergedAnnotationResolver#find} 而非裸的
+     * {@code configClass.getAnnotation(ComponentScan.class)} 读取 {@code @ComponentScan}——一个
+     * 元注解了 {@code @UltiToolsModule} 的类，会通过其 {@code @AliasFor} 声明把
+     * {@code scanBasePackages()}/{@code scanBasePackageClasses()} 的值带入合并后的
+     * {@code @ComponentScan} 视图（D-01），裸查找会完全错过这一点。结果是在 {@code value()}、
+     * {@code basePackages()} 以及 {@code basePackageClasses()} 指名的包之间做累加——按此声明顺序，
+     * 重复项折叠为首次出现（GEN-06）——而不是在它们之间做首个匹配的选择。
      *
      * @param configClass configuration class <br> 配置类
      */
     public void processConfigurationClass(Class<?> configClass) {
-        ComponentScanner scanner = new ComponentScanner(this);
-        if (configClass.isAnnotationPresent(ComponentScan.class)) {
-            ComponentScan componentScan = configClass.getAnnotation(ComponentScan.class);
-            String[] basePackages = componentScan.value();
-            if (basePackages.length == 0) {
-                basePackages = componentScan.basePackages();
-            }
-            if (basePackages.length == 0) {
-                // Default to the package of the configuration class
-                basePackages = new String[]{configClass.getPackage().getName()};
-            }
-            scanner.scanPackages(basePackages);
+        ComponentScan merged = MergedAnnotationResolver.find(configClass, ComponentScan.class);
+        if (merged == null) {
+            return;
         }
+        LinkedHashSet<String> basePackages = new LinkedHashSet<>();
+        basePackages.addAll(Arrays.asList(merged.value()));
+        basePackages.addAll(Arrays.asList(merged.basePackages()));
+        for (Class<?> markerClass : merged.basePackageClasses()) {
+            // Class.getPackage() is null for an array type/primitive/void -- skip rather than
+            // fold a null entry into the scan set (T-03-31).
+            Package markerPackage = markerClass.getPackage();
+            if (markerPackage != null) {
+                basePackages.add(markerPackage.getName());
+            }
+        }
+        if (basePackages.isEmpty()) {
+            // Default to the package of the configuration class, exactly as before.
+            basePackages.add(configClass.getPackage().getName());
+        }
+        ComponentScanner scanner = new ComponentScanner(this);
+        scanner.scanPackages(basePackages.toArray(new String[0]));
     }
 }

--- a/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
+++ b/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -461,7 +462,10 @@ public class SimpleContainer {
         // Collect every assignable candidate in this container and order by @Service(priority)
         // descending, reusing getOrderedBeansOfType -- which had zero production callers before
         // this change (D-11) -- instead of writing a third ordering implementation. It already
-        // dedups a definition-backed singleton that has already been instantiated, and it reads
+        // dedups a definition-backed singleton that has already been instantiated, it
+        // identity-dedups a singleton registered under two names (e.g. DependenceManagers'
+        // TeleportService/NotificationService/EmailService, each aliased under a short name plus
+        // the interface FQN -- regression fixed after PR #352's real-machine UAT), and it reads
         // priority off each candidate's actual resolved instance class, so a proxied bean's
         // priority is read correctly: ProxyFactory copies the target's annotations onto the
         // generated subclass, and getServicePriority relies on that.
@@ -1194,7 +1198,29 @@ public class SimpleContainer {
      */
     public <T> List<T> getOrderedBeansOfType(Class<T> type) {
         Map<String, T> beans = getBeansOfType(type);
-        List<T> result = new ArrayList<>(beans.values());
+
+        // Identity-dedup before ordering: getBeansOfType() is keyed by bean NAME, so the same
+        // singleton instance registered under two names (e.g. DependenceManagers.initCoreServices()
+        // deliberately registers TeleportService/NotificationService/EmailService twice each --
+        // once under a short internal name, once under the interface's FQN, so both getBean(String)
+        // and getBean(Class) resolve it) appears as two separate map entries whose VALUES are the
+        // same object. Without this dedup, getBean(Class)'s ambiguity check below sees that one
+        // object twice and throws a false "ambiguous" error naming the same instance against
+        // itself (regression caught by real-machine UAT on PR #352).
+        //
+        // IdentityHashMap (== semantics), not a HashSet/equals()-based dedup: a bean may override
+        // equals()/hashCode(), and two DISTINCT instances of the same class that happen to be
+        // equal must still be counted as two separate candidates so the ambiguity check below can
+        // still refuse a genuine tie (SILENT-06 / this milestone's own success criterion). Only
+        // reference identity -- the same object reached through two names -- collapses to one.
+        Map<T, Boolean> seenByIdentity = new IdentityHashMap<>();
+        List<T> result = new ArrayList<>();
+        for (T bean : beans.values()) {
+            if (seenByIdentity.put(bean, Boolean.TRUE) == null) {
+                result.add(bean);
+            }
+        }
+
         result.sort((a, b) -> {
             int priorityA = getServicePriority(a.getClass());
             int priorityB = getServicePriority(b.getClass());

--- a/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
+++ b/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
@@ -390,10 +390,33 @@ public class SimpleContainer {
             return (T) bean;
         }
 
-        // Check bean definitions and create bean if found
+        // Check bean definitions and create bean if found -- but only take this shortcut for a
+        // genuine self-match. getBeanName(type) synthesizes a decapitalized default name when
+        // `type` carries no explicit @Component/@Service of its own -- for an INTERFACE (the
+        // exact case this by-type lookup exists for), that default is just "decapitalize the
+        // interface's own simple name". If an unrelated implementer happens to be registered
+        // under that exact name (an ordinary, Spring-idiomatic naming choice: e.g.
+        // @Service("notificationService") on some impl of NotificationService), returning it
+        // here unconditionally would bypass the priority/ambiguity adjudication below entirely,
+        // even when a strictly higher-priority implementer also exists (CR-01).
+        //
+        // Two cases are still trusted as a deliberate, specific request and skip adjudication,
+        // matching Spring's own precedent that a by-name resolution is more specific than a
+        // by-type one (DefaultListableBeanFactory#resolveNamedBean) -- but note Spring itself
+        // never derives that name from the requested TYPE the way getBeanName(type) does here;
+        // it only trusts a name the caller or the bean itself explicitly supplied:
+        //   1. `type` IS the registered class -- querying a concrete class by itself always
+        //      resolves to itself, exactly the exactNameMatchStillShortCircuits case.
+        //   2. `type` itself explicitly declares @Component/@Service(value = beanName) -- i.e.
+        //      beanName did NOT come from getBeanName's decapitalized-default fallback, but from
+        //      a real annotation on `type`. This is `type` naming its own registration, not an
+        //      unrelated class's registration happening to collide with a synthesized guess.
+        // Anything else falls through to the same candidate-set/priority adjudication every
+        // other by-type lookup goes through.
         String beanName = getBeanName(type);
         BeanDefinition definition = beanDefinitions.get(beanName);
-        if (definition != null) {
+        if (definition != null && type.isAssignableFrom(definition.getBeanClass())
+                && (definition.getBeanClass().equals(type) || declaresOwnBeanName(type))) {
             bean = getBean(beanName); // Use getBean(name) for thread-safe creation
             return (T) bean;
         }
@@ -595,6 +618,29 @@ public class SimpleContainer {
         // Default to simple class name with first letter lowercase
         String className = type.getSimpleName();
         return Character.toLowerCase(className.charAt(0)) + className.substring(1);
+    }
+
+    /**
+     * True iff {@code type} itself carries an explicit {@code @Component(value = ...)} or
+     * {@code @Service(value = ...)} name -- the same condition {@link #getBeanName(Class)} checks
+     * before falling back to a decapitalized-simple-name guess.
+     * <p>
+     * Used by {@link #getBean(Class)}'s by-name shortcut (CR-01) to tell a deliberate, specific
+     * request ("{@code type} declares this exact name as its own") apart from an accidental
+     * collision between an unrelated implementer's explicit bean name and an interface's
+     * synthesized default -- only the former is a genuine self-match that should skip the
+     * priority/ambiguity adjudication a few lines below.
+     *
+     * @param type the requested type to check
+     * @return true if {@code type} declares its own non-empty {@code @Component}/{@code @Service} name
+     */
+    private boolean declaresOwnBeanName(Class<?> type) {
+        Component component = type.getAnnotation(Component.class);
+        if (component != null && !component.value().isEmpty()) {
+            return true;
+        }
+        Service service = type.getAnnotation(Service.class);
+        return service != null && !service.value().isEmpty();
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
+++ b/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
@@ -160,6 +160,10 @@ public class SimpleContainer {
     public void registerSingleton(String name, Object instance) {
         addSingleton(name, instance);
         typeMappings.put(instance.getClass(), instance);
+        // A newly registered singleton may be a new candidate for some already-resolved
+        // interface/superclass type -- invalidate so the next getBean(Class) reconsiders it
+        // instead of returning a stale cached resolution (D-12).
+        invalidateResolvedTypeCache();
     }
 
     /**
@@ -619,6 +623,24 @@ public class SimpleContainer {
     public void registerBeanDefinition(String name, BeanDefinition definition) {
         beanDefinitions.put(name, definition);
         beanTypes.put(name, definition.getBeanClass());
+        // A newly registered bean definition may be a new candidate for some already-resolved
+        // interface/superclass type -- invalidate so the next getBean(Class) reconsiders it
+        // instead of returning a stale cached resolution (D-12).
+        invalidateResolvedTypeCache();
+    }
+
+    /**
+     * Invalidates the by-type assignability resolution cache ({@link #resolvedTypeCache}).
+     * <p>
+     * Called whenever a new bean definition or singleton is registered, so a subsequently
+     * registered implementation of an already-resolved type participates in the next
+     * adjudication instead of being masked by a resolution cached before it existed (D-12).
+     * Never touches {@link #typeMappings} -- that map holds author-declared bindings
+     * ({@code registerType}/{@code registerTypeSupplier}/{@code registerSingleton}'s own
+     * concrete-class binding), which must survive registration of unrelated beans.
+     */
+    private void invalidateResolvedTypeCache() {
+        resolvedTypeCache.clear();
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
+++ b/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
@@ -17,9 +17,13 @@ import java.util.logging.Logger;
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.annotations.Component;
 import com.ultikits.ultitools.annotations.ComponentScan;
+import com.ultikits.ultitools.annotations.ExceptionCatch;
 import com.ultikits.ultitools.annotations.PostConstruct;
 import com.ultikits.ultitools.annotations.PreDestroy;
 import com.ultikits.ultitools.annotations.Service;
+import com.ultikits.ultitools.annotations.Transactional;
+import com.ultikits.ultitools.aop.AopEligibility;
+import com.ultikits.ultitools.aop.ProxyFactory;
 import com.ultikits.ultitools.exceptions.ContainerException;
 import com.ultikits.ultitools.exceptions.ErrorCode;
 import com.ultikits.ultitools.utils.ReflectionUtil;
@@ -168,16 +172,30 @@ public class SimpleContainer {
      * reference {@code postProcessAfterInitialization} last returned -- not necessarily
      * {@code instance} itself, if a registered {@link BeanPostProcessor} substitutes it.
      * <p>
+     * <b>Refuses {@code instance} outright when its class carries {@code @Transactional} or
+     * {@code @ExceptionCatch} -- method-level or class-level -- that it can never honour (D-15).</b>
+     * A ByteBuddy proxy is the bean itself in this framework's design; there is no separate
+     * delegate target, so a proxy can never be retrofitted onto an object the caller already
+     * constructed. Before this refusal existed, the annotation was silently inert: the method ran
+     * completely unprotected/untransacted, with no signal anything was wrong. An instance that is
+     * already a generated proxy ({@link ProxyFactory#isProxyClass}) is exempt -- it already honours
+     * its own annotations, copied onto the generated subclass by {@code ProxyFactory} itself.
+     * <p>
      * 注册单例实例，在存储前完成完整装配。运行与 {@link #createBean} 为容器自行构造的 Bean
      * 所执行的同一套顺序——postProcessBeforeInitialization -> autowireBean -> @PostConstruct ->
      * postProcessAfterInitialization——且无条件执行，与 {@link #refresh()} 是否已调用无关。
+     * 当 {@code instance} 的类携带其永远无法生效的 {@code @Transactional} 或
+     * {@code @ExceptionCatch}（方法级或类级）时直接拒绝注册（D-15）。
      *
      * @param name instance name <br> 实例名称
      * @param instance instance object <br> 实例对象
-     * @throws com.ultikits.ultitools.exceptions.ContainerException if a required {@code @Autowired}
-     *         dependency on {@code instance} cannot be resolved (D-08)
+     * @throws com.ultikits.ultitools.exceptions.ContainerException if {@code instance}'s class
+     *         carries an AOP annotation it can never honour (D-15), or if a required
+     *         {@code @Autowired} dependency on it cannot be resolved (D-08)
      */
     public void registerSingleton(String name, Object instance) {
+        refuseIfAopAnnotated(instance);
+
         Object bean = instance;
         for (BeanPostProcessor processor : beanPostProcessors) {
             bean = processor.postProcessBeforeInitialization(bean, name);
@@ -194,6 +212,38 @@ public class SimpleContainer {
         // interface/superclass type -- invalidate so the next getBean(Class) reconsiders it
         // instead of returning a stale cached resolution (D-12).
         invalidateResolvedTypeCache();
+    }
+
+    /**
+     * Refuses {@code instance} when its class carries an AOP annotation
+     * ({@code @Transactional}/{@code @ExceptionCatch}) it can never honour (D-15).
+     * <p>
+     * A generated proxy ({@link ProxyFactory#isProxyClass}) is exempt -- it already honours its own
+     * annotations. Otherwise, method-level annotations are read via
+     * {@link AopEligibility#findAopAnnotatedMethods}, which deliberately omits class-level ones (see
+     * its own javadoc), so the class-level half is checked separately here -- omitting it would
+     * leave a class-level {@code @Transactional} silently inert, restating SILENT-10 rather than
+     * fixing it.
+     *
+     * @param instance the instance about to be registered
+     * @throws ContainerException naming the offending class and the annotated method (or
+     *         {@code "class-level"}) when a refusal applies
+     */
+    private void refuseIfAopAnnotated(Object instance) {
+        Class<?> clazz = instance.getClass();
+        if (ProxyFactory.isProxyClass(clazz)) {
+            return;
+        }
+        Set<Method> annotatedMethods = AopEligibility.findAopAnnotatedMethods(clazz);
+        if (!annotatedMethods.isEmpty()) {
+            Method offending = annotatedMethods.iterator().next();
+            throw ContainerException.aopAnnotationOnPreConstructedBean(clazz,
+                    offending.getDeclaringClass().getName() + "#" + offending.getName());
+        }
+        if (MergedAnnotationResolver.isPresent(clazz, Transactional.class)
+                || MergedAnnotationResolver.isPresent(clazz, ExceptionCatch.class)) {
+            throw ContainerException.aopAnnotationOnPreConstructedBean(clazz, "class-level");
+        }
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
+++ b/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
@@ -150,16 +150,46 @@ public class SimpleContainer {
     }
 
     /**
-     * Register a singleton instance.
-     * <br>
-     * 注册单例实例。
+     * Registers a singleton instance, fully assembling it before storage.
+     * <p>
+     * Runs the same {@code postProcessBeforeInitialization -> autowireBean -> @PostConstruct ->
+     * postProcessAfterInitialization} sequence {@link #createBean} runs for a container-constructed
+     * bean, in that order, before storing -- unconditionally, whether or not {@link #refresh()} has
+     * been called. Before 6.3.0 this method was two lines: {@code addSingleton} plus a type-mapping
+     * write, with no autowiring, no {@code @PostConstruct} invocation, and no
+     * {@link BeanPostProcessor} chain -- an object handed in through this method reached the
+     * container half-initialised. {@link #refresh()} only pre-instantiates non-lazy singleton
+     * <em>definitions</em> and never touches a {@code registerSingleton}-path object, so gating
+     * assembly on refresh state (as a narrower, window-guard fix would) would have left the config
+     * entities, the {@code @Configuration} instance, and the {@code @Bean} products -- all
+     * registered <em>before</em> {@code refresh()} runs -- exactly as uninjected as before (D-14).
+     * <p>
+     * The bean actually stored, and returned by a later {@link #getBean(String)}, is whichever
+     * reference {@code postProcessAfterInitialization} last returned -- not necessarily
+     * {@code instance} itself, if a registered {@link BeanPostProcessor} substitutes it.
+     * <p>
+     * 注册单例实例，在存储前完成完整装配。运行与 {@link #createBean} 为容器自行构造的 Bean
+     * 所执行的同一套顺序——postProcessBeforeInitialization -> autowireBean -> @PostConstruct ->
+     * postProcessAfterInitialization——且无条件执行，与 {@link #refresh()} 是否已调用无关。
      *
      * @param name instance name <br> 实例名称
      * @param instance instance object <br> 实例对象
+     * @throws com.ultikits.ultitools.exceptions.ContainerException if a required {@code @Autowired}
+     *         dependency on {@code instance} cannot be resolved (D-08)
      */
     public void registerSingleton(String name, Object instance) {
-        addSingleton(name, instance);
-        typeMappings.put(instance.getClass(), instance);
+        Object bean = instance;
+        for (BeanPostProcessor processor : beanPostProcessors) {
+            bean = processor.postProcessBeforeInitialization(bean, name);
+        }
+        getAutowireCapableBeanFactory().autowireBean(bean);
+        invokePostConstructMethods(bean);
+        for (BeanPostProcessor processor : beanPostProcessors) {
+            bean = processor.postProcessAfterInitialization(bean, name);
+        }
+
+        addSingleton(name, bean);
+        typeMappings.put(bean.getClass(), bean);
         // A newly registered singleton may be a new candidate for some already-resolved
         // interface/superclass type -- invalidate so the next getBean(Class) reconsiders it
         // instead of returning a stale cached resolution (D-12).

--- a/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
+++ b/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
@@ -561,6 +561,11 @@ public class SimpleContainer {
         beanPostProcessors.clear();
         currentlyCreating.clear();
         supplierTypes.clear();
+        // Release the by-type resolution cache too (WR-01): it holds both requested Class<?>
+        // keys and resolved bean-instance values loaded by this container's own classloader,
+        // exactly the kind of reference every other Class/instance-keyed collection above is
+        // cleared to stop pinning after a plugin unloads.
+        resolvedTypeCache.clear();
         isStarted = false;
         
         LOGGER.info("Container closed.");

--- a/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
+++ b/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
@@ -46,6 +46,13 @@ public class SimpleContainer {
     private final Map<String, Supplier<Object>> suppliers = new ConcurrentHashMap<>();
     private final Map<Class<?>, Object> typeMappings = new ConcurrentHashMap<>();
     private final Map<Class<?>, Supplier<Object>> typeSuppliers = new ConcurrentHashMap<>();
+    // By-type assignability resolution cache. Populated only by getBean(Class)'s ambiguity
+    // adjudication (D-11/D-12) -- distinct from typeMappings, which holds author-declared
+    // bindings (registerType/registerTypeSupplier/registerSingleton's own concrete-class
+    // binding). Kept separate so a newly registered implementation can invalidate this cache
+    // without dropping an explicit binding. Instance-scoped, not static: a static Class-keyed
+    // map would pin module classes and block plugin ClassLoader unload (Phase 1 D-35/D-38).
+    private final Map<Class<?>, Object> resolvedTypeCache = new ConcurrentHashMap<>();
     private final Map<String, BeanScope> beanScopes = new ConcurrentHashMap<>();
     private final Map<String, Class<?>> beanTypes = new ConcurrentHashMap<>();
     private final List<BeanPostProcessor> beanPostProcessors = new java.util.concurrent.CopyOnWriteArrayList<>();
@@ -303,30 +310,47 @@ public class SimpleContainer {
             return (T) bean;
         }
 
-        // Check bean definitions by assignability (interface/superclass → impl resolution)
-        for (Map.Entry<String, BeanDefinition> entry : beanDefinitions.entrySet()) {
-            if (type.isAssignableFrom(entry.getValue().getBeanClass())) {
-                bean = getBean(entry.getKey());
-                if (bean != null) {
-                    typeMappings.put(type, bean);
-                    return (T) bean;
-                }
+        // A prior assignability adjudication for this exact type, if one has already happened
+        // and no registration has invalidated it since (D-12).
+        bean = resolvedTypeCache.get(type);
+        if (bean != null) {
+            return (T) bean;
+        }
+
+        // Collect every assignable candidate in this container and order by @Service(priority)
+        // descending, reusing getOrderedBeansOfType -- which had zero production callers before
+        // this change (D-11) -- instead of writing a third ordering implementation. It already
+        // dedups a definition-backed singleton that has already been instantiated, and it reads
+        // priority off each candidate's actual resolved instance class, so a proxied bean's
+        // priority is read correctly: ProxyFactory copies the target's annotations onto the
+        // generated subclass, and getServicePriority relies on that.
+        List<T> candidates = getOrderedBeansOfType(type);
+
+        if (candidates.isEmpty()) {
+            // Total miss in this container -- only now is the parent consulted, so a child that
+            // has any candidates (even an ambiguous pair that goes on to throw) never falls
+            // through to a parent's unrelated bean (D-13).
+            if (parent != null) {
+                return parent.getBean(type);
+            }
+            return null;
+        }
+
+        if (candidates.size() > 1) {
+            // Only the top two matter: a tie further down the list, among beans that already
+            // lose to the top candidate, is not ambiguous.
+            T first = candidates.get(0);
+            T second = candidates.get(1);
+            if (getServicePriority(first.getClass()) == getServicePriority(second.getClass())) {
+                throw ContainerException.ambiguousBeanType(type, first.getClass(), second.getClass());
             }
         }
 
-        // Fallback: check all singletons by assignability (interface/superclass resolution)
-        for (Object singleton : singletonObjects.values()) {
-            if (type.isInstance(singleton)) {
-                typeMappings.put(type, singleton); // cache for next lookup
-                return (T) singleton;
-            }
-        }
-
-        if (parent != null) {
-            return parent.getBean(type);
-        }
-
-        return null;
+        // Adjudicate before caching: this is reached only once exactly one winner is
+        // determined -- either there was a single candidate, or priority broke the tie (D-12).
+        bean = candidates.get(0);
+        resolvedTypeCache.put(type, bean);
+        return (T) bean;
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/exceptions/ContainerException.java
+++ b/src/main/java/com/ultikits/ultitools/exceptions/ContainerException.java
@@ -150,4 +150,27 @@ public class ContainerException extends UltiToolsException {
                         + "object was created by the container rather than with 'new'. "
                         + "Use @Autowired(required = false) if the dependency really is optional.");
     }
+
+    /**
+     * Creates an exception for an ambiguous by-type bean resolution (D-11/D-12).
+     * <p>
+     * Two or more candidates assignable to the requested type share the highest
+     * {@code @Service(priority)} value, so {@code getBean(Class)} cannot determine which one
+     * the caller intended. Before this check existed, the ambiguity was resolved silently by
+     * whichever candidate the internal map iteration reached first, and that arbitrary choice
+     * was then cached permanently. The message names both tied candidate classes and the
+     * requested type, and points at {@code @Service(priority = ...)} as the remedy.
+     *
+     * @param requestedType the type that was requested via getBean(Class)
+     * @param first         the first tied candidate's class
+     * @param second        the second tied candidate's class
+     * @return a new ContainerException
+     */
+    public static ContainerException ambiguousBeanType(Class<?> requestedType, Class<?> first, Class<?> second) {
+        return new ContainerException(ErrorCode.AMBIGUOUS_BEAN_TYPE,
+                "Ambiguous bean resolution for type " + requestedType.getName() + ": both "
+                        + first.getName() + " and " + second.getName()
+                        + " are assignable candidates with equal @Service(priority). "
+                        + "Disambiguate with a higher @Service(priority = ...) on the intended bean.");
+    }
 }

--- a/src/main/java/com/ultikits/ultitools/exceptions/ContainerException.java
+++ b/src/main/java/com/ultikits/ultitools/exceptions/ContainerException.java
@@ -1,6 +1,7 @@
 package com.ultikits.ultitools.exceptions;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
 
 /**
  * Exception thrown when IoC container operations fail.
@@ -125,5 +126,28 @@ public class ContainerException extends UltiToolsException {
             String attribute, String reason) {
         return new ContainerException(ErrorCode.MALFORMED_ANNOTATION_ALIAS,
                 "Malformed @AliasFor on " + declaringAnnotation.getName() + "#" + attribute + "(): " + reason);
+    }
+
+    /**
+     * Creates an exception for an unresolvable {@code @Autowired(required = true)} field (D-08).
+     * <p>
+     * The message names both the dependency's type and the field's declaring class plus field
+     * name, and repeats the same actionable guidance the earlier warning-only diagnostic gave:
+     * check the target is annotated {@code @Service}/{@code @Component}, that it is inside the
+     * module's {@code scanBasePackages}, that the owning object was created by the container
+     * rather than with {@code new}, and that {@code @Autowired(required = false)} exists for
+     * genuinely optional dependencies.
+     *
+     * @param field the field whose dependency could not be resolved
+     * @return a new ContainerException
+     */
+    public static ContainerException requiredDependencyUnresolved(Field field) {
+        return new ContainerException(ErrorCode.DEPENDENCY_INJECTION_FAILED,
+                "@Autowired could not resolve " + field.getType().getName() + " for field "
+                        + field.getDeclaringClass().getName() + "." + field.getName()
+                        + " - check that the target class is annotated with @Service/@Component, "
+                        + "that it is inside the module's scanBasePackages, and that the owning "
+                        + "object was created by the container rather than with 'new'. "
+                        + "Use @Autowired(required = false) if the dependency really is optional.");
     }
 }

--- a/src/main/java/com/ultikits/ultitools/exceptions/ContainerException.java
+++ b/src/main/java/com/ultikits/ultitools/exceptions/ContainerException.java
@@ -173,4 +173,32 @@ public class ContainerException extends UltiToolsException {
                         + " are assignable candidates with equal @Service(priority). "
                         + "Disambiguate with a higher @Service(priority = ...) on the intended bean.");
     }
+
+    /**
+     * Creates an exception refusing to register, via {@code registerSingleton}, an instance whose
+     * class carries an AOP annotation ({@code @Transactional} or {@code @ExceptionCatch}) that can
+     * never take effect on it (D-15).
+     * <p>
+     * A ByteBuddy proxy is the bean itself in this framework's design -- there is no separate
+     * delegate target -- so a proxy can never be retrofitted onto an object the caller already
+     * constructed. Before this refusal existed, the annotation was silently inert: the method ran
+     * completely unprotected/untransacted, with no signal that anything was wrong. An instance that
+     * is already a generated proxy ({@code ProxyFactory.isProxyClass}) is never passed here -- it
+     * already honours its own annotations and is exempt from this check entirely.
+     *
+     * @param beanClass the class of the pre-constructed instance that was refused
+     * @param location  the offending method's {@code "ClassName#methodName"}, or the literal
+     *                  {@code "class-level"} when the annotation was found at class level
+     * @return a new ContainerException
+     */
+    public static ContainerException aopAnnotationOnPreConstructedBean(Class<?> beanClass, String location) {
+        return new ContainerException(ErrorCode.UNPROXYABLE_SINGLETON,
+                "Refusing to register " + beanClass.getName() + " via registerSingleton: it carries "
+                        + "an AOP annotation (@Transactional/@ExceptionCatch) at " + location
+                        + ", but this object was constructed outside the container. A ByteBuddy proxy "
+                        + "IS the bean in this framework's design, so it cannot be retrofitted onto an "
+                        + "already-constructed instance -- the annotation would otherwise be silently "
+                        + "inert. Declare " + beanClass.getName() + " as @Service or @Component so the "
+                        + "container constructs (and proxies) it instead.");
+    }
 }

--- a/src/main/java/com/ultikits/ultitools/exceptions/ErrorCode.java
+++ b/src/main/java/com/ultikits/ultitools/exceptions/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     DEPENDENCY_INJECTION_FAILED(2003, "Dependency injection failed"),
     DUPLICATE_BEAN(2004, "Duplicate bean definition"),
     MALFORMED_ANNOTATION_ALIAS(2005, "Malformed @AliasFor declaration"),
+    AMBIGUOUS_BEAN_TYPE(2006, "Ambiguous bean type resolution"),
 
     // ===== Data Access Errors (3000-3999) =====
     DATA_ACCESS_ERROR(3000, "Data access error"),

--- a/src/main/java/com/ultikits/ultitools/exceptions/ErrorCode.java
+++ b/src/main/java/com/ultikits/ultitools/exceptions/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     DUPLICATE_BEAN(2004, "Duplicate bean definition"),
     MALFORMED_ANNOTATION_ALIAS(2005, "Malformed @AliasFor declaration"),
     AMBIGUOUS_BEAN_TYPE(2006, "Ambiguous bean type resolution"),
+    UNPROXYABLE_SINGLETON(2007, "AOP annotation on a pre-constructed registerSingleton bean"),
 
     // ===== Data Access Errors (3000-3999) =====
     DATA_ACCESS_ERROR(3000, "Data access error"),

--- a/src/main/java/com/ultikits/ultitools/manager/ListenerManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/ListenerManager.java
@@ -4,6 +4,7 @@ import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.annotations.EventListener;
 import com.ultikits.ultitools.api.ExternalPluginAdapter;
+import com.ultikits.ultitools.context.ConditionalRegistrationEvaluator;
 import com.ultikits.ultitools.context.MergedAnnotationResolver;
 import com.ultikits.ultitools.utils.PackageScanUtils;
 import org.bukkit.Bukkit;
@@ -72,6 +73,9 @@ public class ListenerManager {
                 Objects.requireNonNull(plugin.getClass().getClassLoader())
         );
         for (Class<?> clazz : classes) {
+            if (!ConditionalRegistrationEvaluator.shouldRegister(clazz, plugin.getContext())) {
+                continue;
+            }
             try {
                 Listener listener = (Listener) clazz.getDeclaredConstructor().newInstance();
                 plugin.getContext().getAutowireCapableBeanFactory().autowireBean(listener);

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -254,6 +254,31 @@ public class PluginManager {
             pluginContext.setParent(UltiTools.getInstance().getDependenceManagers().getContext());
             pluginContext.registerShutdownHook();
             pluginContext.setClassLoader(classLoader);
+
+            // Register the plugin as UltiToolsPlugin type so services can inject it via
+            // constructor. Must run BEFORE scanComponents, mirroring initializePlugin's own
+            // T-03-27 fix: registerType writes the type registry directly and never goes through
+            // registerSingleton, so it is unaffected by full assembly (D-14) and does not need to
+            // move.
+            pluginContext.registerType(UltiToolsPlugin.class, plugin);
+
+            // Trigger component scanning to discover @CmdExecutor, @EventListener, @Service beans
+            // BEFORE the plugin instance itself is registered as a singleton below (WR-03). This
+            // overload had no scanComponents call at all until this fix -- unlike initializePlugin,
+            // it was never given the T-03-27 reordering, even though it registers the same kind of
+            // object through the same registerSingleton call two lines below.
+            String[] scanPackages = getPluginScanPackages(plugin.getClass());
+            if (scanPackages.length > 0) {
+                pluginContext.scanComponents(scanPackages);
+            }
+
+            // Register the plugin instance itself by name AFTER scanComponents, not before:
+            // registerSingleton now fully assembles its argument unconditionally (D-14), so
+            // registering the plugin instance before any @Service bean exists would attempt to
+            // autowire it against an empty bean graph -- an unresolvable
+            // @Autowired(required = true) field on the plugin's own class would then throw,
+            // turning a working module into one that cannot load. This is the exact ordering bug
+            // T-03-27 already fixed in initializePlugin; this overload had it too (WR-03).
             pluginContext.getBeanFactory().registerSingleton(plugin.getClass().getSimpleName(), plugin);
             DataScope scope = DataScope.forPlugin(plugin, scanPluginEntities(plugin.getPluginName(), plugin.getClass()));
             registerEntityOwnership(scope);

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1655,16 +1656,37 @@ public class PluginManager {
      * @return scan packages <br> 扫描包
      */
     private String[] getPluginScanPackages(Class<? extends UltiToolsPlugin> pluginClass) {
-        UltiToolsModule module = pluginClass.getAnnotation(UltiToolsModule.class);
-        if (module != null && module.scanBasePackages().length > 0) {
-            return module.scanBasePackages();
+        // Read through the merged resolver, not a bare pluginClass.getAnnotation(...) --
+        // @UltiToolsModule is meta-annotated @ComponentScan, and its scanBasePackages()/
+        // scanBasePackageClasses() attributes both declare @AliasFor onto ComponentScan's
+        // basePackages()/basePackageClasses(), so the merged instance already carries the
+        // module-level values (D-01). Measured: this replaces the old direct
+        // module.scanBasePackages() read entirely -- the merged resolution already covers it,
+        // so keeping a second hand-read alongside it would just be the per-site special-casing
+        // D-01 rejected, reintroduced one attribute later.
+        ComponentScan merged = MergedAnnotationResolver.find(pluginClass, ComponentScan.class);
+        // Additive, not first-match: every source that declares a non-empty value contributes
+        // packages, in declaration order, with duplicates collapsed to their first occurrence
+        // (GEN-06). The old first-match-wins shape silently dropped every source after the
+        // first non-empty one.
+        LinkedHashSet<String> scanPackages = new LinkedHashSet<>();
+        if (merged != null) {
+            Collections.addAll(scanPackages, merged.value());
+            Collections.addAll(scanPackages, merged.basePackages());
+            for (Class<?> markerClass : merged.basePackageClasses()) {
+                // Class.getPackage() is null for an array type/primitive/void -- skip rather
+                // than fold a null entry into the scan set (T-03-31).
+                Package markerPackage = markerClass.getPackage();
+                if (markerPackage != null) {
+                    scanPackages.add(markerPackage.getName());
+                }
+            }
         }
-        ComponentScan componentScan = pluginClass.getAnnotation(ComponentScan.class);
-        if (componentScan != null) {
-            if (componentScan.value().length > 0) return componentScan.value();
-            if (componentScan.basePackages().length > 0) return componentScan.basePackages();
+        if (scanPackages.isEmpty()) {
+            // Default to the package of the plugin class itself, exactly as before.
+            scanPackages.add(pluginClass.getPackage().getName());
         }
-        return new String[]{pluginClass.getPackage().getName()};
+        return scanPackages.toArray(new String[0]);
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -1154,19 +1154,28 @@ public class PluginManager {
      * a {@code DataStore} that can supply neither a {@code DataSource} nor its own
      * {@code TransactionManager} still declares {@code @Transactional} unavailable.
      * <p>
-     * <b>Scope limit 1 — {@code registerSingleton} bypasses this entirely.</b> Only beans the
-     * container constructs itself (through {@code registerBean} or component scanning) are ever
-     * offered to the resolver, because {@link AopProxyResolver#resolve(Class)} only runs on the
-     * constructor branch of bean creation. The plugin instance itself, an {@code @ContextEntry}
-     * bean (built by hand with reflection), config entities, {@code @Configuration} classes, and
-     * the beans their {@code @Bean} methods produce are all registered with
-     * {@code registerSingleton} instead, so none of them ever reach it:
-     * {@code @ExceptionCatch} on such a class stays a no-op, and {@code @Transactional} on it is
-     * silently allowed to run rather than rejected. Unlike the first three, {@code @Configuration}
-     * classes and {@code @Bean} methods are written by module authors rather than the framework,
-     * and they are also constructed before {@code wireAop} runs in {@code initializePlugin}, an
-     * independent second reason they can never be proxied. The "beans using it are rejected"
-     * promise above only reaches beans built through a bean definition. Tracked in issue #308.
+     * <b>Scope limit 1 — {@code registerSingleton} objects are never proxied, but no longer
+     * silently unprotected.</b> Only beans the container constructs itself (through
+     * {@code registerBean} or component scanning) are ever offered to the resolver, because
+     * {@link AopProxyResolver#resolve(Class)} only runs on the constructor branch of bean creation.
+     * The plugin instance itself, an {@code @ContextEntry} bean (built by hand with reflection),
+     * config entities, {@code @Configuration} classes, and the beans their {@code @Bean} methods
+     * produce are all registered with {@code registerSingleton} instead, so none of them can ever be
+     * proxied: a ByteBuddy proxy is the bean itself in this framework's design, and it cannot be
+     * retrofitted onto an object the caller already constructed. Unlike the first three,
+     * {@code @Configuration} classes and {@code @Bean} methods are written by module authors rather
+     * than the framework, and they are also constructed before {@code wireAop} runs in
+     * {@code initializePlugin}, an independent second reason they can never be proxied.
+     * <p>
+     * As of 6.3.0, {@code registerSingleton} itself refuses to register an instance whose class
+     * carries {@code @Transactional} or {@code @ExceptionCatch} — method-level or class-level — for
+     * exactly that reason: an annotation that can never take effect must fail the load rather than
+     * silently do nothing (D-15). An instance that is already a generated proxy is exempt, since it
+     * already honours its own annotations. {@code registerSingleton} also now fully assembles
+     * (autowires, invokes {@code @PostConstruct}, runs the {@code BeanPostProcessor} chain)
+     * whatever it does accept, unconditionally and regardless of {@link SimpleContainer#refresh()}
+     * state (D-14) — it is only proxying, not assembly, that remains structurally impossible here.
+     * See issue #308.
      * <p>
      * <b>Class-level scope.</b> A class-level annotation is a default for the methods the
      * annotated class declares, and for its subclasses. It does not apply to ancestors, so a bean
@@ -1203,13 +1212,20 @@ public class PluginManager {
      * 当 getDataSource(DataScope) 抛出异常时从 JsonStore 获取。只有既不能提供 DataSource
      * 也不能提供自身 TransactionManager 的 DataStore，才仍会把 @Transactional 声明为不可用。
      * <p>
-     * 范围限制一：以 registerSingleton 方式注册的对象完全绕开这套机制——插件实例本身、
-     * {@code @ContextEntry} bean（反射手工构造）、config 实体、{@code @Configuration} 类
-     * 及其 {@code @Bean} 方法产出的 bean 都是这样注册的，它们上面的
-     * {@code @ExceptionCatch} 依旧是空注解，{@code @Transactional} 也不会被拒绝，
-     * 只会静默地不受事务保护地运行。与前三者不同，{@code @Configuration}/{@code @Bean}
-     * 是模块作者自己写的代码，而且它们在 {@code initializePlugin} 中于 {@code wireAop}
-     * 执行前就已构造完成，这是它们永远不会被代理的另一个独立原因。见 issue #308。
+     * 范围限制一：以 registerSingleton 方式注册的对象永远不会被代理，但不再是静默不受保护。
+     * 插件实例本身、{@code @ContextEntry} bean（反射手工构造）、config 实体、
+     * {@code @Configuration} 类及其 {@code @Bean} 方法产出的 bean 都是这样注册的，
+     * 它们永远无法被代理——本框架中 ByteBuddy 代理就是 bean 本身，无法在调用方已经构造好的
+     * 对象上重新套一层。与前三者不同，{@code @Configuration}/{@code @Bean} 是模块作者自己写的
+     * 代码，而且它们在 {@code initializePlugin} 中于 {@code wireAop} 执行前就已构造完成，
+     * 这是它们永远不会被代理的另一个独立原因。
+     * 自 6.3.0 起，registerSingleton 本身会拒绝注册携带 {@code @Transactional} 或
+     * {@code @ExceptionCatch}（方法级或类级）的对象——原因很直接：一个永远不会生效的注解必须
+     * 让加载失败，而不是静默地什么也不做（D-15）。已经是生成代理的实例可以豁免，因为它已经
+     * 遵循自己的注解。对于它确实接受的对象，registerSingleton 现在也会无条件完成完整装配
+     * （自动装配、调用 @PostConstruct、执行 BeanPostProcessor 链），与
+     * {@link SimpleContainer#refresh()} 的状态无关（D-14）——这里仍然结构性不可能的只是代理，
+     * 不再是装配。见 issue #308。
      * 类级作用域：类级注解是「被注解类自己声明的方法」及其子类的默认值，不作用于祖先类。
      * 因此 bean 不会把自己的注解扩张到它继承来的一切——尤其不会扩张到它继承的框架基类上，
      * 在那里吞掉异常会变成一个 null，并在远离原因的地方以不相干的故障重新浮现。
@@ -1474,8 +1490,12 @@ public class PluginManager {
         pluginContext.registerShutdownHook();
         pluginContext.setClassLoader(classLoader);
         try {
-            pluginContext.getBeanFactory().registerSingleton(pluginClass.getSimpleName(), plugin);
-            // Register plugin as UltiToolsPlugin type so services can inject it via constructor
+            // Register plugin as UltiToolsPlugin type so services can inject it via constructor.
+            // This registerType call must run BEFORE scanComponents: ConditionalRegistrationEvaluator
+            // (03-04) resolves the plugin via getBean(UltiToolsPlugin.class) during the scan.
+            // registerType writes the type registry directly and never goes through
+            // registerSingleton, so it is unaffected by full assembly (D-14) and does not need to
+            // move.
             pluginContext.registerType(UltiToolsPlugin.class, plugin);
 
             // Trigger component scanning to discover @CmdExecutor, @EventListener, @Service beans
@@ -1483,6 +1503,14 @@ public class PluginManager {
             if (scanPackages.length > 0) {
                 pluginContext.scanComponents(scanPackages);
             }
+
+            // Register the plugin instance itself by name AFTER scanComponents, not before:
+            // registerSingleton now fully assembles its argument unconditionally (D-14), so
+            // registering the plugin instance before any @Service bean exists would attempt to
+            // autowire it against an empty bean graph -- after 03-03, an unresolvable
+            // @Autowired(required = true) field on the plugin's own main class would then throw,
+            // turning a working module into one that cannot load (T-03-27).
+            pluginContext.getBeanFactory().registerSingleton(pluginClass.getSimpleName(), plugin);
 
             // Register config entities as beans for @Autowired injection
             java.util.Map<String, com.ultikits.ultitools.abstracts.AbstractConfigEntity> configMap =

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -272,7 +272,10 @@ public class PluginManager {
                             String.format("[UltiTools-API] Cannot create context entry for %s", clazz.getName())
                     );
                 }
-                pluginContext.refresh();
+                // No second refresh() here (D-14): registerSingleton above now fully assembles the
+                // @ContextEntry bean itself unconditionally, so there is nothing left for a second
+                // refresh() to do -- the first refresh() at the top of this method already
+                // pre-instantiated every non-lazy singleton definition this container knows about.
                 pluginContext.getAutowireCapableBeanFactory().autowireBean(plugin);
             }
         } catch (Exception | Error e) {

--- a/src/test/java/com/ultikits/testfixtures/beanname/BeanNameFixtures.java
+++ b/src/test/java/com/ultikits/testfixtures/beanname/BeanNameFixtures.java
@@ -1,0 +1,84 @@
+package com.ultikits.testfixtures.beanname;
+
+import com.ultikits.ultitools.annotations.Bean;
+import com.ultikits.ultitools.annotations.Configuration;
+
+/**
+ * {@code @Bean(name=)}/{@code @Bean(value=)} effect fixtures for
+ * {@code com.ultikits.ultitools.context.DeclaredAttributeEffectTest$BeanNameAndValue} (03-09,
+ * Task 1). Every method here is reached only via reflection against
+ * {@code ComponentScanner.processBeanMethod} -- never through a package scan -- but the class
+ * still lives outside {@code com.ultikits.ultitools.context} on purpose; see this package's
+ * {@code package-info} for why co-locating it there would be unsafe once the malformed-{@code
+ * @Bean} hard-fail this plan implements starts propagating.
+ */
+@Configuration
+public class BeanNameFixtures {
+
+    @Bean
+    public Object defaultName() {
+        return new Object();
+    }
+
+    @Bean(name = "customName")
+    public Object withCustomName() {
+        return new Object();
+    }
+
+    @Bean(value = "customValueName")
+    public Object withCustomValue() {
+        return new Object();
+    }
+
+    @Bean(name = {"primary", "alias1", "alias2"})
+    public PostConstructCounter withAliases() {
+        return new PostConstructCounter();
+    }
+
+    @Bean(name = "a", value = "b")
+    public Object conflictingNameValue() {
+        return new Object();
+    }
+
+    @Bean(name = "same", value = "same")
+    public Object identicalNameValue() {
+        return new Object();
+    }
+
+    @Bean(name = {})
+    public Object emptyNameArray() {
+        return new Object();
+    }
+
+    @Bean(value = {})
+    public Object emptyValueArray() {
+        return new Object();
+    }
+
+    @Bean(name = "")
+    public Object blankName() {
+        return new Object();
+    }
+
+    @Bean(name = {"ok", "  "})
+    public Object blankElementInArray() {
+        return new Object();
+    }
+
+    // NFC (precomposed) name -- U+00E9 LATIN SMALL LETTER E WITH ACUTE, written as an explicit
+    // backslash-u escape (not a literal accented character in the source file) so no
+    // editor/tool text pipeline can silently re-normalize it before javac ever sees it.
+    @Bean(name = "café")
+    public String nfcName() {
+        return "nfc-instance";
+    }
+
+    // NFD (decomposed) name -- U+0065 LATIN SMALL LETTER E followed by U+0301 COMBINING ACUTE
+    // ACCENT, also an explicit backslash-u escape pair. Visually identical to nfcName()'s
+    // declared name once rendered, but a different sequence of UTF-16 code units -- exactly
+    // the case String.equals (no normalization) must treat as two distinct bean names.
+    @Bean(name = "café")
+    public String nfdName() {
+        return "nfd-instance";
+    }
+}

--- a/src/test/java/com/ultikits/testfixtures/beanname/BeanNameFixtures.java
+++ b/src/test/java/com/ultikits/testfixtures/beanname/BeanNameFixtures.java
@@ -68,7 +68,7 @@ public class BeanNameFixtures {
     // NFC (precomposed) name -- U+00E9 LATIN SMALL LETTER E WITH ACUTE, written as an explicit
     // backslash-u escape (not a literal accented character in the source file) so no
     // editor/tool text pipeline can silently re-normalize it before javac ever sees it.
-    @Bean(name = "café")
+    @Bean(name = "caf\u00e9")
     public String nfcName() {
         return "nfc-instance";
     }
@@ -77,7 +77,7 @@ public class BeanNameFixtures {
     // ACCENT, also an explicit backslash-u escape pair. Visually identical to nfcName()'s
     // declared name once rendered, but a different sequence of UTF-16 code units -- exactly
     // the case String.equals (no normalization) must treat as two distinct bean names.
-    @Bean(name = "café")
+    @Bean(name = "cafe\u0301")
     public String nfdName() {
         return "nfd-instance";
     }

--- a/src/test/java/com/ultikits/testfixtures/beanname/PostConstructCounter.java
+++ b/src/test/java/com/ultikits/testfixtures/beanname/PostConstructCounter.java
@@ -1,0 +1,20 @@
+package com.ultikits.testfixtures.beanname;
+
+import com.ultikits.ultitools.annotations.PostConstruct;
+
+/**
+ * A POJO whose {@code @PostConstruct} invocation count proves a {@code @Bean} factory's product
+ * was assembled exactly once, even when registered under several names (03-09, Task 1).
+ */
+public class PostConstructCounter {
+    private int constructCount;
+
+    @PostConstruct
+    public void init() {
+        constructCount++;
+    }
+
+    public int getConstructCount() {
+        return constructCount;
+    }
+}

--- a/src/test/java/com/ultikits/testfixtures/beanname/package-info.java
+++ b/src/test/java/com/ultikits/testfixtures/beanname/package-info.java
@@ -1,0 +1,40 @@
+/**
+ * Fixtures for {@code com.ultikits.ultitools.context.DeclaredAttributeEffectTest$BeanNameAndValue}
+ * (03-09, Task 1) -- deliberately <b>not</b> under {@code com.ultikits.ultitools.context} even
+ * though every test that uses these classes reaches them by reflection alone and never scans
+ * this package.
+ * <p>
+ * {@link BeanNameFixtures#conflictingNameValue()} declares {@code @Bean(name = "a", value = "b")}
+ * on purpose, so that method's registration hard-fails with {@code ContainerException} once
+ * {@code ComponentScanner.processBeanMethod}/{@code registerConfiguration} let the malformed
+ * declaration propagate (D-02/D-25). {@code ComponentScanner.scanDirectory} walks a package's
+ * compiled {@code .class} files, not a specific test's usage of them -- so a class merely
+ * <em>compiled into</em> {@code com.ultikits.ultitools.context} (nested or top-level) is
+ * discoverable by <b>any</b> test that scans that package, regardless of whether the test that
+ * declared the class ever calls {@code scanPackage} itself. Several existing tests do exactly
+ * that (e.g. {@code ComponentScannerTest}'s {@code freshScanner.scanPackage(
+ * "com.ultikits.ultitools.context")}) and {@code scanDirectory} recurses into subpackages, so a
+ * fixture with a malformed {@code @Bean} living anywhere under {@code context/} would abort
+ * those unrelated scans the moment the malformed-declaration hard-fail (this plan's own
+ * deliverable) started propagating correctly -- measured directly during this plan's own
+ * execution. This package isolates the malformed fixture the same way
+ * {@link com.ultikits.testfixtures.finalviolation.scanner} isolates a {@code @Final} violation
+ * fixture for the identical reason.
+ * <br>
+ * 03-09 Task 1 的 fixture——刻意不放在 {@code com.ultikits.ultitools.context} 下，尽管所有使用
+ * 这些类的测试都只通过反射到达它们，从不扫描本包。{@link BeanNameFixtures#conflictingNameValue()}
+ * 故意声明了 {@code @Bean(name = "a", value = "b")}，一旦
+ * {@code ComponentScanner.processBeanMethod}/{@code registerConfiguration} 让这类畸形声明正确
+ * 传播（D-02/D-25），该方法的注册就会以 {@code ContainerException} 硬失败。
+ * {@code ComponentScanner.scanDirectory} 遍历的是某个包已编译的 {@code .class}
+ * 文件，而不是某个测试对它们的具体用法——因此一个仅仅*编译进*
+ * {@code com.ultikits.ultitools.context}（无论嵌套与否）的类，能被任何扫描该包的测试发现，
+ * 无论声明该类的测试自身是否调用过 {@code scanPackage}。已有若干测试正是这样做的（例如
+ * {@code ComponentScannerTest} 的 {@code freshScanner.scanPackage(
+ * "com.ultikits.ultitools.context")}），而 {@code scanDirectory} 会递归进入子包——本计划自身
+ * 执行过程中就实测到：若把带畸形 {@code @Bean} 的 fixture 放在 {@code context/}
+ * 下任意位置，一旦畸形声明硬失败（本计划自身的交付物）开始正确传播，就会中止那些无关的扫描。
+ * 本包隔离这个畸形 fixture 的方式，与 {@link com.ultikits.testfixtures.finalviolation.scanner}
+ * 出于同样原因隔离一个 {@code @Final} 违规 fixture 完全一致。
+ */
+package com.ultikits.testfixtures.beanname;

--- a/src/test/java/com/ultikits/testfixtures/conditionalcommand/FalseConditionCommand.java
+++ b/src/test/java/com/ultikits/testfixtures/conditionalcommand/FalseConditionCommand.java
@@ -1,0 +1,24 @@
+package com.ultikits.testfixtures.conditionalcommand;
+
+import com.ultikits.ultitools.abstracts.command.BaseCommandExecutor;
+import com.ultikits.ultitools.annotations.ConditionalOnConfig;
+import com.ultikits.ultitools.annotations.command.CmdExecutor;
+
+import org.bukkit.command.CommandSender;
+
+/**
+ * A command whose {@code @ConditionalOnConfig} condition is deliberately configured to evaluate
+ * {@code false} in the paired test's config file. It must never become a bean, and its alias
+ * must never appear in Bukkit's command map.
+ * <br>
+ * 一个 {@code @ConditionalOnConfig} 条件在配套测试的配置文件中被特意设为 {@code false} 的命令。
+ * 它绝不能成为 bean，其别名也绝不能出现在 Bukkit 的命令表中。
+ */
+@CmdExecutor(alias = {"conditionalfalsecmd"}, permission = "ultitools.test.conditionalfalse")
+@ConditionalOnConfig(value = "config/config.yml", path = "enableFalseCommand")
+public class FalseConditionCommand extends BaseCommandExecutor {
+    @Override
+    protected void handleHelp(CommandSender sender) {
+        sender.sendMessage("false-condition command help");
+    }
+}

--- a/src/test/java/com/ultikits/testfixtures/conditionalcommand/TrueConditionCommand.java
+++ b/src/test/java/com/ultikits/testfixtures/conditionalcommand/TrueConditionCommand.java
@@ -1,0 +1,26 @@
+package com.ultikits.testfixtures.conditionalcommand;
+
+import com.ultikits.ultitools.abstracts.command.BaseCommandExecutor;
+import com.ultikits.ultitools.annotations.ConditionalOnConfig;
+import com.ultikits.ultitools.annotations.command.CmdExecutor;
+
+import org.bukkit.command.CommandSender;
+
+/**
+ * A command whose {@code @ConditionalOnConfig} condition is deliberately configured to evaluate
+ * {@code true} in the paired test's config file -- the control proving the false-condition
+ * sibling's absence from Bukkit's command map is due to the gate, not an unrelated scan or
+ * registration failure.
+ * <br>
+ * 一个 {@code @ConditionalOnConfig} 条件在配套测试的配置文件中被特意设为 {@code true} 的命令——
+ * 作为对照，证明另一个 false 条件命令从 Bukkit 命令表中缺席是因为门控生效，而不是扫描或注册本身
+ * 出了问题。
+ */
+@CmdExecutor(alias = {"conditionaltruecmd"}, permission = "ultitools.test.conditionaltrue")
+@ConditionalOnConfig(value = "config/config.yml", path = "enableTrueCommand")
+public class TrueConditionCommand extends BaseCommandExecutor {
+    @Override
+    protected void handleHelp(CommandSender sender) {
+        sender.sendMessage("true-condition command help");
+    }
+}

--- a/src/test/java/com/ultikits/testfixtures/conditionalcommand/package-info.java
+++ b/src/test/java/com/ultikits/testfixtures/conditionalcommand/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Fixtures for proving that {@code @ConditionalOnConfig} on a {@code @CmdExecutor} class already
+ * works on the standard module-JAR registration path (D-19), pinned at the actual Bukkit command
+ * map boundary rather than assumed. Two real, top-level command classes so
+ * {@code ComponentScanner.scanPackage} has an actual classpath entry to discover -- nested static
+ * test classes are not reliably findable by that scan, so these live as their own files rather
+ * than inside the test class that exercises them.
+ * <br>
+ * 用于证明 {@code @ConditionalOnConfig} 在标准模块 JAR 注册路径（D-19）上已经生效的 fixture，
+ * 并在真实的 Bukkit 命令表边界上钉住这一点，而不是假设它成立。这里使用两个真实的顶层命令类，
+ * 以便 {@code ComponentScanner.scanPackage} 能实际发现它们——嵌套的静态测试类未必能被该扫描
+ * 可靠发现，因此它们各自独立成文件，而不是放在使用它们的测试类内部。
+ */
+package com.ultikits.testfixtures.conditionalcommand;

--- a/src/test/java/com/ultikits/testfixtures/conditionallistener/FalseConditionListener.java
+++ b/src/test/java/com/ultikits/testfixtures/conditionallistener/FalseConditionListener.java
@@ -1,0 +1,19 @@
+package com.ultikits.testfixtures.conditionallistener;
+
+import com.ultikits.ultitools.annotations.ConditionalOnConfig;
+import com.ultikits.ultitools.annotations.EventListener;
+
+import org.bukkit.event.Listener;
+
+/**
+ * A listener whose {@code @ConditionalOnConfig} condition is deliberately configured to
+ * evaluate {@code false} in the paired test's config file. {@code ListenerManager}'s
+ * package-scan path must never instantiate this class.
+ * <br>
+ * 一个 {@code @ConditionalOnConfig} 条件在配套测试的配置文件中被特意设为 {@code false} 的
+ * 监听器。{@code ListenerManager} 的包扫描路径绝不能实例化该类。
+ */
+@EventListener
+@ConditionalOnConfig(value = "config/config.yml", path = "enableFalseListener")
+public class FalseConditionListener implements Listener {
+}

--- a/src/test/java/com/ultikits/testfixtures/conditionallistener/TrueConditionListener.java
+++ b/src/test/java/com/ultikits/testfixtures/conditionallistener/TrueConditionListener.java
@@ -1,0 +1,19 @@
+package com.ultikits.testfixtures.conditionallistener;
+
+import com.ultikits.ultitools.annotations.ConditionalOnConfig;
+import com.ultikits.ultitools.annotations.EventListener;
+
+import org.bukkit.event.Listener;
+
+/**
+ * A listener whose {@code @ConditionalOnConfig} condition is deliberately configured to
+ * evaluate {@code true} in the paired test's config file -- the control proving the
+ * false-condition sibling's absence is due to the gate, not an unrelated scan failure.
+ * <br>
+ * 一个 {@code @ConditionalOnConfig} 条件在配套测试的配置文件中被特意设为 {@code true} 的
+ * 监听器——作为对照，证明另一个 false 条件监听器的缺席是因为门控生效，而不是扫描本身出了问题。
+ */
+@EventListener
+@ConditionalOnConfig(value = "config/config.yml", path = "enableTrueListener")
+public class TrueConditionListener implements Listener {
+}

--- a/src/test/java/com/ultikits/testfixtures/conditionallistener/package-info.java
+++ b/src/test/java/com/ultikits/testfixtures/conditionallistener/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Fixtures for proving {@code ListenerManager.registerAll(UltiToolsPlugin, String)} honours
+ * {@code @ConditionalOnConfig} on the reflective package-scan path (WIRE-07, D-17).
+ * <p>
+ * Two real, top-level {@code @EventListener} classes so the
+ * {@code com.google.common.reflect.ClassPath}-backed {@code PackageScanUtils.scanAnnotatedClasses}
+ * has an actual classpath entry to discover -- nested static test classes are not reliably
+ * findable by that scan, so these live as their own files rather than inside the test class
+ * that exercises them.
+ * <br>
+ * 用于证明 {@code ListenerManager.registerAll(UltiToolsPlugin, String)} 在反射式包扫描路径上
+ * 遵循 {@code @ConditionalOnConfig}（WIRE-07，D-17）的 fixture。这里使用两个真实的顶层
+ * {@code @EventListener} 类，以便基于 {@code com.google.common.reflect.ClassPath} 的
+ * {@code PackageScanUtils.scanAnnotatedClasses} 能实际发现它们——嵌套的静态测试类未必能被该扫描
+ * 可靠发现，因此它们各自独立成文件，而不是放在使用它们的测试类内部。
+ */
+package com.ultikits.testfixtures.conditionallistener;

--- a/src/test/java/com/ultikits/testfixtures/conditionallistenerdispatch/FalseConditionDispatchListener.java
+++ b/src/test/java/com/ultikits/testfixtures/conditionallistenerdispatch/FalseConditionDispatchListener.java
@@ -1,0 +1,32 @@
+package com.ultikits.testfixtures.conditionallistenerdispatch;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.ultikits.ultitools.annotations.ConditionalOnConfig;
+import com.ultikits.ultitools.annotations.EventListener;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+/**
+ * A listener whose {@code @ConditionalOnConfig} condition is deliberately configured to evaluate
+ * {@code false} in the paired test's config file. If {@code ListenerManager} ever registers this
+ * class with Bukkit despite the false condition, firing a {@link PlayerJoinEvent} would increment
+ * {@link #HITS} -- which the test asserts stays at zero.
+ * <br>
+ * 一个 {@code @ConditionalOnConfig} 条件在配套测试的配置文件中被特意设为 {@code false} 的监听器。
+ * 如果 {@code ListenerManager} 无视 false 条件仍然向 Bukkit 注册了该类，触发一次
+ * {@link PlayerJoinEvent} 就会使 {@link #HITS} 递增——测试断言它必须保持为零。
+ */
+@EventListener
+@ConditionalOnConfig(value = "config/config.yml", path = "enableFalseListener")
+public class FalseConditionDispatchListener implements Listener {
+
+    public static final AtomicInteger HITS = new AtomicInteger(0);
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        HITS.incrementAndGet();
+    }
+}

--- a/src/test/java/com/ultikits/testfixtures/conditionallistenerdispatch/TrueConditionDispatchListener.java
+++ b/src/test/java/com/ultikits/testfixtures/conditionallistenerdispatch/TrueConditionDispatchListener.java
@@ -1,0 +1,32 @@
+package com.ultikits.testfixtures.conditionallistenerdispatch;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.ultikits.ultitools.annotations.ConditionalOnConfig;
+import com.ultikits.ultitools.annotations.EventListener;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+/**
+ * A listener whose {@code @ConditionalOnConfig} condition is deliberately configured to evaluate
+ * {@code true} in the paired test's config file -- the control proving that a fired
+ * {@link PlayerJoinEvent} genuinely reaches a correctly-registered listener, so the false-condition
+ * sibling's zero {@code HITS} means the gate worked rather than event dispatch itself being broken.
+ * <br>
+ * 一个 {@code @ConditionalOnConfig} 条件在配套测试的配置文件中被特意设为 {@code true} 的监听器——
+ * 作为对照，证明触发的 {@link PlayerJoinEvent} 确实能到达一个被正确注册的监听器，从而说明另一个
+ * false 条件监听器的零命中是门控生效的结果，而不是事件分发机制本身出了问题。
+ */
+@EventListener
+@ConditionalOnConfig(value = "config/config.yml", path = "enableTrueListener")
+public class TrueConditionDispatchListener implements Listener {
+
+    public static final AtomicInteger HITS = new AtomicInteger(0);
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        HITS.incrementAndGet();
+    }
+}

--- a/src/test/java/com/ultikits/testfixtures/conditionallistenerdispatch/package-info.java
+++ b/src/test/java/com/ultikits/testfixtures/conditionallistenerdispatch/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Fixtures for proving that a listener whose {@code @ConditionalOnConfig} condition evaluates
+ * {@code false} receives no events after {@code ListenerManager.registerAll(plugin, packageName)}
+ * runs -- asserted through an actual Bukkit event dispatch and an observed side effect, not
+ * through inspecting a registration bookkeeping list (ROADMAP Criterion 4). Distinct from
+ * {@code com.ultikits.testfixtures.conditionallistener} (Task 1), whose fixtures only prove the
+ * registration-count half; these two additionally carry a real {@code @EventHandler} method and a
+ * static hit counter so a fired event's effect is directly observable.
+ * <br>
+ * 用于证明一个 {@code @ConditionalOnConfig} 条件为 {@code false} 的监听器，在
+ * {@code ListenerManager.registerAll(plugin, packageName)} 运行之后不会收到任何事件——通过真实
+ * 的 Bukkit 事件分发与可观察的副作用来验证，而不是检查注册台账列表（ROADMAP 验收标准 4）。
+ * 与 {@code com.ultikits.testfixtures.conditionallistener}（Task 1）不同，那里的 fixture 只证明
+ * "注册数量"这一半；这里的两个类额外携带真实的 {@code @EventHandler} 方法和一个静态命中计数器，
+ * 使事件被触发后的效果可以被直接观察到。
+ */
+package com.ultikits.testfixtures.conditionallistenerdispatch;

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/chain/p1/ChainMiddle.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/chain/p1/ChainMiddle.java
@@ -1,0 +1,19 @@
+package com.ultikits.testfixtures.finalviolation.chain.p1;
+
+/**
+ * Test-only fixture: legitimately widens {@link ChainRoot#m()} from package-private to
+ * {@code public} from within {@code ChainRoot}'s own package - a real override per JLS 8.4.8.1,
+ * and the step that makes {@code m()} reachable (and further overridable) from outside this
+ * package. See the parent {@code chain} package-info for the full scenario.
+ * <p>
+ * This class is itself already a live {@code @Final} violation under the pre-existing
+ * (non-transitive) check - it is the same shape as
+ * {@code com.ultikits.testfixtures.finalviolation.validator.WideningOverrideOfSealedPackageMethod}.
+ * It is not asserted on directly by name; {@link com.ultikits.testfixtures.finalviolation.chain.p2.ChainLeaf}
+ * is the fixture that exercises the new transitive behaviour.
+ */
+public class ChainMiddle extends ChainRoot {
+    @Override
+    public void m() {
+    }
+}

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/chain/p1/ChainMiddle.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/chain/p1/ChainMiddle.java
@@ -15,5 +15,7 @@ package com.ultikits.testfixtures.finalviolation.chain.p1;
 public class ChainMiddle extends ChainRoot {
     @Override
     public void m() {
+        // Intentionally empty: this fixture only exercises the widening-override shape
+        // (see class javadoc), not runtime behavior.
     }
 }

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/chain/p1/ChainRoot.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/chain/p1/ChainRoot.java
@@ -1,0 +1,14 @@
+package com.ultikits.testfixtures.finalviolation.chain.p1;
+
+import com.ultikits.ultitools.annotations.Final;
+
+/**
+ * Test-only fixture: declares a <b>package-private</b> {@code @Final} method. Only a same-package
+ * subclass - {@link ChainMiddle} - can legitimately override it (JLS 8.4.8.1). See this
+ * subpackage's {@code p1} folder and the parent {@code chain} package-info for the full scenario.
+ */
+public class ChainRoot {
+    @Final
+    void m() {
+    }
+}

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/chain/p1/ChainRoot.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/chain/p1/ChainRoot.java
@@ -10,5 +10,7 @@ import com.ultikits.ultitools.annotations.Final;
 public class ChainRoot {
     @Final
     void m() {
+        // Intentionally empty: this fixture only exercises override eligibility across the
+        // p1/p2 package boundary (see class javadoc), not runtime behavior.
     }
 }

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/chain/p2/ChainLeaf.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/chain/p2/ChainLeaf.java
@@ -15,5 +15,7 @@ import com.ultikits.testfixtures.finalviolation.chain.p1.ChainMiddle;
 public class ChainLeaf extends ChainMiddle {
     @Override
     public void m() {
+        // Intentionally empty: this fixture only exercises the cross-package transitive
+        // override shape (see class javadoc), not runtime behavior.
     }
 }

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/chain/p2/ChainLeaf.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/chain/p2/ChainLeaf.java
@@ -1,0 +1,19 @@
+package com.ultikits.testfixtures.finalviolation.chain.p2;
+
+import com.ultikits.testfixtures.finalviolation.chain.p1.ChainMiddle;
+
+/**
+ * Test-only fixture: overrides {@link ChainMiddle#m()} from a package different than both
+ * {@code ChainMiddle} and {@link com.ultikits.testfixtures.finalviolation.chain.p1.ChainRoot}.
+ * <p>
+ * This is issue #190's cross-package transitive scenario: {@code FinalContractValidator.validate}
+ * comparing this class's {@code m()} directly against {@code ChainRoot#m()} fails the
+ * package-private access check, but the override genuinely holds transitively through
+ * {@code ChainMiddle#m()} - a real, same-package widening override of the {@code @Final}
+ * package-private method. See the parent {@code chain} package-info for the full scenario.
+ */
+public class ChainLeaf extends ChainMiddle {
+    @Override
+    public void m() {
+    }
+}

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/chain/package-info.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/chain/package-info.java
@@ -1,0 +1,26 @@
+/**
+ * Fixtures for {@code com.ultikits.ultitools.context.FinalContractValidatorTest}'s cross-package
+ * transitive-override scenario: a {@code @Final} package-private method on {@link p1.ChainRoot},
+ * widened to {@code public} by a same-package {@link p1.ChainMiddle}, then overridden again by
+ * {@link p2.ChainLeaf} from a <b>different</b> package.
+ * <p>
+ * {@code ChainRoot} and {@code ChainMiddle} must share a package: per JLS 8.4.8.1, a package-private
+ * method is only overridden by a same-package subclass, so the widening step that makes the whole
+ * chain reachable from {@code ChainLeaf} only exists because {@code ChainMiddle} sits next to
+ * {@code ChainRoot}. {@code ChainLeaf} sits in a second, different package on purpose: comparing
+ * it directly against {@code ChainRoot} fails the package check (that is issue #190's original
+ * bug), and only succeeds by first passing through {@code ChainMiddle}.
+ * <p>
+ * Like the sibling {@code validator} package, these fixtures are only ever validated one class at
+ * a time via {@code FinalContractValidator.validate(Class)}; no test scans this package as a
+ * whole. See the parent {@code finalviolation} package-info for why this whole family lives
+ * outside {@code com.ultikits.ultitools}.
+ * <p>
+ * 本包服务于跨包传递重写场景：{@link p1.ChainRoot} 声明包私有的 {@code @Final} 方法，被同包的
+ * {@link p1.ChainMiddle} 放宽为 {@code public}，再被<b>不同包</b>的 {@link p2.ChainLeaf} 二次重写。
+ * {@code ChainRoot} 与 {@code ChainMiddle} 必须同包——依据 JLS 8.4.8.1，包私有方法只能被同包子类
+ * 覆盖，链条之所以能从 {@code ChainLeaf} 一路追溯回去，正是因为这一步放宽发生在同包内。
+ * {@code ChainLeaf} 故意放在第二个不同的包：直接拿它与 {@code ChainRoot} 比较会因为包不同而失败
+ * （这正是 issue #190 的原始缺陷），只有先经过 {@code ChainMiddle} 才能成立。
+ */
+package com.ultikits.testfixtures.finalviolation.chain;

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/package-info.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/package-info.java
@@ -3,9 +3,14 @@
  * ({@link com.ultikits.ultitools.annotations.Final}): extending a sealed class or overriding a
  * sealed method. See the subpackages for the actual fixture classes:
  * {@link com.ultikits.testfixtures.finalviolation.validator} for
- * {@code FinalContractValidatorTest}'s unit-test fixtures, and
+ * {@code FinalContractValidatorTest}'s unit-test fixtures (including its interface-shaped
+ * fixtures),
  * {@link com.ultikits.testfixtures.finalviolation.scanner} for
- * {@code ComponentScannerFinalContractTest}'s integration-test fixture.
+ * {@code ComponentScannerFinalContractTest}'s integration-test fixture, and
+ * {@link com.ultikits.testfixtures.finalviolation.chain} for
+ * {@code FinalContractValidatorTest}'s cross-package transitive-override fixtures, which need
+ * their own two real packages ({@code chain.p1}, {@code chain.p2}) rather than living directly
+ * here.
  * <p>
  * This package family exists <b>outside</b> {@code com.ultikits.ultitools} on purpose. Component
  * scanning ({@code com.ultikits.ultitools.context.ComponentScanner}) walks whatever package it is

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/validator/ExtendsSealedMarkerInterface.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/validator/ExtendsSealedMarkerInterface.java
@@ -1,0 +1,14 @@
+package com.ultikits.testfixtures.finalviolation.validator;
+
+/**
+ * Test-only fixture for {@code FinalContractValidatorTest}: illegally extends
+ * {@link SealedMarkerInterface}, which is annotated {@code @Final}. Before this plan's change,
+ * {@code FinalContractValidator.validate} returned immediately for any {@code clazz.isInterface()},
+ * so this case was never enforced at all.
+ * <p>
+ * See this package's {@code package-info} for why it is safe to hold more than one violation shape,
+ * and the parent {@code finalviolation} package's {@code package-info} for why any of this lives
+ * outside {@code com.ultikits.ultitools} at all.
+ */
+public interface ExtendsSealedMarkerInterface extends SealedMarkerInterface {
+}

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/validator/ImplementsSealedDefaultMethod.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/validator/ImplementsSealedDefaultMethod.java
@@ -11,5 +11,7 @@ package com.ultikits.testfixtures.finalviolation.validator;
 public class ImplementsSealedDefaultMethod implements SealedInterface {
     @Override
     public void m() {
+        // Intentionally empty: this fixture only exercises the illegal-override shape
+        // (see class javadoc), not runtime behavior.
     }
 }

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/validator/ImplementsSealedDefaultMethod.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/validator/ImplementsSealedDefaultMethod.java
@@ -1,0 +1,15 @@
+package com.ultikits.testfixtures.finalviolation.validator;
+
+/**
+ * Test-only fixture for {@code FinalContractValidatorTest}: illegally overrides
+ * {@link SealedInterface#m()}, a {@code @Final} default method, directly.
+ * <p>
+ * See this package's {@code package-info} for why it is safe to hold more than one violation shape,
+ * and the parent {@code finalviolation} package's {@code package-info} for why any of this lives
+ * outside {@code com.ultikits.ultitools} at all.
+ */
+public class ImplementsSealedDefaultMethod implements SealedInterface {
+    @Override
+    public void m() {
+    }
+}

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/validator/ImplementsSealedMarkerInterface.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/validator/ImplementsSealedMarkerInterface.java
@@ -1,0 +1,12 @@
+package com.ultikits.testfixtures.finalviolation.validator;
+
+/**
+ * Test-only fixture for {@code FinalContractValidatorTest}: illegally implements
+ * {@link SealedMarkerInterface}, which is annotated {@code @Final}.
+ * <p>
+ * See this package's {@code package-info} for why it is safe to hold more than one violation shape,
+ * and the parent {@code finalviolation} package's {@code package-info} for why any of this lives
+ * outside {@code com.ultikits.ultitools} at all.
+ */
+public class ImplementsSealedMarkerInterface implements SealedMarkerInterface {
+}

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/validator/InheritsSealedDefaultMethod.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/validator/InheritsSealedDefaultMethod.java
@@ -1,0 +1,16 @@
+package com.ultikits.testfixtures.finalviolation.validator;
+
+/**
+ * Test-only fixture for {@code FinalContractValidatorTest}: implements {@link SealedInterface}
+ * without overriding {@code m()} - merely inheriting a {@code @Final} default method is not a
+ * violation of anything, since {@code @Final} restricts overriding, not use. This class is not
+ * itself a violation; it exists so {@link OverridesInheritedSealedDefaultMethod} can reach
+ * {@code SealedInterface#m()} through a superclass's interface rather than declaring the interface
+ * itself.
+ * <p>
+ * See this package's {@code package-info} for why it is safe to hold more than one violation shape,
+ * and the parent {@code finalviolation} package's {@code package-info} for why any of this lives
+ * outside {@code com.ultikits.ultitools} at all.
+ */
+public class InheritsSealedDefaultMethod implements SealedInterface {
+}

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/validator/OverridesInheritedSealedDefaultMethod.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/validator/OverridesInheritedSealedDefaultMethod.java
@@ -1,0 +1,20 @@
+package com.ultikits.testfixtures.finalviolation.validator;
+
+/**
+ * Test-only fixture for {@code FinalContractValidatorTest}: extends
+ * {@link InheritsSealedDefaultMethod} (a class that implements {@link SealedInterface} but never
+ * declares {@code m()} itself) and overrides {@code m()} here. {@code FinalContractValidator} can
+ * only find the {@code @Final} declaration for this case by walking
+ * {@code InheritsSealedDefaultMethod}'s own interfaces during the chain walk, not merely its
+ * superclass - proving the walk reaches a {@code @Final} method declared on an interface of a
+ * superclass, not only one reachable through the superclass chain directly.
+ * <p>
+ * See this package's {@code package-info} for why it is safe to hold more than one violation shape,
+ * and the parent {@code finalviolation} package's {@code package-info} for why any of this lives
+ * outside {@code com.ultikits.ultitools} at all.
+ */
+public class OverridesInheritedSealedDefaultMethod extends InheritsSealedDefaultMethod {
+    @Override
+    public void m() {
+    }
+}

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/validator/OverridesInheritedSealedDefaultMethod.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/validator/OverridesInheritedSealedDefaultMethod.java
@@ -16,5 +16,7 @@ package com.ultikits.testfixtures.finalviolation.validator;
 public class OverridesInheritedSealedDefaultMethod extends InheritsSealedDefaultMethod {
     @Override
     public void m() {
+        // Intentionally empty: this fixture only exercises the interface-of-a-superclass
+        // chain-walk shape (see class javadoc), not runtime behavior.
     }
 }

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/validator/SealedInterface.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/validator/SealedInterface.java
@@ -1,0 +1,21 @@
+package com.ultikits.testfixtures.finalviolation.validator;
+
+import com.ultikits.ultitools.annotations.Final;
+
+/**
+ * Test-only fixture for {@code FinalContractValidatorTest}: an interface with a {@code @Final}
+ * default method. {@link ImplementsSealedDefaultMethod} illegally overrides it directly;
+ * {@link InheritsSealedDefaultMethod} legally inherits without overriding, and
+ * {@link OverridesInheritedSealedDefaultMethod} illegally overrides it by way of
+ * {@code InheritsSealedDefaultMethod}, reaching {@code @Final} through an interface of a
+ * superclass rather than through the superclass chain itself.
+ * <p>
+ * See this package's {@code package-info} for why it is safe to hold more than one violation shape,
+ * and the parent {@code finalviolation} package's {@code package-info} for why any of this lives
+ * outside {@code com.ultikits.ultitools} at all.
+ */
+public interface SealedInterface {
+    @Final
+    default void m() {
+    }
+}

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/validator/SealedInterface.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/validator/SealedInterface.java
@@ -17,5 +17,7 @@ import com.ultikits.ultitools.annotations.Final;
 public interface SealedInterface {
     @Final
     default void m() {
+        // Intentionally empty: this fixture only exercises the @Final default-method
+        // sealing shape (see class javadoc), not runtime behavior.
     }
 }

--- a/src/test/java/com/ultikits/testfixtures/finalviolation/validator/SealedMarkerInterface.java
+++ b/src/test/java/com/ultikits/testfixtures/finalviolation/validator/SealedMarkerInterface.java
@@ -1,0 +1,17 @@
+package com.ultikits.testfixtures.finalviolation.validator;
+
+import com.ultikits.ultitools.annotations.Final;
+
+/**
+ * Test-only fixture for {@code FinalContractValidatorTest}: an interface annotated
+ * {@code @Final} at the type level, with no members of its own.
+ * {@link ExtendsSealedMarkerInterface} illegally extends it; {@link ImplementsSealedMarkerInterface}
+ * illegally implements it.
+ * <p>
+ * See this package's {@code package-info} for why it is safe to hold more than one violation shape,
+ * and the parent {@code finalviolation} package's {@code package-info} for why any of this lives
+ * outside {@code com.ultikits.ultitools} at all.
+ */
+@Final
+public interface SealedMarkerInterface {
+}

--- a/src/test/java/com/ultikits/testfixtures/linkageerror/package-info.java
+++ b/src/test/java/com/ultikits/testfixtures/linkageerror/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Fixtures for {@code com.ultikits.ultitools.context.ComponentScannerTest}'s LinkageError
+ * skip-and-continue coverage (03-07, D-25/D-26): a class whose loading raises a
+ * {@link java.lang.LinkageError} (or a subtype such as {@code NoClassDefFoundError}) must be
+ * skipped with a {@code Level.WARNING} record, and every other class in the same package must
+ * still register - on <b>both</b> {@code ComponentScanner} scan modes identically.
+ * <p>
+ * See {@link com.ultikits.testfixtures.linkageerror.scanner} for the two real fixture classes.
+ * Quarantined outside {@code com.ultikits.ultitools} for the same reason as
+ * {@code com.ultikits.testfixtures.finalviolation}: {@code ComponentScanner#scanDirectory}
+ * recurses into subdirectories with no notion of "this is a test fixture" - it just sees real
+ * classes on the classpath - so a fixture that changes a scan's outcome must live entirely
+ * outside the framework's own package tree.
+ * <br>
+ * 本包为 {@code ComponentScannerTest} 的 LinkageError 跳过并继续覆盖（03-07，D-25/D-26）提供
+ * fixture：一个加载时抛出 {@link java.lang.LinkageError}（或其子类，例如
+ * {@code NoClassDefFoundError}）的类必须被跳过并记录一条 {@code Level.WARNING}，同一包内的其他
+ * 类必须照常注册——且在两种扫描模式下表现完全一致。出于与
+ * {@code com.ultikits.testfixtures.finalviolation} 相同的理由，本包放在
+ * {@code com.ultikits.ultitools} 包树之外。
+ */
+package com.ultikits.testfixtures.linkageerror;

--- a/src/test/java/com/ultikits/testfixtures/linkageerror/scanner/LinkageErrorBreakingFixture.java
+++ b/src/test/java/com/ultikits/testfixtures/linkageerror/scanner/LinkageErrorBreakingFixture.java
@@ -1,0 +1,15 @@
+package com.ultikits.testfixtures.linkageerror.scanner;
+
+/**
+ * Test-only fixture for {@code ComponentScannerTest}'s LinkageError skip-and-continue coverage.
+ * <p>
+ * This class is never actually loaded during those tests - the test-supplied {@code ClassLoader}
+ * intercepts {@code loadClass} for this exact name and throws a chosen {@link LinkageError}
+ * before delegating. It exists only so a real {@code .class} file with this name is present on
+ * disk (directory mode) and can be named as a real entry in a hand-built temporary JAR (jar
+ * mode).
+ * <p>
+ * See this package's {@code package-info} for the full rationale.
+ */
+public class LinkageErrorBreakingFixture {
+}

--- a/src/test/java/com/ultikits/testfixtures/linkageerror/scanner/LinkageErrorSurvivorFixture.java
+++ b/src/test/java/com/ultikits/testfixtures/linkageerror/scanner/LinkageErrorSurvivorFixture.java
@@ -1,0 +1,14 @@
+package com.ultikits.testfixtures.linkageerror.scanner;
+
+import com.ultikits.ultitools.annotations.Component;
+
+/**
+ * Test-only control fixture for {@code ComponentScannerTest}'s LinkageError skip-and-continue
+ * coverage: a plain, loadable {@code @Component} that must still register after its sibling
+ * {@link LinkageErrorBreakingFixture} is skipped - on both scan modes.
+ * <p>
+ * See this package's {@code package-info} for the full rationale.
+ */
+@Component
+public class LinkageErrorSurvivorFixture {
+}

--- a/src/test/java/com/ultikits/testfixtures/linkageerror/scanner/package-info.java
+++ b/src/test/java/com/ultikits/testfixtures/linkageerror/scanner/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * The two real, compiled fixture classes {@code ComponentScannerTest} drives its LinkageError
+ * skip-and-continue tests against.
+ * <p>
+ * {@link com.ultikits.testfixtures.linkageerror.scanner.LinkageErrorBreakingFixture}'s own
+ * {@code .class} bytes are never actually read in these tests - a test-only {@code ClassLoader}
+ * intercepts {@code loadClass} for its exact name and throws a chosen {@code LinkageError}
+ * before delegation, on both the directory-mode and the jar-mode path. It only needs to exist as
+ * a real file on disk so {@code ComponentScanner#scanDirectory}'s {@code File.listFiles()} walk
+ * (directory mode) and a hand-built temporary JAR's entry list (jar mode) both have a real class
+ * name to name.
+ * {@link com.ultikits.testfixtures.linkageerror.scanner.LinkageErrorSurvivorFixture} is the
+ * control: a plain {@code @Component} that must still register after its sibling is skipped.
+ * <br>
+ * {@code ComponentScannerTest} 用来驱动 LinkageError 跳过并继续测试的两个真实、已编译 fixture
+ * 类。破坏类自身的 {@code .class} 字节内容从未被真正读取——测试专用的 {@code ClassLoader} 会针对
+ * 其确切类名拦截 {@code loadClass} 并在委派之前抛出预设的 {@code LinkageError}，目录模式和 JAR
+ * 模式两条路径皆是如此；它只需要在磁盘上作为一个真实文件存在，以便目录遍历与手工构造的临时 JAR
+ * 条目列表都能引用到一个真实的类名。存活 fixture 是对照组：一个普通的 {@code @Component}，
+ * 必须在其同级类被跳过之后仍然完成注册。
+ */
+package com.ultikits.testfixtures.linkageerror.scanner;

--- a/src/test/java/com/ultikits/testfixtures/registersingletonordering/OrderingFixtureModule.java
+++ b/src/test/java/com/ultikits/testfixtures/registersingletonordering/OrderingFixtureModule.java
@@ -1,0 +1,36 @@
+package com.ultikits.testfixtures.registersingletonordering;
+
+import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
+import com.ultikits.ultitools.annotations.Autowired;
+
+/**
+ * A module main class carrying an {@code @Autowired} field pointing at a {@code @Service} in its
+ * own scanned package -- the scenario {@code PluginManager.initializePlugin} must resolve
+ * correctly by registering the plugin instance itself only AFTER component scanning (03-08, Task
+ * 2, T-03-27). No {@code @UltiToolsModule} annotation is declared: {@code getPluginScanPackages}
+ * falls back to this class's own package when neither {@code @UltiToolsModule} nor
+ * {@code @ComponentScan} is present, which is exactly this package.
+ * <br>
+ * 一个在自身模块主类上携带 {@code @Autowired} 字段、指向自己扫描包内某个 {@code @Service}
+ * 的 fixture——这正是 {@code PluginManager.initializePlugin} 必须正确处理的场景：只有在组件扫描
+ * 之后才注册插件实例自身，才能让该字段解析成功（03-08，Task 2，T-03-27）。此类未声明
+ * {@code @UltiToolsModule}：当既没有 {@code @UltiToolsModule} 也没有 {@code @ComponentScan} 时，
+ * {@code getPluginScanPackages} 会回退到该类自身所在的包——正是本包。
+ */
+public class OrderingFixtureModule extends UltiToolsPlugin {
+
+    @Autowired
+    private OrderingFixtureService service;
+
+    @Override
+    public boolean registerSelf() {
+        return true;
+    }
+
+    /**
+     * @return the resolved {@code @Autowired} service, or {@code null} if it was never populated
+     */
+    public OrderingFixtureService getService() {
+        return service;
+    }
+}

--- a/src/test/java/com/ultikits/testfixtures/registersingletonordering/OrderingFixtureService.java
+++ b/src/test/java/com/ultikits/testfixtures/registersingletonordering/OrderingFixtureService.java
@@ -1,0 +1,12 @@
+package com.ultikits.testfixtures.registersingletonordering;
+
+import com.ultikits.ultitools.annotations.Service;
+
+/**
+ * A trivial {@code @Service} bean, scanned from {@link OrderingFixtureModule}'s own package.
+ * <br>
+ * 一个简单的 {@code @Service} bean，从 {@link OrderingFixtureModule} 自己所在的包中被扫描到。
+ */
+@Service
+public class OrderingFixtureService {
+}

--- a/src/test/java/com/ultikits/testfixtures/registersingletonordering/package-info.java
+++ b/src/test/java/com/ultikits/testfixtures/registersingletonordering/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Fixtures for {@code RegisterSingletonAssemblyTest}'s {@code initializePlugin}-level proof that
+ * the plugin instance's own {@code registerSingleton} call runs AFTER component scanning, so an
+ * {@code @Autowired} field on the module main class resolves against its own scanned
+ * {@code @Service} beans (03-08, Task 2, T-03-27).
+ * <p>
+ * These two classes are real, top-level files rather than nested test classes -- both so
+ * {@code ComponentScanner.scanPackage} has an actual classpath entry to discover (see
+ * {@code com.ultikits.testfixtures.conditionalcommand}'s package javadoc for the established
+ * reason nested static test classes are not reliably found by that scan) and, more specifically
+ * for this fixture, so the module main class can be packaged into a throwaway jar and loaded
+ * through an isolated classloader: {@code UltiToolsPlugin}'s no-arg constructor reads
+ * {@code plugin.yml} from its own class's {@code CodeSource}, which must be a real jar file, not
+ * the {@code target/test-classes} directory Surefire runs from.
+ * <br>
+ * 为 {@code RegisterSingletonAssemblyTest} 的 {@code initializePlugin} 级证明提供 fixture：
+ * 插件实例自身的 {@code registerSingleton} 调用必须在组件扫描之后运行，这样模块主类上的
+ * {@code @Autowired} 字段才能解析到它自己扫描到的 {@code @Service} bean（03-08，Task 2，
+ * T-03-27）。
+ */
+package com.ultikits.testfixtures.registersingletonordering;

--- a/src/test/java/com/ultikits/ultitools/context/AutowireFactoryTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/AutowireFactoryTest.java
@@ -1,17 +1,10 @@
 package com.ultikits.ultitools.context;
 
 import com.ultikits.ultitools.annotations.Autowired;
-import org.junit.jupiter.api.AfterEach;
+import com.ultikits.ultitools.exceptions.ContainerException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Handler;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -26,61 +19,10 @@ class AutowireFactoryTest {
     private SimpleContainer container;
     private AutowireFactory autowireFactory;
 
-    private final List<LogRecord> captured = new ArrayList<>();
-    private Logger factoryLogger;
-    private Handler captureHandler;
-    private Level previousLevel;
-    private boolean previousUseParentHandlers;
-
     @BeforeEach
     void setUp() {
         container = new SimpleContainer();
         autowireFactory = new AutowireFactory(container);
-
-        captured.clear();
-        factoryLogger = Logger.getLogger(AutowireFactory.class.getName());
-        previousLevel = factoryLogger.getLevel();
-        previousUseParentHandlers = factoryLogger.getUseParentHandlers();
-        // 关掉向上冒泡，否则这些用例每跑一条就往测试输出里打一段堆栈
-        factoryLogger.setUseParentHandlers(false);
-        factoryLogger.setLevel(Level.ALL);
-        captureHandler = new Handler() {
-            @Override
-            public void publish(LogRecord record) {
-                captured.add(record);
-            }
-
-            @Override
-            public void flush() {
-                // nothing buffered
-            }
-
-            @Override
-            public void close() {
-                // nothing to release
-            }
-        };
-        factoryLogger.addHandler(captureHandler);
-    }
-
-    @AfterEach
-    void tearDown() {
-        factoryLogger.removeHandler(captureHandler);
-        factoryLogger.setLevel(previousLevel);
-        factoryLogger.setUseParentHandlers(previousUseParentHandlers);
-    }
-
-    /**
-     * WARNING 级别的记录。别的级别（比如 SimpleContainer 的 fine）不算。
-     */
-    private List<LogRecord> warnings() {
-        List<LogRecord> result = new ArrayList<>();
-        for (LogRecord record : captured) {
-            if (Level.WARNING.equals(record.getLevel())) {
-                result.add(record);
-            }
-        }
-        return result;
     }
 
     @Test
@@ -88,9 +30,9 @@ class AutowireFactoryTest {
     void testAutowireDependencies() {
         // Given
         TestRepository testRepository = new TestRepository();
-        
+
         container.registerType(TestRepository.class, testRepository);
-        
+
         TestController controller = new TestController();
 
         // When
@@ -102,11 +44,11 @@ class AutowireFactoryTest {
     }
 
     @Test
-    @DisplayName("Should handle null dependencies gracefully")
+    @DisplayName("Should handle null dependencies gracefully when optional")
     void testNullDependencies() {
         // Given
-        TestController controller = new TestController();
-        // No repository registered
+        TestOptionalController controller = new TestOptionalController();
+        // No repository registered, but the field is @Autowired(required = false)
 
         // When - should not throw exception
         assertDoesNotThrow(() -> autowireFactory.autowireBean(controller));
@@ -121,10 +63,10 @@ class AutowireFactoryTest {
         // Given
         TestRepository repository = new TestRepository();
         TestService service = new TestService();
-        
+
         container.registerType(TestRepository.class, repository);
         container.registerType(TestService.class, service);
-        
+
         TestComplexController controller = new TestComplexController();
 
         // When
@@ -143,7 +85,7 @@ class AutowireFactoryTest {
         // Given
         TestRepository repository = new TestRepository();
         container.registerType(TestRepository.class, repository);
-        
+
         TestNoAutowireController controller = new TestNoAutowireController();
 
         // When
@@ -159,7 +101,7 @@ class AutowireFactoryTest {
         // Given
         TestService service = new TestService();
         container.registerType(TestService.class, service);
-        
+
         TestExtendedController controller = new TestExtendedController();
 
         // When
@@ -171,29 +113,25 @@ class AutowireFactoryTest {
     }
 
     @Test
-    @DisplayName("Should warn when a required dependency cannot be resolved")
-    void testWarnOnMissingRequiredDependency() {
+    @DisplayName("Should throw when a required dependency cannot be resolved")
+    void testThrowsOnMissingRequiredDependency() {
         // Given - nothing registered, so TestRepository cannot be resolved
         TestController controller = new TestController();
 
         // When
-        autowireFactory.autowireBean(controller);
+        ContainerException exception = assertThrows(ContainerException.class,
+                () -> autowireFactory.autowireBean(controller));
 
         // Then
-        List<LogRecord> warnings = warnings();
-        assertEquals(1, warnings.size());
-        LogRecord record = warnings.get(0);
-        assertTrue(record.getMessage().contains(TestRepository.class.getName()),
-                "the warning must name the bean type that could not be resolved");
-        assertTrue(record.getMessage().contains(TestController.class.getName() + ".repository"),
-                "the warning must name the host field");
-        assertNotNull(record.getThrown(),
-                "the stack is the point: it tells the module author which code path triggered the injection");
+        assertTrue(exception.getMessage().contains(TestRepository.class.getName()),
+                "the exception must name the bean type that could not be resolved");
+        assertTrue(exception.getMessage().contains(TestController.class.getName() + ".repository"),
+                "the exception must name the host field");
     }
 
     @Test
     @DisplayName("Should stay silent when required = false")
-    void testNoWarnWhenDependencyIsOptional() {
+    void testNoThrowWhenDependencyIsOptional() {
         // Given
         TestOptionalController controller = new TestOptionalController();
 
@@ -202,51 +140,41 @@ class AutowireFactoryTest {
 
         // Then - opting out is exactly what required = false means
         assertNull(controller.getRepository());
-        assertTrue(warnings().isEmpty());
     }
 
     @Test
     @DisplayName("Should stay silent when the dependency resolves")
-    void testNoWarnWhenDependencyResolves() {
+    void testNoThrowWhenDependencyResolves() {
         // Given
         container.registerType(TestRepository.class, new TestRepository());
 
-        // When
-        autowireFactory.autowireBean(new TestController());
-
-        // Then
-        assertTrue(warnings().isEmpty());
+        // When / Then
+        assertDoesNotThrow(() -> autowireFactory.autowireBean(new TestController()));
     }
 
     @Test
     @DisplayName("Should name the declaring class for inherited fields")
-    void testWarnNamesDeclaringClassForInheritedField() {
+    void testThrowNamesDeclaringClassForInheritedField() {
         // Given - the annotated field lives on the base class, not the one being autowired
         TestExtendedController controller = new TestExtendedController();
 
         // When
-        autowireFactory.autowireBean(controller);
+        ContainerException exception = assertThrows(ContainerException.class,
+                () -> autowireFactory.autowireBean(controller));
 
         // Then
-        assertEquals(1, warnings().size());
-        assertTrue(warnings().get(0).getMessage().contains(TestBaseController.class.getName() + ".service"),
+        assertTrue(exception.getMessage().contains(TestBaseController.class.getName() + ".service"),
                 "pointing at the subclass would send the author to a file that has no such field");
     }
 
     @Test
-    @DisplayName("Should not interrupt container refresh when a required dependency is missing")
-    void testRefreshIsNotInterrupted() {
+    @DisplayName("Container refresh aborts when a required dependency is missing")
+    void testRefreshAbortsOnMissingRequiredDependency() {
         // Given - a bean whose required dependency is not registered
         container.registerBean(TestController.class);
 
-        // When - 本版只警告不抛，可能有下游模块正带着 null 字段跑在生产上
-        assertDoesNotThrow(() -> container.refresh());
-
-        // Then
-        TestController bean = container.getBean(TestController.class);
-        assertNotNull(bean);
-        assertNull(bean.getRepository());
-        assertFalse(warnings().isEmpty());
+        // When / Then - required = true now aborts the container instead of leaving a null field
+        assertThrows(RuntimeException.class, () -> container.refresh());
     }
 
     // Test helper classes

--- a/src/test/java/com/ultikits/ultitools/context/ComponentScannerCmdTargetAmbiguityTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ComponentScannerCmdTargetAmbiguityTest.java
@@ -4,9 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +37,11 @@ import com.ultikits.ultitools.context.scan.cmdtargetlegalonly.NarrowingCommand;
  * <p>
  * 验证歧义的 @CmdTarget 组合（放宽或横向切换）在插件加载期被拒绝注册——永远不会成为
  * bean 定义——而同一模块中的其他指令类仍正常注册。
+ * <p>
+ * The refusal was converted from a direct standard-error write to a leveled
+ * {@code Logger}/{@code Level.SEVERE} call by 03-07 (D-24: a refusal is a registration failure,
+ * not a skip) - this test now captures {@link LogRecord}s from
+ * {@code Logger.getLogger(ComponentScanner.class.getName())} instead of {@code System.err}.
  */
 @DisplayName("ComponentScanner @CmdTarget ambiguity refusal")
 class ComponentScannerCmdTargetAmbiguityTest {
@@ -41,8 +49,9 @@ class ComponentScannerCmdTargetAmbiguityTest {
     private SimpleContainer container;
     private ComponentScanner scanner;
 
-    private ByteArrayOutputStream capturedErr;
-    private PrintStream originalErr;
+    private final List<LogRecord> capturedLogs = new ArrayList<>();
+    private Logger scannerLogger;
+    private Handler captureHandler;
 
     @BeforeEach
     void setUp() {
@@ -50,14 +59,41 @@ class ComponentScannerCmdTargetAmbiguityTest {
         container.setClassLoader(getClass().getClassLoader());
         scanner = new ComponentScanner(container);
 
-        originalErr = System.err;
-        capturedErr = new ByteArrayOutputStream();
-        System.setErr(new PrintStream(capturedErr, true, StandardCharsets.UTF_8));
+        capturedLogs.clear();
+        scannerLogger = Logger.getLogger(ComponentScanner.class.getName());
+        captureHandler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                capturedLogs.add(record);
+            }
+
+            @Override
+            public void flush() {
+                // nothing buffered
+            }
+
+            @Override
+            public void close() {
+                // nothing to release
+            }
+        };
+        scannerLogger.addHandler(captureHandler);
     }
 
     @AfterEach
     void tearDown() {
-        System.setErr(originalErr);
+        scannerLogger.removeHandler(captureHandler);
+    }
+
+    /** Concatenates every captured {@code Level.SEVERE} message, mirroring the old stderr capture's shape. */
+    private String severeMessages() {
+        StringBuilder sb = new StringBuilder();
+        for (LogRecord record : capturedLogs) {
+            if (Level.SEVERE.equals(record.getLevel()) && record.getMessage() != null) {
+                sb.append(record.getMessage()).append('\n');
+            }
+        }
+        return sb.toString();
     }
 
     @Test
@@ -78,9 +114,9 @@ class ComponentScannerCmdTargetAmbiguityTest {
     void refusalMessageNamesClassAndMethod() {
         scanner.scanPackage("com.ultikits.ultitools.context.scan.cmdtargetambiguity");
 
-        String stderr = capturedErr.toString(StandardCharsets.UTF_8);
-        assertTrue(stderr.contains(WideningCommand.class.getName()), stderr);
-        assertTrue(stderr.contains("widensToBoth"), stderr);
+        String severe = severeMessages();
+        assertTrue(severe.contains(WideningCommand.class.getName()), severe);
+        assertTrue(severe.contains("widensToBoth"), severe);
     }
 
     @Test
@@ -100,9 +136,9 @@ class ComponentScannerCmdTargetAmbiguityTest {
         assertFalse(container.containsBean(beanNameOf(LateralCommand.class)),
                 "LateralCommand must not become a bean definition");
 
-        String stderr = capturedErr.toString(StandardCharsets.UTF_8);
-        assertTrue(stderr.contains(LateralCommand.class.getName()), stderr);
-        assertTrue(stderr.contains("switchesToConsole"), stderr);
+        String severe = severeMessages();
+        assertTrue(severe.contains(LateralCommand.class.getName()), severe);
+        assertTrue(severe.contains("switchesToConsole"), severe);
     }
 
     /** Mirrors {@code ComponentScanner.getBeanName}'s default: decapitalized simple name. */

--- a/src/test/java/com/ultikits/ultitools/context/ComponentScannerTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ComponentScannerTest.java
@@ -6,7 +6,9 @@ import com.ultikits.ultitools.annotations.Service;
 import com.ultikits.ultitools.annotations.Configuration;
 import com.ultikits.ultitools.annotations.Bean;
 import com.ultikits.ultitools.annotations.UltiToolsModule;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
 
@@ -14,9 +16,20 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.spy;
 
 /**
  * Unit tests for ComponentScanner class.
@@ -187,4 +200,216 @@ class ComponentScannerTest {
             return 42;
         }
     }
+
+    private static String decapitalize(String simpleName) {
+        return Character.toLowerCase(simpleName.charAt(0)) + simpleName.substring(1);
+    }
+
+    // ===== Task 1 (03-07, D-24): leveled scan diagnostics =====
+
+    /**
+     * {@code @Configuration} whose constructor throws -- exercises
+     * {@code ComponentScanner.registerConfiguration}'s catch-all.
+     */
+    @Configuration
+    public static class ThrowingConfigConstructorFixture {
+        public ThrowingConfigConstructorFixture() {
+            throw new IllegalStateException("boom-config-constructor");
+        }
+    }
+
+    /**
+     * {@code @Configuration} whose {@code @Bean} method throws -- exercises
+     * {@code ComponentScanner.processBeanMethod}'s catch-all.
+     */
+    @Configuration
+    public static class ThrowingBeanMethodFixture {
+        @Bean
+        public String explodingBean() {
+            throw new IllegalStateException("boom-bean-method");
+        }
+    }
+
+    /**
+     * Paired with {@link RegistrationSurvivorComponentFixture}: used with a spied
+     * {@link SimpleContainer} that throws only for this fixture's bean name, exercising
+     * {@code ComponentScanner.registerComponent}'s catch-all while proving the sibling class in
+     * the same package still registers.
+     */
+    @Component
+    public static class ThrowingRegistrationComponentFixture {
+    }
+
+    @Component
+    public static class RegistrationSurvivorComponentFixture {
+    }
+
+    @Nested
+    @DisplayName("Task 1 (03-07): leveled scan diagnostics, throwable-carrying (D-24)")
+    class LogDiagnostics {
+
+        private final List<LogRecord> captured = new ArrayList<>();
+        private Logger scannerLogger;
+        private Handler captureHandler;
+
+        @BeforeEach
+        void captureLogs() {
+            captured.clear();
+            scannerLogger = Logger.getLogger(ComponentScanner.class.getName());
+            captureHandler = new Handler() {
+                @Override
+                public void publish(LogRecord record) {
+                    captured.add(record);
+                }
+
+                @Override
+                public void flush() {
+                    // nothing buffered
+                }
+
+                @Override
+                public void close() {
+                    // nothing to release
+                }
+            };
+            scannerLogger.addHandler(captureHandler);
+        }
+
+        @AfterEach
+        void releaseLogs() {
+            scannerLogger.removeHandler(captureHandler);
+        }
+
+        private List<LogRecord> withLevel(Level level) {
+            List<LogRecord> result = new ArrayList<>();
+            for (LogRecord record : captured) {
+                if (level.equals(record.getLevel())) {
+                    result.add(record);
+                }
+            }
+            return result;
+        }
+
+        @Test
+        @DisplayName("A @Configuration class whose constructor throws logs SEVERE with the throwable attached, naming the class")
+        void configurationConstructorFailureLogsSevereWithThrowable() {
+            SimpleContainer freshContainer = new SimpleContainer();
+            ComponentScanner freshScanner = new ComponentScanner(freshContainer);
+
+            assertDoesNotThrow(() -> freshScanner.scanPackage("com.ultikits.ultitools.context"));
+
+            List<LogRecord> severe = withLevel(Level.SEVERE);
+            boolean found = severe.stream().anyMatch(r ->
+                    r.getMessage() != null
+                            && r.getMessage().contains(ThrowingConfigConstructorFixture.class.getName())
+                            && r.getThrown() != null);
+            assertTrue(found, "expected a SEVERE record naming the throwing configuration class "
+                    + "with its throwable attached");
+            assertTrue(withLevel(Level.WARNING).stream().noneMatch(r ->
+                            r.getMessage() != null
+                                    && r.getMessage().contains(ThrowingConfigConstructorFixture.class.getName())),
+                    "a registration failure must never also be logged at WARNING");
+        }
+
+        @Test
+        @DisplayName("A @Bean method whose invocation throws logs SEVERE with the throwable attached and the method name in the message")
+        void beanMethodFailureLogsSevereWithThrowableAndMethodName() {
+            SimpleContainer freshContainer = new SimpleContainer();
+            ComponentScanner freshScanner = new ComponentScanner(freshContainer);
+
+            assertDoesNotThrow(() -> freshScanner.scanPackage("com.ultikits.ultitools.context"));
+
+            List<LogRecord> severe = withLevel(Level.SEVERE);
+            boolean found = severe.stream().anyMatch(r ->
+                    r.getMessage() != null && r.getMessage().contains("explodingBean") && r.getThrown() != null);
+            assertTrue(found, "expected a SEVERE record naming the exploding @Bean method with its "
+                    + "throwable attached");
+        }
+
+        @Test
+        @DisplayName("A component whose registration throws logs SEVERE with the throwable attached; the sibling class in the same package still registers")
+        void componentRegistrationFailureLogsSevereAndSiblingStillRegisters() {
+            SimpleContainer spyContainer = spy(new SimpleContainer());
+            RuntimeException boom = new RuntimeException("boom-component");
+            String throwingBeanName = decapitalize(ThrowingRegistrationComponentFixture.class.getSimpleName());
+            String survivorBeanName = decapitalize(RegistrationSurvivorComponentFixture.class.getSimpleName());
+            doThrow(boom).when(spyContainer).registerBeanDefinition(eq(throwingBeanName), any());
+            ComponentScanner throwingScanner = new ComponentScanner(spyContainer);
+
+            assertDoesNotThrow(() -> throwingScanner.scanPackage("com.ultikits.ultitools.context"));
+
+            assertFalse(Arrays.asList(spyContainer.getBeanDefinitionNames()).contains(throwingBeanName),
+                    "the throwing component must not end up registered");
+            assertTrue(spyContainer.containsBean(survivorBeanName),
+                    "a sibling class in the same package must still register after the throwing "
+                            + "class is skipped");
+
+            List<LogRecord> severe = withLevel(Level.SEVERE);
+            boolean found = severe.stream().anyMatch(r ->
+                    r.getMessage() != null
+                            && r.getMessage().contains(ThrowingRegistrationComponentFixture.class.getName())
+                            && boom.equals(r.getThrown()));
+            assertTrue(found, "expected a SEVERE record naming the class with the original "
+                    + "throwable instance attached");
+        }
+
+        @Test
+        @DisplayName("A package that cannot be resolved logs WARNING with the throwable attached, never SEVERE")
+        void unresolvablePackageLogsWarningNotSevere() {
+            SimpleContainer freshContainer = new SimpleContainer();
+            String breakingPath = "com/ultikits/testfixtures/scanpackageboom";
+            ClassLoader throwingLoader = new ClassLoader(getClass().getClassLoader()) {
+                @Override
+                public URL getResource(String name) {
+                    if (breakingPath.equals(name)) {
+                        throw new IllegalStateException("simulated package resolution failure");
+                    }
+                    return super.getResource(name);
+                }
+            };
+            freshContainer.setClassLoader(throwingLoader);
+            ComponentScanner freshScanner = new ComponentScanner(freshContainer);
+
+            assertDoesNotThrow(() -> freshScanner.scanPackage("com.ultikits.testfixtures.scanpackageboom"));
+
+            List<LogRecord> warnings = withLevel(Level.WARNING);
+            assertTrue(warnings.stream().anyMatch(r ->
+                            r.getMessage() != null
+                                    && r.getMessage().contains("com.ultikits.testfixtures.scanpackageboom")
+                                    && r.getThrown() != null),
+                    "expected a WARNING naming the package with the throwable attached");
+            assertTrue(withLevel(Level.SEVERE).isEmpty(),
+                    "a package-resolution skip must never be logged at SEVERE");
+        }
+
+        @Test
+        @DisplayName("An unreadable JAR logs WARNING with the throwable attached, never SEVERE")
+        void unreadableJarLogsWarningNotSevere() throws Exception {
+            SimpleContainer freshContainer = new SimpleContainer();
+            String breakingPath = "com/ultikits/testfixtures/scanjarboom";
+            URL badJarUrl = new URL("jar:file:/nonexistent/does-not-exist-" + System.nanoTime() + ".jar!/");
+            ClassLoader jarLoader = new ClassLoader(getClass().getClassLoader()) {
+                @Override
+                public URL getResource(String name) {
+                    if (breakingPath.equals(name)) {
+                        return badJarUrl;
+                    }
+                    return super.getResource(name);
+                }
+            };
+            freshContainer.setClassLoader(jarLoader);
+            ComponentScanner freshScanner = new ComponentScanner(freshContainer);
+
+            assertDoesNotThrow(() -> freshScanner.scanPackage("com.ultikits.testfixtures.scanjarboom"));
+
+            List<LogRecord> warnings = withLevel(Level.WARNING);
+            assertTrue(warnings.stream().anyMatch(r ->
+                            r.getMessage() != null
+                                    && r.getMessage().contains("com.ultikits.testfixtures.scanjarboom")
+                                    && r.getThrown() != null),
+                    "expected a WARNING naming the package with the throwable attached");
+            assertTrue(withLevel(Level.SEVERE).isEmpty(), "a JAR-resolution skip must never be logged at SEVERE");
+        }
+    }
+
 }

--- a/src/test/java/com/ultikits/ultitools/context/ComponentScannerTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ComponentScannerTest.java
@@ -1,25 +1,36 @@
 package com.ultikits.ultitools.context;
 
+import com.ultikits.testfixtures.finalviolation.scanner.ViolatingComponent;
+import com.ultikits.testfixtures.linkageerror.scanner.LinkageErrorBreakingFixture;
+import com.ultikits.testfixtures.linkageerror.scanner.LinkageErrorSurvivorFixture;
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.annotations.Component;
 import com.ultikits.ultitools.annotations.Service;
 import com.ultikits.ultitools.annotations.Configuration;
 import com.ultikits.ultitools.annotations.Bean;
 import com.ultikits.ultitools.annotations.UltiToolsModule;
+import com.ultikits.ultitools.exceptions.ContainerException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
+import java.io.IOException;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Supplier;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -412,4 +423,201 @@ class ComponentScannerTest {
         }
     }
 
+    // ===== Task 2 (03-07, D-25, D-26): symmetric LinkageError skip-and-continue =====
+
+    @Nested
+    @DisplayName("Task 2 (03-07): LinkageError skip-and-continue, identical on both scan modes (D-25, D-26)")
+    class LinkageErrorSkipAndContinue {
+
+        @TempDir
+        File tempDir;
+
+        private static final String PACKAGE_NAME = "com.ultikits.testfixtures.linkageerror.scanner";
+        private static final String PACKAGE_PATH = "com/ultikits/testfixtures/linkageerror/scanner";
+        private final String breakingClassName = LinkageErrorBreakingFixture.class.getName();
+        private final String survivorClassName = LinkageErrorSurvivorFixture.class.getName();
+
+        private final List<LogRecord> captured = new ArrayList<>();
+        private Logger scannerLogger;
+        private Handler captureHandler;
+
+        @BeforeEach
+        void captureLogs() {
+            captured.clear();
+            scannerLogger = Logger.getLogger(ComponentScanner.class.getName());
+            captureHandler = new Handler() {
+                @Override
+                public void publish(LogRecord record) {
+                    captured.add(record);
+                }
+
+                @Override
+                public void flush() {
+                    // nothing buffered
+                }
+
+                @Override
+                public void close() {
+                    // nothing to release
+                }
+            };
+            scannerLogger.addHandler(captureHandler);
+        }
+
+        @AfterEach
+        void releaseLogs() {
+            scannerLogger.removeHandler(captureHandler);
+        }
+
+        @Test
+        @DisplayName("A NoClassDefFoundError during directory-mode loadClass is skipped with WARNING; the survivor still registers")
+        void directoryModeSkipsNoClassDefFoundError() throws Exception {
+            assertSkippedAndSurvivorRegisters(NoClassDefFoundError::new, false);
+        }
+
+        @Test
+        @DisplayName("The identical NoClassDefFoundError during jar-mode loadClass is skipped with WARNING; the survivor still registers")
+        void jarModeSkipsNoClassDefFoundError() throws Exception {
+            assertSkippedAndSurvivorRegisters(NoClassDefFoundError::new, true);
+        }
+
+        @Test
+        @DisplayName("UnsupportedClassVersionError is skipped with WARNING on both scan modes, not just JAR mode")
+        void unsupportedClassVersionErrorSkippedOnBothModes() throws Exception {
+            assertSkippedAndSurvivorRegisters(UnsupportedClassVersionError::new, false);
+            assertSkippedAndSurvivorRegisters(UnsupportedClassVersionError::new, true);
+        }
+
+        @Test
+        @DisplayName("ExceptionInInitializerError is skipped with WARNING on both scan modes")
+        void exceptionInInitializerErrorSkippedOnBothModes() throws Exception {
+            assertSkippedAndSurvivorRegisters(ExceptionInInitializerError::new, false);
+            assertSkippedAndSurvivorRegisters(ExceptionInInitializerError::new, true);
+        }
+
+        @Test
+        @DisplayName("A @Final contract violation still escapes scanPackage as ContainerException after the catch-set change")
+        void finalViolationStillEscapesAfterCatchSetChange() {
+            SimpleContainer freshContainer = new SimpleContainer();
+            ComponentScanner freshScanner = new ComponentScanner(freshContainer);
+
+            ContainerException exception = assertThrows(ContainerException.class, () ->
+                    freshScanner.scanPackage("com.ultikits.testfixtures.finalviolation.scanner"));
+
+            assertTrue(exception.getMessage().contains(ViolatingComponent.class.getName()),
+                    exception.getMessage());
+        }
+
+        private void assertSkippedAndSurvivorRegisters(Supplier<? extends LinkageError> errorSupplier,
+                boolean jarMode) throws IOException {
+            captured.clear();
+            SimpleContainer freshContainer = new SimpleContainer();
+            ClassLoader realLoader = getClass().getClassLoader();
+            ClassLoader loader;
+            if (jarMode) {
+                File jar = buildLinkageJar();
+                URL jarUrl = new URL("jar:" + jar.toURI().toURL() + "!/");
+                loader = new JarBackedBrokenLoader(realLoader, PACKAGE_PATH, jarUrl, breakingClassName,
+                        errorSupplier);
+            } else {
+                loader = new SelectivelyBrokenLoader(realLoader, breakingClassName, errorSupplier);
+            }
+            freshContainer.setClassLoader(loader);
+            ComponentScanner freshScanner = new ComponentScanner(freshContainer);
+
+            String mode = jarMode ? "jar" : "directory";
+            assertDoesNotThrow(() -> freshScanner.scanPackage(PACKAGE_NAME),
+                    mode + " mode: a LinkageError from one class must never abort the package scan");
+
+            assertTrue(freshContainer.containsBean(decapitalize(LinkageErrorSurvivorFixture.class.getSimpleName())),
+                    mode + " mode: the survivor class must still register after its sibling is skipped");
+
+            boolean warned = captured.stream().anyMatch(r ->
+                    Level.WARNING.equals(r.getLevel())
+                            && r.getMessage() != null
+                            && r.getMessage().contains(breakingClassName)
+                            && r.getThrown() != null);
+            assertTrue(warned, mode + " mode: expected a WARNING naming the breaking class with its "
+                    + "throwable attached");
+        }
+
+        private File buildLinkageJar() throws IOException {
+            File jar = new File(tempDir, "linkage-" + System.nanoTime() + ".jar");
+            try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jar.toPath()))) {
+                for (String className : new String[]{survivorClassName, breakingClassName}) {
+                    String entryName = className.replace('.', '/') + ".class";
+                    output.putNextEntry(new JarEntry(entryName));
+                    output.closeEntry();
+                }
+            }
+            return jar;
+        }
+
+        /**
+         * Directory-mode loader: delegates {@code getResource} entirely to the real classloader
+         * (so {@code scanPackage} naturally takes the "file" protocol branch), and throws the
+         * configured {@link LinkageError} for exactly one class name before delegating
+         * {@code loadClass} for everything else. Used together with
+         * {@link JarBackedBrokenLoader} so the identical fixture pair drives both scan modes.
+         */
+        private final class SelectivelyBrokenLoader extends ClassLoader {
+            private final String breakingClassName;
+            private final Supplier<? extends LinkageError> errorSupplier;
+
+            SelectivelyBrokenLoader(ClassLoader parent, String breakingClassName,
+                    Supplier<? extends LinkageError> errorSupplier) {
+                super(parent);
+                this.breakingClassName = breakingClassName;
+                this.errorSupplier = errorSupplier;
+            }
+
+            @Override
+            public Class<?> loadClass(String name) throws ClassNotFoundException {
+                if (breakingClassName.equals(name)) {
+                    throw errorSupplier.get();
+                }
+                return super.loadClass(name);
+            }
+        }
+
+        /**
+         * Jar-mode loader: returns a hand-built temporary JAR's URL for exactly the requested
+         * package path (forcing {@code scanPackage}'s "jar" protocol branch), and throws the
+         * configured {@link LinkageError} for exactly one class name before delegating
+         * {@code loadClass} for everything else. {@code ComponentScanner.scanJar} never reads
+         * bytecode from the JAR itself - only entry names - so the JAR's entries carry no real
+         * class bytes.
+         */
+        private final class JarBackedBrokenLoader extends ClassLoader {
+            private final String packagePath;
+            private final URL jarUrl;
+            private final String breakingClassName;
+            private final Supplier<? extends LinkageError> errorSupplier;
+
+            JarBackedBrokenLoader(ClassLoader parent, String packagePath, URL jarUrl, String breakingClassName,
+                    Supplier<? extends LinkageError> errorSupplier) {
+                super(parent);
+                this.packagePath = packagePath;
+                this.jarUrl = jarUrl;
+                this.breakingClassName = breakingClassName;
+                this.errorSupplier = errorSupplier;
+            }
+
+            @Override
+            public URL getResource(String name) {
+                if (packagePath.equals(name)) {
+                    return jarUrl;
+                }
+                return super.getResource(name);
+            }
+
+            @Override
+            public Class<?> loadClass(String name) throws ClassNotFoundException {
+                if (breakingClassName.equals(name)) {
+                    throw errorSupplier.get();
+                }
+                return super.loadClass(name);
+            }
+        }
+    }
 }

--- a/src/test/java/com/ultikits/ultitools/context/ConditionalOnConfigTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ConditionalOnConfigTest.java
@@ -211,6 +211,7 @@ class ConditionalOnConfigTest {
 
         @Test
         @DisplayName("No plugin in container should register by default")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void noPluginRegisters() throws Exception {
             SimpleContainer emptyContainer = new SimpleContainer();
             ComponentScanner scanner = new ComponentScanner(emptyContainer);

--- a/src/test/java/com/ultikits/ultitools/context/ConditionalOnConfigTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ConditionalOnConfigTest.java
@@ -267,10 +267,14 @@ class ConditionalOnConfigTest {
 
                 @Override
                 public void flush() {
+                    // Intentionally empty: this in-memory capture handler has no buffered
+                    // output to flush -- records are appended directly in publish().
                 }
 
                 @Override
                 public void close() {
+                    // Intentionally empty: no resource to release; the handler is detached
+                    // via releaseLogs()/removeHandler() below.
                 }
             };
             evaluatorLogger.addHandler(captureHandler);

--- a/src/test/java/com/ultikits/ultitools/context/ConditionalOnConfigTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ConditionalOnConfigTest.java
@@ -7,6 +7,12 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -220,6 +226,111 @@ class ConditionalOnConfigTest {
         void nullFolderRegisters() throws Exception {
             when(mockPlugin.getResourceFolderPath()).thenReturn(null);
             assertTrue(invokesShouldRegister(ConditionalServiceA.class));
+        }
+    }
+
+    // === D-20: fail-open branches stay fail-open but stop being silent ===
+
+    /**
+     * Both fail-open branches of the shared evaluator (D-20) must keep returning {@code true}
+     * <b>and</b> announce themselves with a {@code Level.WARNING} record naming the evaluated
+     * class. Captured on the evaluator's own logger by name (rather than
+     * {@code ConditionalRegistrationEvaluator.class.getName()}) so this test class compiles
+     * before that extracted type exists -- it is the RED half of Task 1's TDD cycle.
+     * <br>
+     * 共享判定器（D-20）的两条"无法判定 -> 默认放行"分支必须继续返回 {@code true}，并且不再沉默：
+     * 各自发出一条命名了被判定类的 {@code Level.WARNING} 记录。这里按名字（而不是
+     * {@code ConditionalRegistrationEvaluator.class.getName()}）获取 logger，以便本测试类在
+     * 该抽取出的类型存在之前也能编译通过——这是 Task 1 TDD 循环的 RED 一半。
+     */
+    @Nested
+    @DisplayName("Fail-open branches announce themselves (D-20)")
+    class FailOpenWarnings {
+
+        private static final String EVALUATOR_LOGGER_NAME =
+                "com.ultikits.ultitools.context.ConditionalRegistrationEvaluator";
+
+        private final List<LogRecord> captured = new ArrayList<>();
+        private Logger evaluatorLogger;
+        private Handler captureHandler;
+
+        @BeforeEach
+        void captureLogs() {
+            captured.clear();
+            evaluatorLogger = Logger.getLogger(EVALUATOR_LOGGER_NAME);
+            captureHandler = new Handler() {
+                @Override
+                public void publish(LogRecord record) {
+                    captured.add(record);
+                }
+
+                @Override
+                public void flush() {
+                }
+
+                @Override
+                public void close() {
+                }
+            };
+            evaluatorLogger.addHandler(captureHandler);
+        }
+
+        @AfterEach
+        void releaseLogs() {
+            evaluatorLogger.removeHandler(captureHandler);
+        }
+
+        private List<LogRecord> warnings() {
+            List<LogRecord> result = new ArrayList<>();
+            for (LogRecord record : captured) {
+                if (Level.WARNING.equals(record.getLevel())) {
+                    result.add(record);
+                }
+            }
+            return result;
+        }
+
+        @Test
+        @DisplayName("Unresolvable plugin from container still registers, and warns naming the class")
+        void unresolvablePluginWarnsAndRegisters() throws Exception {
+            SimpleContainer throwingContainer = mock(SimpleContainer.class);
+            when(throwingContainer.getBean(UltiToolsPlugin.class))
+                    .thenThrow(new IllegalStateException("simulated container failure"));
+
+            boolean result = invokesShouldRegisterAgainst(ConditionalServiceA.class, throwingContainer);
+
+            assertTrue(result, "an unresolvable plugin must still fail open (register by default)");
+            List<LogRecord> warnings = warnings();
+            assertTrue(warnings.size() >= 1,
+                    "expected a WARNING when no plugin could be resolved from the container");
+            assertTrue(warnings.stream().anyMatch(r ->
+                            r.getMessage().contains(ConditionalServiceA.class.getName())),
+                    "expected the warning to name the evaluated class");
+        }
+
+        @Test
+        @DisplayName("Null resourceFolderPath still registers, and warns naming the class")
+        void nullResourceFolderWarnsAndRegisters() throws Exception {
+            when(mockPlugin.getResourceFolderPath()).thenReturn(null);
+
+            boolean result = invokesShouldRegister(ConditionalServiceA.class);
+
+            assertTrue(result, "a null resource folder path must still fail open (register by default)");
+            List<LogRecord> warnings = warnings();
+            assertTrue(warnings.size() >= 1,
+                    "expected a WARNING when the plugin's resource folder path is null");
+            assertTrue(warnings.stream().anyMatch(r ->
+                            r.getMessage().contains(ConditionalServiceA.class.getName())),
+                    "expected the warning to name the evaluated class");
+        }
+
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+        private boolean invokesShouldRegisterAgainst(Class<?> clazz, SimpleContainer testContainer) throws Exception {
+            ComponentScanner scanner = new ComponentScanner(testContainer);
+            java.lang.reflect.Method shouldRegister =
+                    ComponentScanner.class.getDeclaredMethod("shouldRegister", Class.class);
+            shouldRegister.setAccessible(true);
+            return (boolean) shouldRegister.invoke(scanner, clazz);
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/context/ContextConfigTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ContextConfigTest.java
@@ -1,8 +1,10 @@
 package com.ultikits.ultitools.context;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
@@ -30,25 +32,13 @@ class ContextConfigTest {
     }
 
     @Test
-    @DisplayName("Should be annotated with @ComponentScan")
-    void testComponentScanAnnotation() {
-        // Then
-        assertTrue(ContextConfig.class.isAnnotationPresent(ComponentScan.class),
-                "ContextConfig should be annotated with @ComponentScan");
-    }
-
-    @Test
-    @DisplayName("Should scan com.ultikits.ultitools package")
-    void testComponentScanPackage() {
-        // Given
-        ComponentScan componentScan = ContextConfig.class.getAnnotation(ComponentScan.class);
-
-        // Then
-        assertNotNull(componentScan);
-        String[] basePackages = componentScan.value();
-        assertNotNull(basePackages);
-        assertEquals(1, basePackages.length);
-        assertEquals("com.ultikits.ultitools", basePackages[0]);
+    @DisplayName("Should no longer be annotated with @ComponentScan")
+    void testComponentScanAnnotationAbsent() {
+        // @ComponentScan("com.ultikits.ultitools") was removed in 6.3.0 (D-23): nothing in
+        // src/main ever invoked SimpleContainer#processConfigurationClass against it, so the
+        // declaration was a scan nobody performed. See ContextConfig's own javadoc.
+        assertFalse(ContextConfig.class.isAnnotationPresent(ComponentScan.class),
+                "ContextConfig should no longer be annotated with @ComponentScan");
     }
 
     @Test
@@ -133,26 +123,19 @@ class ContextConfigTest {
     }
 
     @Test
-    @DisplayName("ComponentScan annotation should have correct attributes")
-    void testComponentScanAttributes() {
+    @DisplayName("getAnnotation(ComponentScan.class) should return null now that the declaration "
+            + "is gone")
+    void testComponentScanAnnotationInstanceIsNull() {
         // Given
         ComponentScan componentScan = ContextConfig.class.getAnnotation(ComponentScan.class);
 
         // Then
-        assertNotNull(componentScan);
-        
-        // Check value attribute
-        String[] value = componentScan.value();
-        assertEquals(1, value.length);
-        assertEquals("com.ultikits.ultitools", value[0]);
-        
-        // Check basePackages attribute (should be empty as value is used)
-        String[] basePackages = componentScan.basePackages();
-        assertEquals(0, basePackages.length);
+        assertNull(componentScan,
+                "ContextConfig no longer carries @ComponentScan, so its instance must be null");
     }
 
     @Test
-    @DisplayName("Should be a simple marker configuration class")
+    @DisplayName("Should be a simple marker configuration class with no scan declaration")
     void testIsMarkerClass() {
         // Given - filter out synthetic members
         boolean hasConfigAnnotation = ContextConfig.class.isAnnotationPresent(Configuration.class);
@@ -164,7 +147,8 @@ class ContextConfigTest {
 
         // Then
         assertTrue(hasConfigAnnotation);
-        assertTrue(hasComponentScanAnnotation);
+        assertFalse(hasComponentScanAnnotation,
+                "ContextConfig should no longer be annotated with @ComponentScan (D-23)");
         assertTrue(hasNoMethods);
         assertTrue(hasNoFields);
     }

--- a/src/test/java/com/ultikits/ultitools/context/DeclaredAttributeEffectTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/DeclaredAttributeEffectTest.java
@@ -1,0 +1,389 @@
+package com.ultikits.ultitools.context;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.ultikits.testfixtures.beanname.BeanNameFixtures;
+import com.ultikits.testfixtures.beanname.PostConstructCounter;
+import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
+import com.ultikits.ultitools.annotations.ComponentScan;
+import com.ultikits.ultitools.annotations.UltiToolsModule;
+import com.ultikits.ultitools.context.scanfixture.markerpkg.MarkerClass;
+import com.ultikits.ultitools.context.scanfixture.otherpkg.OtherMarkerClass;
+import com.ultikits.ultitools.exceptions.ContainerException;
+import com.ultikits.ultitools.manager.PluginManager;
+
+/**
+ * Per-attribute effect tests for this phase's last two declared-but-dead attributes (03-09):
+ * {@code @Bean(name=)}/{@code @Bean(value=)} (Task 1) and {@code scanBasePackageClasses()} at
+ * both of its read sites (Task 2). Every assertion here looks up the bean or registration the
+ * attribute declares -- never observes a log line -- per this phase's success criterion 3.
+ * <p>
+ * Task 1's {@code @Bean} fixtures live in {@code com.ultikits.testfixtures.beanname}, not
+ * nested here -- see that package's {@code package-info} for why co-locating a deliberately
+ * malformed {@code @Bean} declaration under {@code com.ultikits.ultitools.context} would abort
+ * every unrelated test that scans this package. Task 2's {@code scanBasePackageClasses} fixture
+ * modules stay nested here at this outer class's top level (JUnit 5 requires {@code @Nested}
+ * test classes to be non-static inner classes, and a non-static inner class cannot itself
+ * declare a {@code static} member class) -- matching {@code ComponentScannerTest}'s established
+ * shape, where {@code TestComponent}/{@code TestConfiguration} sit at the top level and
+ * {@code @Nested} groups hold only test methods. They carry no risk of the same collision:
+ * {@code ComponentScanner.hasComponentAnnotation} unconditionally excludes every
+ * {@code UltiToolsPlugin} subclass, so an unrelated scan of this package can encounter them
+ * without side effects.
+ */
+@DisplayName("Declared-but-dead attribute effect tests (03-09)")
+class DeclaredAttributeEffectTest {
+
+    // ===== Task 2 fixtures: scanBasePackageClasses =====
+
+    private static final String MARKER_PKG = "com.ultikits.ultitools.context.scanfixture.markerpkg";
+    private static final String OTHER_PKG = "com.ultikits.ultitools.context.scanfixture.otherpkg";
+
+    @UltiToolsModule(scanBasePackageClasses = MarkerClass.class)
+    static class ModuleWithBasePackageClassesOnly extends UltiToolsPlugin {
+        @Override
+        public boolean registerSelf() {
+            return true;
+        }
+    }
+
+    @UltiToolsModule(scanBasePackages = MARKER_PKG, scanBasePackageClasses = OtherMarkerClass.class)
+    static class ModuleWithBothSources extends UltiToolsPlugin {
+        @Override
+        public boolean registerSelf() {
+            return true;
+        }
+    }
+
+    @UltiToolsModule(scanBasePackages = OTHER_PKG, scanBasePackageClasses = OtherMarkerClass.class)
+    static class ModuleWithAdjacentDuplicate extends UltiToolsPlugin {
+        @Override
+        public boolean registerSelf() {
+            return true;
+        }
+    }
+
+    @UltiToolsModule(scanBasePackages = MARKER_PKG, scanBasePackageClasses = {})
+    static class ModuleWithEmptyScanBasePackageClasses extends UltiToolsPlugin {
+        @Override
+        public boolean registerSelf() {
+            return true;
+        }
+    }
+
+    @UltiToolsModule
+    static class ModuleWithNothingDeclared extends UltiToolsPlugin {
+        @Override
+        public boolean registerSelf() {
+            return true;
+        }
+    }
+
+    @UltiToolsModule(scanBasePackages = MARKER_PKG, scanBasePackageClasses = {Object[].class})
+    static class ModuleWithNullPackageClassElement extends UltiToolsPlugin {
+        @Override
+        public boolean registerSelf() {
+            return true;
+        }
+    }
+
+    @ComponentScan(basePackageClasses = MarkerClass.class)
+    static class ConfigWithBasePackageClasses {
+    }
+
+    /**
+     * Task 1: {@code @Bean(name=)}/{@code @Bean(value=)} determine the registered bean name, with
+     * the rest of a declared name array bound as aliases sharing one fully-assembled instance
+     * (D-06). Every scenario invokes {@code ComponentScanner.processBeanMethod} directly via
+     * reflection against a freshly built {@link SimpleContainer}/{@link ComponentScanner} pair --
+     * deliberately not through a package scan, so a deliberately malformed fixture here can never
+     * abort an unrelated test's {@code scanPackage("com.ultikits.ultitools.context")} call (the
+     * same isolation reason {@code com.ultikits.testfixtures.finalviolation.scanner} exists as its
+     * own package rather than living inside {@code ComponentScannerTest}).
+     */
+    @Nested
+    @DisplayName("Task 1: @Bean(name)/@Bean(value) determine the registered bean name")
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+    class BeanNameAndValue {
+
+        private SimpleContainer container;
+        private ComponentScanner scanner;
+        private Method processBeanMethod;
+
+        @BeforeEach
+        void setUp() throws NoSuchMethodException {
+            container = new SimpleContainer();
+            scanner = new ComponentScanner(container);
+            processBeanMethod = ComponentScanner.class.getDeclaredMethod(
+                    "processBeanMethod", Object.class, Method.class);
+            processBeanMethod.setAccessible(true);
+        }
+
+        /**
+         * Invokes {@code ComponentScanner.processBeanMethod} reflectively for the named
+         * {@code @Bean} method on {@code configInstance}, unwrapping the
+         * {@link InvocationTargetException} {@code Method.invoke} wraps any thrown exception in
+         * so callers see the real {@link ContainerException} (or none at all).
+         */
+        private void invokeProcessBeanMethod(Object configInstance, String methodName) throws Throwable {
+            Method beanMethod = configInstance.getClass().getDeclaredMethod(methodName);
+            try {
+                processBeanMethod.invoke(scanner, configInstance, beanMethod);
+            } catch (InvocationTargetException e) {
+                throw e.getCause();
+            }
+        }
+
+        @Test
+        @DisplayName("no name/value declared -> registered under the method name, exactly as today")
+        void defaultsToMethodName() throws Throwable {
+            BeanNameFixtures fixtures = new BeanNameFixtures();
+            invokeProcessBeanMethod(fixtures, "defaultName");
+            assertNotNull(container.getBean("defaultName"));
+        }
+
+        @Test
+        @DisplayName("@Bean(name = \"customName\") registers under customName, not the method name")
+        void customNameWins() throws Throwable {
+            BeanNameFixtures fixtures = new BeanNameFixtures();
+            invokeProcessBeanMethod(fixtures, "withCustomName");
+            assertNotNull(container.getBean("customName"));
+            assertNull(container.getBean("withCustomName"),
+                    "the method-name key must not also resolve once a custom name is declared");
+        }
+
+        @Test
+        @DisplayName("@Bean(value = \"customValueName\") is interchangeable with name")
+        void valueAliasWins() throws Throwable {
+            BeanNameFixtures fixtures = new BeanNameFixtures();
+            invokeProcessBeanMethod(fixtures, "withCustomValue");
+            assertNotNull(container.getBean("customValueName"));
+            assertNull(container.getBean("withCustomValue"));
+        }
+
+        @Test
+        @DisplayName("@Bean(name = {primary, alias1, alias2}) -- all three resolve to the same instance")
+        void multipleNamesShareOneInstance() throws Throwable {
+            BeanNameFixtures fixtures = new BeanNameFixtures();
+            invokeProcessBeanMethod(fixtures, "withAliases");
+
+            Object primary = container.getBean("primary");
+            Object alias1 = container.getBean("alias1");
+            Object alias2 = container.getBean("alias2");
+
+            assertNotNull(primary);
+            assertSame(primary, alias1, "alias1 must be the SAME assembled instance as primary");
+            assertSame(primary, alias2, "alias2 must be the SAME assembled instance as primary");
+        }
+
+        @Test
+        @DisplayName("a @PostConstruct method on a three-name bean runs exactly once")
+        void postConstructRunsOnceDespiteAliases() throws Throwable {
+            BeanNameFixtures fixtures = new BeanNameFixtures();
+            invokeProcessBeanMethod(fixtures, "withAliases");
+
+            PostConstructCounter bean = (PostConstructCounter) container.getBean("primary");
+            assertEquals(1, bean.getConstructCount(),
+                    "registering 3 names for one bean must not invoke @PostConstruct 3 times");
+        }
+
+        @Test
+        @DisplayName("@Bean(name = \"a\", value = \"b\") -- conflicting non-empty name/value throws")
+        void conflictingNameAndValueThrows() {
+            BeanNameFixtures fixtures = new BeanNameFixtures();
+            ContainerException thrown = assertThrows(ContainerException.class,
+                    () -> invokeProcessBeanMethod(fixtures, "conflictingNameValue"));
+            String message = thrown.getMessage();
+            assertTrue(message.contains("conflictingNameValue"), message);
+            assertTrue(message.contains("a"), message);
+            assertTrue(message.contains("b"), message);
+        }
+
+        @Test
+        @DisplayName("@Bean(name = \"same\", value = \"same\") -- identical content is legal")
+        void identicalNameAndValueIsLegal() throws Throwable {
+            BeanNameFixtures fixtures = new BeanNameFixtures();
+            invokeProcessBeanMethod(fixtures, "identicalNameValue");
+            assertNotNull(container.getBean("same"));
+        }
+
+        @Test
+        @DisplayName("@Bean(name = {}) falls back to the method name, same as absent")
+        void emptyNameArrayFallsBackToMethodName() throws Throwable {
+            BeanNameFixtures fixtures = new BeanNameFixtures();
+            invokeProcessBeanMethod(fixtures, "emptyNameArray");
+            assertNotNull(container.getBean("emptyNameArray"));
+        }
+
+        @Test
+        @DisplayName("@Bean(value = {}) falls back to the method name, same as absent")
+        void emptyValueArrayFallsBackToMethodName() throws Throwable {
+            BeanNameFixtures fixtures = new BeanNameFixtures();
+            invokeProcessBeanMethod(fixtures, "emptyValueArray");
+            assertNotNull(container.getBean("emptyValueArray"));
+        }
+
+        @Test
+        @DisplayName("@Bean(name = \"\") -- a blank declared name fails at load")
+        void blankNameThrows() {
+            BeanNameFixtures fixtures = new BeanNameFixtures();
+            assertThrows(ContainerException.class, () -> invokeProcessBeanMethod(fixtures, "blankName"));
+        }
+
+        @Test
+        @DisplayName("@Bean(name = {\"ok\", \"  \"}) -- a blank element among several also fails at load")
+        void blankElementInArrayThrows() {
+            BeanNameFixtures fixtures = new BeanNameFixtures();
+            assertThrows(ContainerException.class,
+                    () -> invokeProcessBeanMethod(fixtures, "blankElementInArray"));
+        }
+
+        @Test
+        @DisplayName("two @Bean names differing only by Unicode normalization form register as two distinct beans")
+        void unicodeNormalizationFormsAreDistinctNames() throws Throwable {
+            BeanNameFixtures fixtures = new BeanNameFixtures();
+            invokeProcessBeanMethod(fixtures, "nfcName");
+            invokeProcessBeanMethod(fixtures, "nfdName");
+
+            String nfc = "caf\u00e9";
+            String nfd = "cafe\u0301";
+            assertNotEquals(nfc, nfd,
+                    "the two literals must actually differ by code unit for this test to mean anything");
+
+            Object nfcBean = container.getBean(nfc);
+            Object nfdBean = container.getBean(nfd);
+            assertNotNull(nfcBean);
+            assertNotNull(nfdBean);
+            assertNotSame(nfcBean, nfdBean, "normalization-distinct names must never merge into one bean");
+        }
+    }
+
+    /**
+     * Task 2: {@code scanBasePackageClasses()} is implemented at both of its dead read sites --
+     * {@code PluginManager.getPluginScanPackages} (via reflection, since the method is private and
+     * needs no Bukkit/plugin bootstrap to exercise) and
+     * {@code SimpleContainer.processConfigurationClass} (its own public entry point, following
+     * {@code ScanTest}'s established pattern). Every positive assertion retrieves the scanned
+     * component from a real container, per this phase's success criterion 3 -- never just
+     * inspects the resolved package-name array.
+     */
+    @Nested
+    @DisplayName("Task 2: scanBasePackageClasses is implemented at both read sites")
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+    class ScanBasePackageClasses {
+
+        private PluginManager pluginManager;
+        private Method getPluginScanPackagesMethod;
+
+        @BeforeEach
+        void setUp() throws NoSuchMethodException {
+            pluginManager = new PluginManager();
+            getPluginScanPackagesMethod = PluginManager.class.getDeclaredMethod(
+                    "getPluginScanPackages", Class.class);
+            getPluginScanPackagesMethod.setAccessible(true);
+        }
+
+        private String[] resolvePackages(Class<? extends UltiToolsPlugin> pluginClass) throws Throwable {
+            try {
+                return (String[]) getPluginScanPackagesMethod.invoke(pluginManager, pluginClass);
+            } catch (InvocationTargetException e) {
+                throw e.getCause();
+            }
+        }
+
+        private SimpleContainer freshScanningContainer() {
+            SimpleContainer container = new SimpleContainer();
+            container.setClassLoader(getClass().getClassLoader());
+            return container;
+        }
+
+        @Test
+        @DisplayName("scanBasePackageClasses alone resolves to the marker's package and its @Service is retrievable")
+        void scanBasePackageClassesAloneScansAndRegisters() throws Throwable {
+            String[] resolved = resolvePackages(ModuleWithBasePackageClassesOnly.class);
+            assertArrayEquals(new String[]{MARKER_PKG}, resolved);
+
+            SimpleContainer container = freshScanningContainer();
+            container.scanComponents(resolved);
+            assertNotNull(container.getBean("markerService"));
+        }
+
+        @Test
+        @DisplayName("@ComponentScan(basePackageClasses = Marker.class) declared directly is honoured too")
+        void componentScanBasePackageClassesDirectlyDeclared() {
+            SimpleContainer container = freshScanningContainer();
+            container.processConfigurationClass(ConfigWithBasePackageClasses.class);
+            assertNotNull(container.getBean("markerService"));
+        }
+
+        @Test
+        @DisplayName("scanBasePackages and scanBasePackageClasses combine, scanBasePackages first, both scanned")
+        void bothSourcesCombineInDeclarationOrder() throws Throwable {
+            String[] resolved = resolvePackages(ModuleWithBothSources.class);
+            assertArrayEquals(new String[]{MARKER_PKG, OTHER_PKG}, resolved);
+
+            SimpleContainer container = freshScanningContainer();
+            container.scanComponents(resolved);
+            assertNotNull(container.getBean("markerService"));
+            assertNotNull(container.getBean("otherService"));
+        }
+
+        @Test
+        @DisplayName("a package named by both sources resolves and registers exactly once")
+        void adjacentDuplicateCollapsesToOneEntry() throws Throwable {
+            String[] resolved = resolvePackages(ModuleWithAdjacentDuplicate.class);
+            assertArrayEquals(new String[]{OTHER_PKG}, resolved);
+
+            SimpleContainer container = freshScanningContainer();
+            container.scanComponents(resolved);
+
+            int matches = 0;
+            for (String beanName : container.getBeanDefinitionNames()) {
+                if ("otherService".equals(beanName)) {
+                    matches++;
+                }
+            }
+            assertEquals(1, matches, "the shared package must be registered exactly once, not duplicated");
+        }
+
+        @Test
+        @DisplayName("scanBasePackageClasses = {} contributes nothing and does not suppress scanBasePackages")
+        void emptyScanBasePackageClassesContributesNothing() throws Throwable {
+            String[] resolved = resolvePackages(ModuleWithEmptyScanBasePackageClasses.class);
+            assertArrayEquals(new String[]{MARKER_PKG}, resolved);
+        }
+
+        @Test
+        @DisplayName("neither attribute set -- falls back to the plugin class's own package, unchanged")
+        void bothEmptyFallsBackToOwnPackage() throws Throwable {
+            String[] resolved = resolvePackages(ModuleWithNothingDeclared.class);
+            assertArrayEquals(new String[]{ModuleWithNothingDeclared.class.getPackage().getName()}, resolved);
+        }
+
+        @Test
+        @DisplayName("a Class whose getPackage() is null (array type) does not produce a null entry")
+        void nullPackageElementIsSkipped() throws Throwable {
+            String[] resolved = resolvePackages(ModuleWithNullPackageClassElement.class);
+            assertArrayEquals(new String[]{MARKER_PKG}, resolved);
+            for (String pkg : resolved) {
+                assertNotNull(pkg);
+            }
+        }
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/context/FinalContractValidatorTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/FinalContractValidatorTest.java
@@ -17,12 +17,21 @@ import java.util.logging.Logger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.ultikits.testfixtures.finalviolation.chain.p1.ChainRoot;
+import com.ultikits.testfixtures.finalviolation.chain.p2.ChainLeaf;
+import com.ultikits.testfixtures.finalviolation.validator.ExtendsSealedMarkerInterface;
 import com.ultikits.testfixtures.finalviolation.validator.IllegalOverride;
 import com.ultikits.testfixtures.finalviolation.validator.IllegalSubclass;
 import com.ultikits.testfixtures.finalviolation.validator.IllegalSubclassWithMissingTypeMethod;
+import com.ultikits.testfixtures.finalviolation.validator.ImplementsSealedDefaultMethod;
+import com.ultikits.testfixtures.finalviolation.validator.ImplementsSealedMarkerInterface;
+import com.ultikits.testfixtures.finalviolation.validator.InheritsSealedDefaultMethod;
 import com.ultikits.testfixtures.finalviolation.validator.OpenBase;
+import com.ultikits.testfixtures.finalviolation.validator.OverridesInheritedSealedDefaultMethod;
 import com.ultikits.testfixtures.finalviolation.validator.PackagePrivateSealedBase;
 import com.ultikits.testfixtures.finalviolation.validator.SealedBase;
+import com.ultikits.testfixtures.finalviolation.validator.SealedInterface;
+import com.ultikits.testfixtures.finalviolation.validator.SealedMarkerInterface;
 import com.ultikits.testfixtures.finalviolation.validator.WideningOverrideOfSealedPackageMethod;
 import com.ultikits.testfixtures.missingdependency.HasMethodReferencingMissingType;
 import com.ultikits.testfixtures.missingdependency.MissingDependencyType;
@@ -196,6 +205,100 @@ class FinalContractValidatorTest {
                 "fixture must be a real generated proxy for this test to mean anything");
 
         assertTrue(FinalContractValidator.validate(proxyClass).isEmpty());
+    }
+
+    // --- Transitive chain and interface coverage (D-21 / D-22, issue #190) ------------------------
+
+    @Test
+    @DisplayName("Should accept an annotation type")
+    void shouldAcceptAnnotationType() {
+        // Annotation types are, at the JVM level, also interfaces - this pins that the isEnum()/
+        // isAnnotation() short-circuits in validate() are untouched by removing isInterface().
+        assertTrue(FinalContractValidator.validate(Final.class).isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should accept an enum type")
+    void shouldAcceptEnumType() {
+        assertTrue(FinalContractValidator.validate(java.lang.annotation.RetentionPolicy.class)
+                .isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should reject a cross-package transitive override of a @Final package-private "
+            + "method reached through a same-package widening class")
+    void shouldRejectCrossPackageTransitiveWideningOverride() {
+        // ChainRoot#m() (package-private, @Final) is widened to public by the same-package
+        // ChainMiddle, then overridden again by ChainLeaf from a third, different package.
+        // Comparing ChainLeaf#m() directly against ChainRoot#m() fails the package-private access
+        // check - that is issue #190's original gap - but the override genuinely holds
+        // transitively through ChainMiddle#m(), which the widened chain walk now follows.
+        List<String> violations = FinalContractValidator.validate(ChainLeaf.class);
+
+        assertEquals(1, violations.size(), violations.toString());
+        assertTrue(violations.get(0).contains("#m"), violations.get(0));
+        assertTrue(violations.get(0).contains(ChainRoot.class.getName()), violations.get(0));
+    }
+
+    @Test
+    @DisplayName("Should reject directly overriding a @Final default method declared on an "
+            + "interface")
+    void shouldRejectOverridingSealedDefaultMethod() {
+        List<String> violations =
+                FinalContractValidator.validate(ImplementsSealedDefaultMethod.class);
+
+        assertEquals(1, violations.size(), violations.toString());
+        assertTrue(violations.get(0).contains("#m"), violations.get(0));
+        assertTrue(violations.get(0).contains(SealedInterface.class.getName()), violations.get(0));
+    }
+
+    @Test
+    @DisplayName("Should not flag merely inheriting a @Final default method without overriding it")
+    void shouldNotFlagInheritingSealedDefaultMethodWithoutOverride() {
+        // @Final restricts overriding, not use - a class that implements the interface and never
+        // redeclares the method has not violated anything.
+        assertTrue(FinalContractValidator.validate(InheritsSealedDefaultMethod.class).isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should reject overriding a @Final default method reached through an interface "
+            + "of a superclass, not only through the superclass chain")
+    void shouldRejectOverridingSealedDefaultMethodInheritedThroughSuperclass() {
+        // InheritsSealedDefaultMethod never redeclares m() itself, so the only way to find
+        // SealedInterface#m() is to walk InheritsSealedDefaultMethod's own interfaces during the
+        // chain walk - proving the walk follows an ancestor's interfaces, not only its superclass.
+        List<String> violations =
+                FinalContractValidator.validate(OverridesInheritedSealedDefaultMethod.class);
+
+        assertEquals(1, violations.size(), violations.toString());
+        assertTrue(violations.get(0).contains("#m"), violations.get(0));
+        assertTrue(violations.get(0).contains(SealedInterface.class.getName()), violations.get(0));
+    }
+
+    @Test
+    @DisplayName("Should reject an interface extending a @Final interface")
+    void shouldRejectInterfaceExtendingSealedInterface() {
+        // Before this plan's change, validate() returned immediately for any clazz.isInterface(),
+        // so this case was never enforced at all.
+        List<String> violations =
+                FinalContractValidator.validate(ExtendsSealedMarkerInterface.class);
+
+        assertEquals(1, violations.size(), violations.toString());
+        assertTrue(violations.get(0).contains("extends"), violations.get(0));
+        assertTrue(violations.get(0).contains(SealedMarkerInterface.class.getName()),
+                violations.get(0));
+    }
+
+    @Test
+    @DisplayName("Should reject a class implementing a @Final interface")
+    void shouldRejectImplementingSealedInterface() {
+        List<String> violations =
+                FinalContractValidator.validate(ImplementsSealedMarkerInterface.class);
+
+        assertEquals(1, violations.size(), violations.toString());
+        assertTrue(violations.get(0).contains("implements"), violations.get(0));
+        assertTrue(violations.get(0).contains(SealedMarkerInterface.class.getName()),
+                violations.get(0));
     }
 
     // --- NoClassDefFoundError tolerance (Important 2 of the 2026-08-20 final review) -------------

--- a/src/test/java/com/ultikits/ultitools/context/RegisterSingletonAssemblyTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/RegisterSingletonAssemblyTest.java
@@ -1,22 +1,34 @@
 package com.ultikits.ultitools.context;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.ultikits.ultitools.annotations.Autowired;
+import com.ultikits.ultitools.annotations.ExceptionCatch;
 import com.ultikits.ultitools.annotations.PostConstruct;
+import com.ultikits.ultitools.annotations.Transactional;
+import com.ultikits.ultitools.aop.AopAdvisor;
+import com.ultikits.ultitools.aop.AopProxyResolver;
+import com.ultikits.ultitools.aop.ExceptionInterceptor;
+import com.ultikits.ultitools.aop.ProxyFactory;
+import com.ultikits.ultitools.exceptions.ContainerException;
 
 /**
- * Pins D-14 (full assembly, unconditional on {@code refresh()} state) for
- * {@link SimpleContainer#registerSingleton}.
+ * Pins D-14 (full assembly, unconditional on {@code refresh()} state) and D-15 (refusal of an
+ * AOP-annotated pre-constructed instance) for {@link SimpleContainer#registerSingleton}.
  * <p>
  * Before this plan, {@code registerSingleton} was a two-line method: {@code addSingleton} plus a
  * type-mapping write. No autowiring, no {@code @PostConstruct}, no {@code BeanPostProcessor}
- * chain. Every assembly case below is run <b>both</b> before and after {@code refresh()}, because
+ * chain -- and no refusal for an object whose class carries an AOP annotation it could never
+ * honour. Every assembly case below is run <b>both</b> before and after {@code refresh()}, because
  * "the outcome does not depend on refresh state" is the substance of D-14 and a single-state test
  * cannot show it -- a post-refresh-only case would also pass under a narrower window-guard fix
  * that D-14 explicitly rejects as insufficient (it would have left the config entities, the
@@ -213,6 +225,133 @@ class RegisterSingletonAssemblyTest {
 
             assertSame(plain, container.getBean("plain"));
             assertEquals("unchanged", plain.value);
+        }
+    }
+
+    // ===== Task 2: AOP refusal on a pre-constructed instance (D-15) =====
+
+    static class MethodLevelExceptionCatchBean {
+        @ExceptionCatch
+        void guarded() {
+        }
+    }
+
+    static class MethodLevelTransactionalBean {
+        @Transactional
+        void guarded() {
+        }
+    }
+
+    @Transactional
+    static class ClassLevelTransactionalBean {
+        void work() {
+        }
+    }
+
+    @ExceptionCatch
+    static class ClassLevelExceptionCatchBean {
+        void work() {
+        }
+    }
+
+    static class NoAopAnnotationBean {
+        void work() {
+        }
+    }
+
+    @Nested
+    @DisplayName("refuses an instance whose class carries an AOP annotation it can never honour")
+    class AopRefusal {
+
+        @Test
+        @DisplayName("method-level @ExceptionCatch is refused, naming the class and the method")
+        void methodLevelExceptionCatchRefused() {
+            SimpleContainer container = new SimpleContainer();
+
+            ContainerException thrown = assertThrows(ContainerException.class,
+                    () -> container.registerSingleton("guarded", new MethodLevelExceptionCatchBean()));
+
+            assertTrue(thrown.getMessage().contains(MethodLevelExceptionCatchBean.class.getName()),
+                    thrown.getMessage());
+            assertTrue(thrown.getMessage().contains("guarded"), thrown.getMessage());
+        }
+
+        @Test
+        @DisplayName("method-level @Transactional is refused too")
+        void methodLevelTransactionalRefused() {
+            SimpleContainer container = new SimpleContainer();
+
+            ContainerException thrown = assertThrows(ContainerException.class,
+                    () -> container.registerSingleton("guarded", new MethodLevelTransactionalBean()));
+
+            assertTrue(thrown.getMessage().contains(MethodLevelTransactionalBean.class.getName()),
+                    thrown.getMessage());
+        }
+
+        @Test
+        @DisplayName("class-level @Transactional is refused -- not just method-level")
+        void classLevelTransactionalRefused() {
+            SimpleContainer container = new SimpleContainer();
+
+            ContainerException thrown = assertThrows(ContainerException.class,
+                    () -> container.registerSingleton("classLevel", new ClassLevelTransactionalBean()));
+
+            assertTrue(thrown.getMessage().contains(ClassLevelTransactionalBean.class.getName()),
+                    thrown.getMessage());
+        }
+
+        @Test
+        @DisplayName("class-level @ExceptionCatch is refused too")
+        void classLevelExceptionCatchRefused() {
+            SimpleContainer container = new SimpleContainer();
+
+            ContainerException thrown = assertThrows(ContainerException.class,
+                    () -> container.registerSingleton("classLevel", new ClassLevelExceptionCatchBean()));
+
+            assertTrue(thrown.getMessage().contains(ClassLevelExceptionCatchBean.class.getName()),
+                    thrown.getMessage());
+        }
+
+        @Test
+        @DisplayName("an instance with no AOP annotation is never refused")
+        void noAnnotationNotRefused() {
+            SimpleContainer container = new SimpleContainer();
+
+            assertDoesNotThrow(() -> container.registerSingleton("plain", new NoAopAnnotationBean()));
+        }
+
+        @Test
+        @DisplayName("a generated proxy is not refused, even though its class carries the copied annotation")
+        void generatedProxyNotRefused() {
+            SimpleContainer aopContainer = new SimpleContainer();
+            AopProxyResolver resolver = new AopProxyResolver();
+            resolver.addAdvisor(AopAdvisor.forAnnotation(ExceptionCatch.class, new ExceptionInterceptor(), 200));
+            aopContainer.setAopProxyResolver(resolver);
+            aopContainer.registerBean(MethodLevelExceptionCatchBean.class);
+            aopContainer.refresh();
+
+            MethodLevelExceptionCatchBean proxied = aopContainer.getBean(MethodLevelExceptionCatchBean.class);
+            assertTrue(ProxyFactory.isProxyClass(proxied.getClass()),
+                    "guard: this case must actually exercise a real generated proxy, or refusing "
+                            + "it (or not) proves nothing");
+
+            SimpleContainer target = new SimpleContainer();
+            assertDoesNotThrow(() -> target.registerSingleton("proxied", proxied),
+                    "a generated proxy already honours its own AOP annotations and must not be refused");
+        }
+    }
+
+    @Nested
+    @DisplayName("the framework's own bootstrap registrations must still succeed")
+    class BootstrapCompatibility {
+
+        @Test
+        @DisplayName("a plain object with neither @Autowired, @PostConstruct, nor an AOP annotation still loads")
+        void plainBootstrapObjectStillLoads() {
+            SimpleContainer container = new SimpleContainer();
+
+            assertDoesNotThrow(() -> container.registerSingleton("bootstrap", new NoAopAnnotationBean()));
+            assertNotNull(container.getBean("bootstrap"));
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/context/RegisterSingletonAssemblyTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/RegisterSingletonAssemblyTest.java
@@ -1,0 +1,218 @@
+package com.ultikits.ultitools.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.ultikits.ultitools.annotations.Autowired;
+import com.ultikits.ultitools.annotations.PostConstruct;
+
+/**
+ * Pins D-14 (full assembly, unconditional on {@code refresh()} state) for
+ * {@link SimpleContainer#registerSingleton}.
+ * <p>
+ * Before this plan, {@code registerSingleton} was a two-line method: {@code addSingleton} plus a
+ * type-mapping write. No autowiring, no {@code @PostConstruct}, no {@code BeanPostProcessor}
+ * chain. Every assembly case below is run <b>both</b> before and after {@code refresh()}, because
+ * "the outcome does not depend on refresh state" is the substance of D-14 and a single-state test
+ * cannot show it -- a post-refresh-only case would also pass under a narrower window-guard fix
+ * that D-14 explicitly rejects as insufficient (it would have left the config entities, the
+ * {@code @Configuration} instance, and the {@code @Bean} products -- all registered before
+ * {@code refresh()} -- exactly as uninjected as before).
+ */
+@DisplayName("registerSingleton full assembly and AOP refusal (D-14/D-15)")
+class RegisterSingletonAssemblyTest {
+
+    // ===== Fixtures =====
+
+    static class Dependency {
+    }
+
+    static class WithAutowiredField {
+        @Autowired
+        Dependency dependency;
+    }
+
+    static class WithPostConstruct {
+        int callCount = 0;
+
+        @PostConstruct
+        void init() {
+            callCount++;
+        }
+    }
+
+    static class Plain {
+        String value = "unchanged";
+    }
+
+    /** Substitutes the bean with a different instance in postProcessAfterInitialization. */
+    static class SubstitutingPostProcessor implements BeanPostProcessor {
+        final Object replacement;
+
+        SubstitutingPostProcessor(Object replacement) {
+            this.replacement = replacement;
+        }
+
+        @Override
+        public Object postProcessAfterInitialization(Object bean, String beanName) {
+            return replacement;
+        }
+    }
+
+    /** Records every bean name/instance it sees, for both processor callbacks. */
+    static class RecordingPostProcessor implements BeanPostProcessor {
+        java.util.List<String> beforeNames = new java.util.ArrayList<>();
+        java.util.List<String> afterNames = new java.util.ArrayList<>();
+
+        @Override
+        public Object postProcessBeforeInitialization(Object bean, String beanName) {
+            beforeNames.add(beanName);
+            return bean;
+        }
+
+        @Override
+        public Object postProcessAfterInitialization(Object bean, String beanName) {
+            afterNames.add(beanName);
+            return bean;
+        }
+    }
+
+    // ===== Task 1: full assembly, unconditional on refresh() state (D-14) =====
+
+    @Nested
+    @DisplayName("@Autowired field is populated regardless of refresh() state")
+    class AutowiringAssembly {
+
+        @Test
+        @DisplayName("before refresh(): field is populated")
+        void populatedBeforeRefresh() {
+            SimpleContainer container = new SimpleContainer();
+            Dependency dependency = new Dependency();
+            container.registerSingleton("dependency", dependency);
+
+            WithAutowiredField bean = new WithAutowiredField();
+            container.registerSingleton("withAutowiredField", bean);
+
+            assertSame(dependency, bean.dependency,
+                    "the @Autowired field must be populated even though refresh() has not run yet");
+        }
+
+        @Test
+        @DisplayName("after refresh(): field is populated too -- same outcome, not gated on refresh state")
+        void populatedAfterRefresh() {
+            SimpleContainer container = new SimpleContainer();
+            Dependency dependency = new Dependency();
+            container.registerSingleton("dependency", dependency);
+            container.refresh();
+
+            WithAutowiredField bean = new WithAutowiredField();
+            container.registerSingleton("withAutowiredField", bean);
+
+            assertSame(dependency, bean.dependency,
+                    "the @Autowired field must be populated after refresh() has already run -- "
+                            + "D-14 explicitly rejects gating assembly on refresh state");
+        }
+    }
+
+    @Nested
+    @DisplayName("@PostConstruct is invoked exactly once, regardless of refresh() state")
+    class PostConstructAssembly {
+
+        @Test
+        @DisplayName("before refresh(): @PostConstruct runs once")
+        void invokedBeforeRefresh() {
+            SimpleContainer container = new SimpleContainer();
+            WithPostConstruct bean = new WithPostConstruct();
+
+            container.registerSingleton("withPostConstruct", bean);
+
+            assertEquals(1, bean.callCount,
+                    "@PostConstruct must run exactly once as a side effect of registerSingleton, "
+                            + "not merely leave the bean retrievable afterwards");
+        }
+
+        @Test
+        @DisplayName("after refresh(): @PostConstruct runs once too")
+        void invokedAfterRefresh() {
+            SimpleContainer container = new SimpleContainer();
+            container.refresh();
+            WithPostConstruct bean = new WithPostConstruct();
+
+            container.registerSingleton("withPostConstruct", bean);
+
+            assertEquals(1, bean.callCount, "@PostConstruct must run once after refresh() too");
+        }
+
+        @Test
+        @DisplayName("registering a second bean under the same name does not re-invoke the first's @PostConstruct")
+        void secondRegistrationUnderSameNameDoesNotDoubleInvokeFirst() {
+            SimpleContainer container = new SimpleContainer();
+            WithPostConstruct first = new WithPostConstruct();
+            container.registerSingleton("shared", first);
+            assertEquals(1, first.callCount);
+
+            WithPostConstruct second = new WithPostConstruct();
+            container.registerSingleton("shared", second);
+
+            assertEquals(1, first.callCount,
+                    "the first object's own @PostConstruct must not run again just because a "
+                            + "second object was registered under the same name");
+            assertEquals(1, second.callCount, "the second object's own @PostConstruct must run exactly once");
+        }
+    }
+
+    @Nested
+    @DisplayName("BeanPostProcessor chain sees the instance both before and after initialization")
+    class BeanPostProcessorChain {
+
+        @Test
+        @DisplayName("both callbacks are invoked with the registered name")
+        void bothCallbacksInvoked() {
+            SimpleContainer container = new SimpleContainer();
+            RecordingPostProcessor processor = new RecordingPostProcessor();
+            container.addBeanPostProcessor(processor);
+
+            container.registerSingleton("plain", new Plain());
+
+            assertEquals(java.util.Collections.singletonList("plain"), processor.beforeNames);
+            assertEquals(java.util.Collections.singletonList("plain"), processor.afterNames);
+        }
+
+        @Test
+        @DisplayName("a substitute returned from postProcessAfterInitialization is what getBean returns")
+        void substituteIsStored() {
+            SimpleContainer container = new SimpleContainer();
+            Plain replacement = new Plain();
+            replacement.value = "substituted";
+            container.addBeanPostProcessor(new SubstitutingPostProcessor(replacement));
+
+            container.registerSingleton("plain", new Plain());
+
+            assertSame(replacement, container.getBean("plain"),
+                    "getBean must return whatever postProcessAfterInitialization returned, not the "
+                            + "original argument -- otherwise every processor sees the bean and none "
+                            + "of them can actually affect it");
+        }
+    }
+
+    @Nested
+    @DisplayName("an object with nothing to assemble behaves exactly as before")
+    class NoOpAssembly {
+
+        @Test
+        @DisplayName("stored and retrievable, unchanged")
+        void storedAndRetrievable() {
+            SimpleContainer container = new SimpleContainer();
+            Plain plain = new Plain();
+
+            container.registerSingleton("plain", plain);
+
+            assertSame(plain, container.getBean("plain"));
+            assertEquals("unchanged", plain.value);
+        }
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/context/RegisterSingletonAssemblyTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/RegisterSingletonAssemblyTest.java
@@ -449,7 +449,6 @@ class RegisterSingletonAssemblyTest {
         void firstRegisteredObjectThrowsWhenFieldIsRequired() {
             SimpleContainer container = new SimpleContainer();
             MutualARequired a = new MutualARequired();
-            MutualBRequired b = new MutualBRequired();
 
             assertThrows(ContainerException.class,
                     () -> container.registerSingleton("mutualARequired", a),

--- a/src/test/java/com/ultikits/ultitools/context/RegisterSingletonAssemblyTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/RegisterSingletonAssemblyTest.java
@@ -378,6 +378,77 @@ class RegisterSingletonAssemblyTest {
         }
     }
 
+    // ===== WR-02: documented mutual-reference limitation =====
+
+    static class MutualA {
+        @Autowired(required = false)
+        MutualB b;
+    }
+
+    static class MutualB {
+        @Autowired(required = false)
+        MutualA a;
+    }
+
+    static class MutualARequired {
+        @Autowired
+        MutualBRequired b;
+    }
+
+    static class MutualBRequired {
+        @Autowired(required = false)
+        MutualARequired a;
+    }
+
+    /**
+     * Pins the documented WR-02 limitation on {@code registerSingleton}'s javadoc: two objects
+     * registered via separate, sequential {@code registerSingleton} calls that mutually
+     * {@code @Autowired} each other cannot both resolve one another, because -- unlike
+     * {@code createBean} -- the container never constructs either object and so has no hook to
+     * trigger the second (not-yet-registered) one's construction on the first's behalf. This is
+     * NOT a bug fix -- registerSingleton's behaviour here is unchanged by 03-fix. The test exists
+     * so a future change that silently breaks (or, more likely, silently "half fixes" only one
+     * side of) this documented constraint is caught.
+     */
+    @Nested
+    @DisplayName("mutual @Autowired between two registerSingleton-registered objects (WR-02, documented limitation)")
+    class MutualReferenceLimitation {
+
+        @Test
+        @DisplayName("the object registered FIRST cannot resolve the object registered SECOND "
+                + "(required = false: field stays null)")
+        void firstRegisteredObjectCannotResolveSecondWhenOptional() {
+            SimpleContainer container = new SimpleContainer();
+            MutualA a = new MutualA();
+            MutualB b = new MutualB();
+
+            container.registerSingleton("mutualA", a);
+            container.registerSingleton("mutualB", b);
+
+            assertEquals(null, a.b,
+                    "inert-case guard: A's field must actually be null here -- if a future change "
+                            + "silently fixed only this direction, this assertion is what would "
+                            + "catch it and the javadoc would need updating, not deleting");
+            assertSame(a, b.a,
+                    "B, registered second, resolves normally since A already exists in the "
+                            + "container by the time B is autowired");
+        }
+
+        @Test
+        @DisplayName("the object registered FIRST throws if its field is required = true")
+        void firstRegisteredObjectThrowsWhenFieldIsRequired() {
+            SimpleContainer container = new SimpleContainer();
+            MutualARequired a = new MutualARequired();
+            MutualBRequired b = new MutualBRequired();
+
+            assertThrows(ContainerException.class,
+                    () -> container.registerSingleton("mutualARequired", a),
+                    "A's required @Autowired field cannot resolve B, which does not exist in the "
+                            + "container in any form yet -- this must fail loudly (D-08), not "
+                            + "silently leave the field null");
+        }
+    }
+
     // ===== Task 2: initializePlugin ordering (T-03-27) =====
 
     @Nested

--- a/src/test/java/com/ultikits/ultitools/context/RegisterSingletonAssemblyTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/RegisterSingletonAssemblyTest.java
@@ -6,11 +6,30 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.logging.Logger;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import com.ultikits.testfixtures.registersingletonordering.OrderingFixtureModule;
+import com.ultikits.testfixtures.registersingletonordering.OrderingFixtureService;
+import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.annotations.Autowired;
 import com.ultikits.ultitools.annotations.ExceptionCatch;
 import com.ultikits.ultitools.annotations.PostConstruct;
@@ -20,6 +39,10 @@ import com.ultikits.ultitools.aop.AopProxyResolver;
 import com.ultikits.ultitools.aop.ExceptionInterceptor;
 import com.ultikits.ultitools.aop.ProxyFactory;
 import com.ultikits.ultitools.exceptions.ContainerException;
+import com.ultikits.ultitools.interfaces.impl.data.json.JsonStore;
+import com.ultikits.ultitools.manager.ConfigManager;
+import com.ultikits.ultitools.manager.DependenceManagers;
+import com.ultikits.ultitools.manager.PluginManager;
 
 /**
  * Pins D-14 (full assembly, unconditional on {@code refresh()} state) and D-15 (refusal of an
@@ -352,6 +375,160 @@ class RegisterSingletonAssemblyTest {
 
             assertDoesNotThrow(() -> container.registerSingleton("bootstrap", new NoAopAnnotationBean()));
             assertNotNull(container.getBean("bootstrap"));
+        }
+    }
+
+    // ===== Task 2: initializePlugin ordering (T-03-27) =====
+
+    @Nested
+    @DisplayName("PluginManager.initializePlugin: the plugin's own @Autowired field resolves "
+            + "against its own scanned beans")
+    class InitializePluginOrdering {
+
+        @TempDir
+        File tempDir;
+
+        @org.junit.jupiter.api.BeforeEach
+        void setUpBukkit() {
+            // scanEntitiesInJar's own IOException/LinkageError/RuntimeException catch (D-19)
+            // reaches Bukkit.getLogger() when this fixture's untrusted-package SecurityException
+            // is logged; that call NPEs without a real Bukkit server present.
+            com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
+            org.mockbukkit.mockbukkit.MockBukkit.mock();
+        }
+
+        @org.junit.jupiter.api.AfterEach
+        void tearDownBukkit() {
+            com.ultikits.ultitools.utils.MockBukkitHelper.safeUnmock();
+        }
+
+        /**
+         * Child-first for the fixture package only. {@link OrderingFixtureModule} and
+         * {@link OrderingFixtureService} are also compiled normally onto the ambient test
+         * classpath (so {@code ComponentScanner}'s directory-based package scan can discover
+         * them there via ordinary parent-first {@code getResource}), but {@code
+         * UltiToolsPlugin}'s no-arg constructor needs the plugin class's own {@code CodeSource}
+         * to be a real jar file, which {@code target/test-classes} is not. Trying this loader's
+         * own jar FIRST for the fixture package (instead of standard parent-first delegation) is
+         * what gives {@code OrderingFixtureModule} a jar-backed {@code CodeSource}; every other
+         * class (supertypes, annotations) still delegates to the parent normally.
+         */
+        private final class FixtureJarClassLoader extends URLClassLoader {
+            private final String isolatedPrefix;
+
+            FixtureJarClassLoader(URL jarUrl, ClassLoader parent, String isolatedPrefix) {
+                super(new URL[]{jarUrl}, parent);
+                this.isolatedPrefix = isolatedPrefix;
+            }
+
+            @Override
+            protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                synchronized (getClassLoadingLock(name)) {
+                    Class<?> found = findLoadedClass(name);
+                    if (found == null && name.startsWith(isolatedPrefix)) {
+                        try {
+                            found = findClass(name);
+                        } catch (ClassNotFoundException ignored) {
+                            // Not present in this loader's own jar -- fall through to normal
+                            // parent-first delegation below.
+                        }
+                    }
+                    if (found == null) {
+                        found = super.loadClass(name, false);
+                    }
+                    if (resolve) {
+                        resolveClass(found);
+                    }
+                    return found;
+                }
+            }
+        }
+
+        private File buildFixtureJar() throws Exception {
+            File jar = new File(tempDir, "ordering-fixture.jar");
+            try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jar.toPath()))) {
+                writeClassEntry(output, OrderingFixtureService.class);
+                writeClassEntry(output, OrderingFixtureModule.class);
+
+                output.putNextEntry(new JarEntry("plugin.yml"));
+                output.write("name: OrderingFixtureModule\nversion: 1.0.0\n"
+                        .getBytes(StandardCharsets.UTF_8));
+                output.closeEntry();
+            }
+            return jar;
+        }
+
+        private void writeClassEntry(JarOutputStream output, Class<?> clazz) throws Exception {
+            String resourceName = clazz.getName().replace('.', '/') + ".class";
+            output.putNextEntry(new JarEntry(resourceName));
+            try (InputStream input = clazz.getResourceAsStream("/" + resourceName)) {
+                assertNotNull(input, "compiled class resource for " + clazz.getName());
+                byte[] buffer = new byte[4096];
+                int read;
+                while ((read = input.read(buffer)) != -1) {
+                    output.write(buffer, 0, read);
+                }
+            }
+            output.closeEntry();
+        }
+
+        @Test
+        @DisplayName("the module main class's @Autowired field is populated after initializePlugin returns")
+        void autowiredFieldOnModuleMainClassIsPopulated() throws Exception {
+            File jar = buildFixtureJar();
+            FixtureJarClassLoader loader = new FixtureJarClassLoader(jar.toURI().toURL(),
+                    Thread.currentThread().getContextClassLoader(),
+                    "com.ultikits.testfixtures.registersingletonordering.");
+            Class<?> pluginClass = Class.forName(
+                    "com.ultikits.testfixtures.registersingletonordering.OrderingFixtureModule",
+                    true, loader);
+
+            DependenceManagers mockDependenceManagers = mock(DependenceManagers.class);
+            when(mockDependenceManagers.getContext()).thenReturn(new SimpleContainer());
+
+            JsonStore jsonStore = new JsonStore(new File(tempDir, "json").getAbsolutePath());
+
+            UltiTools mockUltiTools = mock(UltiTools.class);
+            lenient().when(mockUltiTools.getDataFolder()).thenReturn(tempDir);
+            lenient().when(mockUltiTools.getLogger()).thenReturn(
+                    Logger.getLogger("RegisterSingletonAssemblyTest.InitializePluginOrdering"));
+            lenient().when(mockUltiTools.getDataStore()).thenReturn(jsonStore);
+            lenient().when(mockUltiTools.getDependenceManagers()).thenReturn(mockDependenceManagers);
+            lenient().when(mockUltiTools.getConfigManager()).thenReturn(mock(ConfigManager.class));
+            // UltiToolsPlugin's no-arg constructor reads getConfig().getString("language")
+            // (Bukkit's own JavaPlugin.getConfig(), unstubbed on a full mock returns null and
+            // NPEs) -- an empty YamlConfiguration is enough; a missing "language" key just falls
+            // through to the {} default language.
+            lenient().when(mockUltiTools.getConfig())
+                    .thenReturn(new org.bukkit.configuration.file.YamlConfiguration());
+
+            PluginManager pluginManager = new PluginManager();
+            Method initializePlugin = PluginManager.class.getDeclaredMethod(
+                    "initializePlugin", ClassLoader.class, Class.class, Object[].class);
+            initializePlugin.setAccessible(true);
+
+            Object plugin;
+            // passesCompatibilityGates -> UltiTools.getPluginVersion() -> getEnv() reads env.yml
+            // through getInstance().getTextResource(String), which is protected on Bukkit's own
+            // JavaPlugin and cannot be stubbed from this package -- so the STATIC call site is
+            // stubbed directly instead, the same workaround PluginManagerTest's own
+            // CompatibilityGateOrderingTests uses for the identical problem.
+            try (org.mockito.MockedStatic<UltiTools> ultiToolsStatic = org.mockito.Mockito.mockStatic(
+                    UltiTools.class, org.mockito.Mockito.CALLS_REAL_METHODS)) {
+                ultiToolsStatic.when(UltiTools::getInstance).thenReturn(mockUltiTools);
+                ultiToolsStatic.when(UltiTools::getPluginVersion).thenReturn(Integer.MAX_VALUE);
+
+                plugin = initializePlugin.invoke(pluginManager, loader, pluginClass, new Object[0]);
+            }
+
+            assertNotNull(plugin, "initializePlugin must not refuse this module");
+            Field serviceField = pluginClass.getDeclaredField("service");
+            serviceField.setAccessible(true);
+            assertNotNull(serviceField.get(plugin),
+                    "the module main class's own @Autowired field must be populated -- inert "
+                            + "case: asserting only that initializePlugin returned non-null passes "
+                            + "even if the field is null, which is the pre-6.3.0 defect this "
+                            + "milestone exists to delete");
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/context/RegisterSingletonAssemblyTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/RegisterSingletonAssemblyTest.java
@@ -256,29 +256,39 @@ class RegisterSingletonAssemblyTest {
     static class MethodLevelExceptionCatchBean {
         @ExceptionCatch
         void guarded() {
+            // Intentionally empty: this fixture only proves AOP eligibility/refusal wiring
+            // (D-15) -- the method body itself is never exercised.
         }
     }
 
     static class MethodLevelTransactionalBean {
         @Transactional
         void guarded() {
+            // Intentionally empty: this fixture only proves AOP eligibility/refusal wiring
+            // (D-15) -- the method body itself is never exercised.
         }
     }
 
     @Transactional
     static class ClassLevelTransactionalBean {
         void work() {
+            // Intentionally empty: this fixture only proves AOP eligibility/refusal wiring
+            // (D-15) -- the method body itself is never exercised.
         }
     }
 
     @ExceptionCatch
     static class ClassLevelExceptionCatchBean {
         void work() {
+            // Intentionally empty: this fixture only proves AOP eligibility/refusal wiring
+            // (D-15) -- the method body itself is never exercised.
         }
     }
 
     static class NoAopAnnotationBean {
         void work() {
+            // Intentionally empty: this fixture only proves AOP eligibility/refusal wiring
+            // (D-15) -- the method body itself is never exercised.
         }
     }
 

--- a/src/test/java/com/ultikits/ultitools/context/RegisterSingletonAssemblyTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/RegisterSingletonAssemblyTest.java
@@ -554,6 +554,7 @@ class RegisterSingletonAssemblyTest {
 
         @Test
         @DisplayName("the module main class's @Autowired field is populated after initializePlugin returns")
+        @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
         void autowiredFieldOnModuleMainClassIsPopulated() throws Exception {
             File jar = buildFixtureJar();
             FixtureJarClassLoader loader = new FixtureJarClassLoader(jar.toURI().toURL(),

--- a/src/test/java/com/ultikits/ultitools/context/RequiredDependencyModuleIsolationTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/RequiredDependencyModuleIsolationTest.java
@@ -1,0 +1,98 @@
+package com.ultikits.ultitools.context;
+
+import com.ultikits.ultitools.context.isolationfixture.clean.CleanService;
+import com.ultikits.ultitools.exceptions.ContainerException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Container-granularity layer of D-08's isolation guarantee: an unresolvable
+ * {@code @Autowired(required = true)} dependency aborts the container whose scan hit it, and a
+ * sibling container scanning a clean package -- and the shared parent both containers descend
+ * from -- are unaffected.
+ * <p>
+ * {@link com.ultikits.ultitools.manager.PluginManagerClassScanningTest} already proves the
+ * JAR-loading layer above this one ("a bad JAR doesn't block scanning of a subsequent valid
+ * JAR"); this test proves the container-level layer beneath it and deliberately does not rebuild
+ * a JAR-loading harness.
+ * <br>
+ * D-08 隔离保证在容器粒度上的一层：一个无法解析的 {@code @Autowired(required = true)} 依赖会中止
+ * 触发它的那个容器的扫描，而扫描干净包的同级容器——以及两个容器共同的父容器——都不受影响。
+ * {@link com.ultikits.ultitools.manager.PluginManagerClassScanningTest} 已经证明了它上层的
+ * JAR 加载层（"坏 JAR 不应该阻止后续有效 JAR 扫描"）；本测试证明的是它下方的容器层，故意不重建
+ * 一套 JAR 加载测试设施。
+ */
+@DisplayName("Required-dependency refusal is contained to one module's container")
+class RequiredDependencyModuleIsolationTest {
+
+    private static final String BROKEN_PACKAGE =
+            "com.ultikits.ultitools.context.isolationfixture.broken";
+    private static final String CLEAN_PACKAGE =
+            "com.ultikits.ultitools.context.isolationfixture.clean";
+
+    private SimpleContainer parentContainer;
+    private SimpleContainer brokenContainer;
+    private SimpleContainer cleanContainer;
+
+    @BeforeEach
+    void setUp() {
+        parentContainer = new SimpleContainer();
+        parentContainer.registerSingleton("parentMarker", "parent value");
+
+        brokenContainer = new SimpleContainer(parentContainer);
+        cleanContainer = new SimpleContainer(parentContainer);
+    }
+
+    @Test
+    @DisplayName("A container whose scan hits an unresolvable required dependency aborts on refresh")
+    void brokenContainerAbortsOnScanAndRefresh() {
+        // Given - scanning only registers the bean definition, it does not eagerly instantiate it
+        brokenContainer.scanComponents(BROKEN_PACKAGE);
+
+        // When / Then - the unresolvable @Autowired(required = true) field surfaces as
+        // ContainerException when the container is refreshed (bean instantiation time), not
+        // caught and logged as a skip
+        assertThrows(ContainerException.class, () -> brokenContainer.refresh());
+    }
+
+    @Test
+    @DisplayName("A sibling container scanning a clean package still registers its components")
+    void siblingContainerStillRegistersAfterBrokenContainerFails() {
+        // Given - the broken container's scan+refresh has already failed
+        brokenContainer.scanComponents(BROKEN_PACKAGE);
+        assertThrows(ContainerException.class, () -> brokenContainer.refresh());
+
+        // When - a second, independent container scans a clean package
+        cleanContainer.scanComponents(CLEAN_PACKAGE);
+        assertDoesNotThrow(() -> cleanContainer.refresh());
+
+        // Then - its own component is retrievable, by name and by type
+        assertNotNull(cleanContainer.getBean("cleanService"),
+                "the sibling container's own component must still be retrievable by name");
+        CleanService service = cleanContainer.getBean(CleanService.class);
+        assertNotNull(service, "the sibling container's own component must still be retrievable by type");
+        assertEquals("pong", service.ping());
+    }
+
+    @Test
+    @DisplayName("A bean registered on the shared parent before the failure is still retrievable after it")
+    void parentContainerIsUnaffectedByChildFailure() {
+        // Given - a bean already registered on the shared parent, before either child scans
+        assertEquals("parent value", parentContainer.getBean("parentMarker"));
+
+        // When - the broken child container fails
+        brokenContainer.scanComponents(BROKEN_PACKAGE);
+        assertThrows(ContainerException.class, () -> brokenContainer.refresh());
+
+        // Then - the parent-registered bean is still retrievable directly, and through the
+        // still-working sibling container's own parent-delegation
+        assertEquals("parent value", parentContainer.getBean("parentMarker"));
+        assertEquals("parent value", cleanContainer.getBean("parentMarker"));
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/context/SimpleContainerAmbiguityTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/SimpleContainerAmbiguityTest.java
@@ -3,6 +3,7 @@ package com.ultikits.ultitools.context;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -110,6 +111,28 @@ class SimpleContainerAmbiguityTest {
         public String id() {
             return "marker";
         }
+    }
+
+    @Service(priority = 20)
+    static class LateHigherPriorityGreeter implements Greeter {
+        @Override
+        public String greet() {
+            return "late-higher";
+        }
+    }
+
+    @Service(priority = 0)
+    static class LateEqualPriorityGreeter implements Greeter {
+        @Override
+        public String greet() {
+            return "late-equal";
+        }
+    }
+
+    static class UnrelatedSingleton {
+    }
+
+    static class UnrelatedBean {
     }
 
     // === Task 1: priority ordering and the tie refusal ===
@@ -291,6 +314,84 @@ class SimpleContainerAmbiguityTest {
             child.refresh();
 
             assertThrows(ContainerException.class, () -> child.getBean(Greeter.class));
+        }
+    }
+
+    // === Task 2: cache invalidation ===
+
+    @Nested
+    @DisplayName("Resolution cache invalidation (D-12)")
+    class CacheInvalidationTests {
+
+        @Test
+        @DisplayName("A late higher-priority implementation is not masked by an earlier resolution")
+        void lateHigherPriorityImplementationParticipatesInNextResolution() {
+            SimpleContainer container = new SimpleContainer();
+            container.registerBean(LowPriorityGreeter.class);
+            container.refresh();
+
+            Greeter firstResolution = container.getBean(Greeter.class);
+            assertEquals("low", firstResolution.greet());
+
+            container.registerBean(LateHigherPriorityGreeter.class);
+            container.refresh();
+
+            Greeter secondResolution = container.getBean(Greeter.class);
+
+            // Inert-case guard: without invalidation the first resolution stays cached
+            // permanently and this would still return "low".
+            assertEquals("late-higher", secondResolution.greet());
+        }
+
+        @Test
+        @DisplayName("A late equal-priority implementation throws on the next resolution")
+        void lateEqualPriorityImplementationThrowsOnNextResolution() {
+            SimpleContainer container = new SimpleContainer();
+            container.registerBean(DefaultPriorityGreeterA.class);
+            container.refresh();
+
+            Greeter firstResolution = container.getBean(Greeter.class);
+            assertEquals("default-a", firstResolution.greet());
+
+            container.registerBean(LateEqualPriorityGreeter.class);
+            container.refresh();
+
+            // Inert-case guard: this is precisely the scenario D-12 exists for. Without
+            // invalidation the cached first resolution is returned and the ambiguity check
+            // never fires here -- indistinguishable from there being no check at all.
+            assertThrows(ContainerException.class, () -> container.getBean(Greeter.class));
+        }
+
+        @Test
+        @DisplayName("An explicit registerType binding survives an unrelated registerSingleton and registerBeanDefinition")
+        void explicitTypeBindingSurvivesUnrelatedRegistrations() {
+            SimpleContainer container = new SimpleContainer();
+            MarkerImpl explicitInstance = new MarkerImpl();
+            container.registerType(Marker.class, explicitInstance);
+
+            container.registerSingleton("unrelatedSingleton", new UnrelatedSingleton());
+            container.registerBean(UnrelatedBean.class);
+            container.refresh();
+
+            Marker resolved = container.getBean(Marker.class);
+
+            // Inert-case guard: a blanket typeMappings.clear() invalidation strategy would
+            // satisfy every other assertion in this class while silently dropping this
+            // author-declared binding.
+            assertSame(explicitInstance, resolved);
+        }
+
+        @Test
+        @DisplayName("Repeated resolution with no intervening registration returns the same cached instance")
+        void repeatedResolutionWithoutRegistrationReturnsCachedInstance() {
+            SimpleContainer container = new SimpleContainer();
+            container.registerBean(HighPriorityGreeter.class);
+            container.refresh();
+
+            Greeter first = container.getBean(Greeter.class);
+            Greeter second = container.getBean(Greeter.class);
+
+            assertSame(first, second);
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/context/SimpleContainerAmbiguityTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/SimpleContainerAmbiguityTest.java
@@ -127,6 +127,19 @@ class SimpleContainerAmbiguityTest {
         }
     }
 
+    /**
+     * CR-01 fixture: an ordinary, Spring-idiomatic naming choice (a lower-priority implementer
+     * explicitly named after the interface's own decapitalized default) that must NOT bypass
+     * priority adjudication -- unlike {@link MarkerImpl}, which is a genuine self-match.
+     */
+    @Service(value = "greeter", priority = 0)
+    static class NameCollidesWithInterfaceDefaultGreeter implements Greeter {
+        @Override
+        public String greet() {
+            return "name-collision-low";
+        }
+    }
+
     @Service(priority = 0)
     static class LateEqualPriorityGreeter implements Greeter {
         @Override
@@ -291,6 +304,33 @@ class SimpleContainerAmbiguityTest {
             MarkerImpl bean = container.getBean(MarkerImpl.class);
 
             assertEquals("marker", bean.id());
+        }
+
+        @Test
+        @DisplayName("CR-01: an unrelated bean explicitly named after the interface's own "
+                + "decapitalized default must not bypass priority adjudication")
+        void explicitNameCollidingWithInterfaceDefaultNameDoesNotBypassPriority() {
+            // getBeanName(Greeter.class) synthesizes "greeter" (Greeter has no @Component/
+            // @Service of its own). NameCollidesWithInterfaceDefaultGreeter is registered under
+            // that exact name via an explicit, ordinary @Service(value = "greeter") -- a
+            // completely idiomatic naming choice a module author could make with no idea it
+            // shares the requested interface's synthesized default. Before the CR-01 fix,
+            // getBean(Greeter.class)'s by-name shortcut (SimpleContainer.java:393-399) matched
+            // this name and returned it unconditionally, never reaching the priority/ambiguity
+            // adjudication a few lines below -- even though a strictly higher-priority
+            // implementer is also registered.
+            SimpleContainer container = new SimpleContainer();
+            container.registerBean(NameCollidesWithInterfaceDefaultGreeter.class);
+            container.registerBean(HighPriorityGreeter.class);
+            container.refresh();
+
+            Greeter bean = container.getBean(Greeter.class);
+
+            assertEquals("high", bean.greet(),
+                    "the higher-priority candidate (@Service(priority = 10)) must win even though "
+                            + "a lower-priority bean happens to be registered under the interface's "
+                            + "own decapitalized default name (\"greeter\") -- an accidental name "
+                            + "collision must not silently outrank @Service(priority = ...)");
         }
     }
 

--- a/src/test/java/com/ultikits/ultitools/context/SimpleContainerAmbiguityTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/SimpleContainerAmbiguityTest.java
@@ -467,6 +467,42 @@ class SimpleContainerAmbiguityTest {
         }
     }
 
+    @Nested
+    @DisplayName("close() releases resolvedTypeCache (WR-01)")
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+    class CloseReleasesResolvedTypeCache {
+
+        @Test
+        @DisplayName("resolvedTypeCache is empty after close(), not merely stale")
+        void closeClearsResolvedTypeCache() throws Exception {
+            SimpleContainer container = new SimpleContainer();
+            container.registerBean(HighPriorityGreeter.class);
+            container.refresh();
+
+            // Populate resolvedTypeCache via the normal by-type adjudication path -- the exact
+            // cache close() is supposed to release.
+            Greeter bean = container.getBean(Greeter.class);
+            assertNotNull(bean);
+
+            java.lang.reflect.Field cacheField = SimpleContainer.class.getDeclaredField("resolvedTypeCache");
+            cacheField.setAccessible(true);
+            java.util.Map<?, ?> cacheBeforeClose = (java.util.Map<?, ?>) cacheField.get(container);
+            assertFalse(cacheBeforeClose.isEmpty(),
+                    "guard: resolvedTypeCache must actually be populated before close(), or "
+                            + "clearing it proves nothing");
+
+            container.close();
+
+            java.util.Map<?, ?> cacheAfterClose = (java.util.Map<?, ?>) cacheField.get(container);
+            assertTrue(cacheAfterClose.isEmpty(),
+                    "close() must release resolvedTypeCache the same way it releases every other "
+                            + "Class/instance-keyed collection (singletonObjects, typeMappings, "
+                            + "beanDefinitions, ...), so a plugin's classloader-loaded Class objects "
+                            + "and instances stop being reachable through the container after "
+                            + "unload (WR-01)");
+        }
+    }
+
     // === Task 3: the proxy-annotation-copy dependency ===
 
     @Nested

--- a/src/test/java/com/ultikits/ultitools/context/SimpleContainerAmbiguityTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/SimpleContainerAmbiguityTest.java
@@ -389,6 +389,76 @@ class SimpleContainerAmbiguityTest {
         }
     }
 
+    // === Regression: PR #352 real-machine UAT -- singleton alias identity dedup ===
+
+    /**
+     * {@code getOrderedBeansOfType} must identity-deduplicate a singleton registered under two
+     * names before the ambiguity check runs. {@code DependenceManagers.initCoreServices()}
+     * deliberately registers the same {@code TeleportService}/{@code NotificationService}/
+     * {@code EmailService} instance under two names each (a short internal name plus the
+     * interface's FQN, so both {@code getBean(String)} and {@code getBean(Class)} resolve it) --
+     * before this fix, {@code getBean(NotificationService.class)} threw
+     * {@code ContainerException.ambiguousBeanType} naming the SAME instance against itself, which
+     * broke UltiSocial's {@code socialListener} bean on real-machine UAT (module load regressed
+     * 14/16 -> 13/16 against the #349 control run).
+     */
+    @Nested
+    @DisplayName("Singleton alias identity deduplication (regression: PR #352 UAT)")
+    class SingletonAliasIdentityDeduplicationTests {
+
+        @Test
+        @DisplayName("One instance registered under two names resolves by type without a false ambiguity")
+        void sameInstanceRegisteredUnderTwoNamesResolvesWithoutThrowing() {
+            SimpleContainer container = new SimpleContainer();
+            HighPriorityGreeter instance = new HighPriorityGreeter();
+            container.registerSingleton("aliasOne", instance);
+            container.registerSingleton("aliasTwo", instance);
+
+            Greeter resolved = assertDoesNotThrow(() -> container.getBean(Greeter.class),
+                    "the same object reached through two registration names is ONE candidate, "
+                            + "not two -- it must not trip the equal-priority ambiguity check");
+
+            assertSame(instance, resolved);
+        }
+
+        @Test
+        @DisplayName("Two DISTINCT instances of the same type at equal priority still throw "
+                + "(identity dedup must not reopen SILENT-06)")
+        void distinctInstancesAtEqualPriorityStillThrowAfterDedup() {
+            SimpleContainer container = new SimpleContainer();
+            HighPriorityGreeter first = new HighPriorityGreeter();
+            HighPriorityGreeter second = new HighPriorityGreeter();
+            container.registerSingleton("first", first);
+            container.registerSingleton("second", second);
+
+            ContainerException thrown = assertThrows(ContainerException.class,
+                    () -> container.getBean(Greeter.class),
+                    "two genuinely distinct instances of the same class at equal priority must "
+                            + "still be adjudicated as ambiguous -- deduping by class or by equals() "
+                            + "would silently delete the guarantee this milestone exists to add");
+
+            assertTrue(thrown.getMessage().contains(HighPriorityGreeter.class.getName()));
+        }
+
+        @Test
+        @DisplayName("A singleton aliased twice in the parent resolves from a child container (D-13)")
+        void aliasedParentSingletonResolvesFromChildWithoutThrowing() {
+            SimpleContainer parent = new SimpleContainer();
+            HighPriorityGreeter instance = new HighPriorityGreeter();
+            parent.registerSingleton("aliasOne", instance);
+            parent.registerSingleton("aliasTwo", instance);
+
+            SimpleContainer child = new SimpleContainer();
+            child.setParent(parent);
+
+            Greeter resolved = assertDoesNotThrow(() -> child.getBean(Greeter.class),
+                    "the child has zero candidates of its own, so it must fall through to the "
+                            + "parent (D-13) and the parent's own alias-dedup must not throw");
+
+            assertSame(instance, resolved);
+        }
+    }
+
     // === Task 2: cache invalidation ===
 
     @Nested

--- a/src/test/java/com/ultikits/ultitools/context/SimpleContainerAmbiguityTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/SimpleContainerAmbiguityTest.java
@@ -1,0 +1,296 @@
+package com.ultikits.ultitools.context;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.ultikits.ultitools.annotations.Service;
+import com.ultikits.ultitools.exceptions.ContainerException;
+
+/**
+ * Covers {@code SimpleContainer#getBean(Class)}'s by-type ambiguity adjudication (D-11/D-12):
+ * priority-ordered resolution between assignable candidates, a load-time refusal naming both
+ * candidates on a genuine tie, cache invalidation when a later implementation is registered, and
+ * the dependency priority ordering silently rests on -- that {@code ProxyFactory} copies the
+ * target's annotations onto the generated AOP subclass.
+ */
+@DisplayName("SimpleContainer by-type ambiguity adjudication")
+class SimpleContainerAmbiguityTest {
+
+    // === Fixture types ===
+
+    interface Greeter {
+        String greet();
+    }
+
+    @Service(priority = 10)
+    static class HighPriorityGreeter implements Greeter {
+        @Override
+        public String greet() {
+            return "high";
+        }
+    }
+
+    @Service(priority = 5)
+    static class LowPriorityGreeter implements Greeter {
+        @Override
+        public String greet() {
+            return "low";
+        }
+    }
+
+    @Service(priority = 5)
+    static class AnotherLowPriorityGreeter implements Greeter {
+        @Override
+        public String greet() {
+            return "low-2";
+        }
+    }
+
+    @Service
+    static class DefaultPriorityGreeterA implements Greeter {
+        @Override
+        public String greet() {
+            return "default-a";
+        }
+    }
+
+    @Service
+    static class DefaultPriorityGreeterB implements Greeter {
+        @Override
+        public String greet() {
+            return "default-b";
+        }
+    }
+
+    @Service(priority = 7)
+    static class EqualPriorityGreeterA implements Greeter {
+        @Override
+        public String greet() {
+            return "equal-a";
+        }
+    }
+
+    @Service(priority = 7)
+    static class EqualPriorityGreeterB implements Greeter {
+        @Override
+        public String greet() {
+            return "equal-b";
+        }
+    }
+
+    @Service
+    static class ParentGreeterImpl implements Greeter {
+        @Override
+        public String greet() {
+            return "parent";
+        }
+    }
+
+    @Service
+    static class ChildGreeterImpl implements Greeter {
+        @Override
+        public String greet() {
+            return "child";
+        }
+    }
+
+    interface Marker {
+        String id();
+    }
+
+    static class MarkerImpl implements Marker {
+        @Override
+        public String id() {
+            return "marker";
+        }
+    }
+
+    // === Task 1: priority ordering and the tie refusal ===
+
+    @Nested
+    @DisplayName("Priority-ordered resolution")
+    class PriorityOrderingTests {
+
+        @Test
+        @DisplayName("A single assignable candidate resolves without error")
+        void singleCandidateResolves() {
+            SimpleContainer container = new SimpleContainer();
+            container.registerBean(HighPriorityGreeter.class);
+            container.refresh();
+
+            Greeter bean = container.getBean(Greeter.class);
+
+            assertNotNull(bean);
+            assertEquals("high", bean.greet());
+        }
+
+        @Test
+        @DisplayName("Priority 10 beats priority 5 -- registration order A, B")
+        void higherPriorityWinsRegisteredHighFirst() {
+            SimpleContainer container = new SimpleContainer();
+            container.registerBean(HighPriorityGreeter.class);
+            container.registerBean(LowPriorityGreeter.class);
+            container.refresh();
+
+            Greeter bean = container.getBean(Greeter.class);
+
+            assertEquals("high", bean.greet(),
+                    "priority 10 must win regardless of registration order");
+        }
+
+        @Test
+        @DisplayName("Priority 10 beats priority 5 -- registration order reversed (B, A)")
+        void higherPriorityWinsRegisteredLowFirst() {
+            // Inert-case guard: a single-order test can pass under first-match-wins hash
+            // iteration purely by luck. Reversing registration order is what proves priority,
+            // not registration order, decided the outcome.
+            SimpleContainer container = new SimpleContainer();
+            container.registerBean(LowPriorityGreeter.class);
+            container.registerBean(HighPriorityGreeter.class);
+            container.refresh();
+
+            Greeter bean = container.getBean(Greeter.class);
+
+            assertEquals("high", bean.greet(),
+                    "priority 10 must win regardless of registration order");
+        }
+
+        @Test
+        @DisplayName("Direction matches @Service's own javadoc: higher value wins, not Spring's lower-wins")
+        void directionMatchesServiceJavadocNotSpring() {
+            SimpleContainer container = new SimpleContainer();
+            container.registerBean(LowPriorityGreeter.class);
+            container.registerBean(HighPriorityGreeter.class);
+            container.refresh();
+
+            Greeter bean = container.getBean(Greeter.class);
+
+            // If the framework silently adopted Spring's opposite (lower-wins) direction, this
+            // would return "low" instead -- deterministic, but inverted from what every
+            // 6.2.5-era javadoc reader expects.
+            assertEquals("high", bean.greet());
+        }
+
+        @Test
+        @DisplayName("A tie among lower-ranked candidates does not throw when the top candidate is unambiguous")
+        void tieAmongLowerCandidatesDoesNotThrow() {
+            SimpleContainer container = new SimpleContainer();
+            container.registerBean(HighPriorityGreeter.class);
+            container.registerBean(LowPriorityGreeter.class);
+            container.registerBean(AnotherLowPriorityGreeter.class);
+            container.refresh();
+
+            Greeter bean = assertDoesNotThrow(() -> container.getBean(Greeter.class),
+                    "priorities 10/5/5 must resolve to the unambiguous top candidate");
+
+            assertEquals("high", bean.greet());
+        }
+
+        @Test
+        @DisplayName("Two candidates at the default priority (0) throw, naming both")
+        void defaultPriorityTieThrowsNamingBoth() {
+            SimpleContainer container = new SimpleContainer();
+            container.registerBean(DefaultPriorityGreeterA.class);
+            container.registerBean(DefaultPriorityGreeterB.class);
+            container.refresh();
+
+            ContainerException thrown = assertThrows(ContainerException.class,
+                    () -> container.getBean(Greeter.class));
+
+            assertTrue(thrown.getMessage().contains(DefaultPriorityGreeterA.class.getName()));
+            assertTrue(thrown.getMessage().contains(DefaultPriorityGreeterB.class.getName()));
+        }
+
+        @Test
+        @DisplayName("Two candidates at an equal explicit priority (7) throw, naming both")
+        void equalExplicitPriorityTieThrowsNamingBoth() {
+            SimpleContainer container = new SimpleContainer();
+            container.registerBean(EqualPriorityGreeterA.class);
+            container.registerBean(EqualPriorityGreeterB.class);
+            container.refresh();
+
+            ContainerException thrown = assertThrows(ContainerException.class,
+                    () -> container.getBean(Greeter.class));
+
+            assertTrue(thrown.getMessage().contains(EqualPriorityGreeterA.class.getName()));
+            assertTrue(thrown.getMessage().contains(EqualPriorityGreeterB.class.getName()));
+        }
+
+        @Test
+        @DisplayName("An exact bean-name match still short-circuits ahead of assignability resolution")
+        void exactNameMatchStillShortCircuits() {
+            SimpleContainer container = new SimpleContainer();
+            container.registerBean(MarkerImpl.class);
+            container.refresh();
+
+            // MarkerImpl is registered under its own concrete-class name, so requesting it by
+            // its own concrete class resolves via the exact-name path, unaffected by any
+            // assignability adjudication.
+            MarkerImpl bean = container.getBean(MarkerImpl.class);
+
+            assertEquals("marker", bean.id());
+        }
+    }
+
+    @Nested
+    @DisplayName("Parent-child delegation (D-13)")
+    class ParentDelegationTests {
+
+        @Test
+        @DisplayName("Zero candidates in the child fall through to the parent's bean")
+        void zeroCandidatesFallsThroughToParent() {
+            SimpleContainer parent = new SimpleContainer();
+            parent.registerBean(ParentGreeterImpl.class);
+            parent.refresh();
+
+            SimpleContainer child = new SimpleContainer();
+            child.setParent(parent);
+            child.refresh();
+
+            Greeter bean = child.getBean(Greeter.class);
+
+            assertEquals("parent", bean.greet());
+        }
+
+        @Test
+        @DisplayName("One candidate in the child is returned, and the parent is not consulted")
+        void oneCandidateInChildIsNotOverriddenByParent() {
+            SimpleContainer parent = new SimpleContainer();
+            parent.registerBean(ParentGreeterImpl.class);
+            parent.refresh();
+
+            SimpleContainer child = new SimpleContainer();
+            child.setParent(parent);
+            child.registerBean(ChildGreeterImpl.class);
+            child.refresh();
+
+            Greeter bean = child.getBean(Greeter.class);
+
+            assertEquals("child", bean.greet(),
+                    "the child's own candidate must win; the parent must not be consulted");
+        }
+
+        @Test
+        @DisplayName("Two ambiguous candidates in the child throw and never fall through to the parent")
+        void ambiguousChildDoesNotFallThroughToParent() {
+            SimpleContainer parent = new SimpleContainer();
+            parent.registerBean(ParentGreeterImpl.class);
+            parent.refresh();
+
+            SimpleContainer child = new SimpleContainer();
+            child.setParent(parent);
+            child.registerBean(DefaultPriorityGreeterA.class);
+            child.registerBean(DefaultPriorityGreeterB.class);
+            child.refresh();
+
+            assertThrows(ContainerException.class, () -> child.getBean(Greeter.class));
+        }
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/context/SimpleContainerAmbiguityTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/SimpleContainerAmbiguityTest.java
@@ -2,6 +2,7 @@ package com.ultikits.ultitools.context;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -12,6 +13,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.ultikits.ultitools.annotations.Service;
+import com.ultikits.ultitools.annotations.Transactional;
+import com.ultikits.ultitools.aop.AopAdvisor;
+import com.ultikits.ultitools.aop.AopProxyResolver;
+import com.ultikits.ultitools.aop.MethodInterceptor;
+import com.ultikits.ultitools.aop.ProxyFactory;
 import com.ultikits.ultitools.exceptions.ContainerException;
 
 /**
@@ -133,6 +139,32 @@ class SimpleContainerAmbiguityTest {
     }
 
     static class UnrelatedBean {
+    }
+
+    @Service(priority = 10)
+    static class ProxiedHighPriorityGreeter implements Greeter {
+        @Transactional
+        @Override
+        public String greet() {
+            return "proxied-high";
+        }
+    }
+
+    @Service(priority = 5)
+    static class PlainLowPriorityGreeter implements Greeter {
+        @Override
+        public String greet() {
+            return "plain-low";
+        }
+    }
+
+    private static SimpleContainer containerWithAop() {
+        SimpleContainer container = new SimpleContainer();
+        AopProxyResolver resolver = new AopProxyResolver();
+        MethodInterceptor passthrough = invocation -> invocation.proceed();
+        resolver.addAdvisor(AopAdvisor.forAnnotation(Transactional.class, passthrough, 100));
+        container.setAopProxyResolver(resolver);
+        return container;
     }
 
     // === Task 1: priority ordering and the tie refusal ===
@@ -392,6 +424,54 @@ class SimpleContainerAmbiguityTest {
             Greeter second = container.getBean(Greeter.class);
 
             assertSame(first, second);
+        }
+    }
+
+    // === Task 3: the proxy-annotation-copy dependency ===
+
+    @Nested
+    @DisplayName("Priority ordering for a proxied bean (D-11's dependency on ProxyFactory)")
+    class ProxyPriorityTests {
+
+        @Test
+        @DisplayName("A proxied @Service(priority) bean reports its true priority, not 0")
+        void proxiedBeanReportsTruePriority() {
+            SimpleContainer container = containerWithAop();
+            container.registerBean(ProxiedHighPriorityGreeter.class);
+            container.refresh();
+
+            Greeter bean = container.getBean(ProxiedHighPriorityGreeter.class);
+
+            // Ordering matters: assert the bean is genuinely proxied FIRST. Without this guard,
+            // a harness that silently failed to wire AOP would hand back the plain class, and
+            // the remaining assertions would pass without ever exercising the behaviour this
+            // test exists to pin.
+            assertTrue(ProxyFactory.isProxyClass(bean.getClass()),
+                    "the harness must be exercising the proxied path, not a plain instance");
+
+            Service annotation = bean.getClass().getAnnotation(Service.class);
+            assertNotNull(annotation,
+                    "ProxyFactory must copy the target's @Service annotation onto the generated subclass");
+            assertEquals(10, annotation.priority());
+        }
+
+        @Test
+        @DisplayName("A proxied higher-priority bean wins a real getBean(Interface.class) resolution against an unproxied lower-priority one")
+        void proxiedHigherPriorityBeanWinsRealResolution() {
+            SimpleContainer container = containerWithAop();
+            container.registerBean(ProxiedHighPriorityGreeter.class);
+            container.registerBean(PlainLowPriorityGreeter.class);
+            container.refresh();
+
+            Greeter proxiedCandidate = container.getBean(ProxiedHighPriorityGreeter.class);
+            assertTrue(ProxyFactory.isProxyClass(proxiedCandidate.getClass()));
+
+            // The assertion that matters: the proxied bean must win a real interface-typed
+            // resolution, not merely report the right value from an isolated getter call.
+            Greeter resolved = container.getBean(Greeter.class);
+
+            assertEquals("proxied-high", resolved.greet());
+            assertFalse(resolved instanceof PlainLowPriorityGreeter);
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/context/SimpleContainerComprehensiveTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/SimpleContainerComprehensiveTest.java
@@ -789,6 +789,9 @@ class SimpleContainerComprehensiveTest {
     }
 
     public static class UnresolvableConstructorBean {
+        // The parameter's presence -- not its use -- is the point: it forces the container's
+        // constructor-injection resolver down the "dependency type cannot be resolved" branch.
+        @SuppressWarnings("PMD.UnusedFormalParameter")
         public UnresolvableConstructorBean(UnresolvableConstructorDependency dependency) {
             // Never reached: the dependency cannot be resolved.
         }
@@ -799,6 +802,9 @@ class SimpleContainerComprehensiveTest {
     }
 
     public static class ThrowingConstructorBean {
+        // The parameter's presence -- not its use -- is the point: it forces the container
+        // through constructor injection before the constructor body deliberately fails.
+        @SuppressWarnings("PMD.UnusedFormalParameter")
         public ThrowingConstructorBean(SimpleConstructorDependency dependency) {
             throw new IllegalStateException("constructor body deliberately fails");
         }

--- a/src/test/java/com/ultikits/ultitools/context/SimpleContainerComprehensiveTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/SimpleContainerComprehensiveTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import com.ultikits.ultitools.annotations.PostConstruct;
 import com.ultikits.ultitools.annotations.PreDestroy;
+import com.ultikits.ultitools.exceptions.ContainerException;
 
 /**
  * Comprehensive tests for SimpleContainer covering all functionality.
@@ -510,6 +512,73 @@ class SimpleContainerComprehensiveTest {
         }
     }
 
+    @Nested
+    @DisplayName("Constructor Injection Failure Tests")
+    class ConstructorInjectionFailureTests {
+
+        @Test
+        @DisplayName("Should throw ContainerException when the bean class has no usable constructor")
+        void testNoUsableConstructorThrows() {
+            // Given - an interface has no constructors at all, so
+            // createBeanWithConstructorInjection's best-constructor search comes up empty
+            container.registerBean(NoConstructorInterface.class);
+
+            // When
+            ContainerException exception = assertThrows(ContainerException.class,
+                    () -> container.getBean(NoConstructorInterface.class));
+
+            // Then
+            assertTrue(exception.getMessage().contains("No constructor found for: "));
+            assertTrue(exception.getMessage().contains(NoConstructorInterface.class.getName()));
+        }
+
+        @Test
+        @DisplayName("Should throw ContainerException when a constructor parameter cannot be resolved")
+        void testUnresolvableConstructorParameterThrows() {
+            // Given - UnresolvableConstructorDependency is never registered
+            container.registerBean(UnresolvableConstructorBean.class);
+
+            // When
+            ContainerException exception = assertThrows(ContainerException.class,
+                    () -> container.getBean(UnresolvableConstructorBean.class));
+
+            // Then
+            assertTrue(exception.getMessage().contains(UnresolvableConstructorDependency.class.getName()));
+            assertTrue(exception.getMessage().contains(UnresolvableConstructorBean.class.getName()));
+        }
+
+        @Test
+        @DisplayName("Should surface the original throwable as the cause when the constructor itself throws")
+        void testThrowingConstructorPreservesCause() {
+            // Given - the dependency resolves, but the constructor body throws
+            container.registerType(SimpleConstructorDependency.class, new SimpleConstructorDependency());
+            container.registerBean(ThrowingConstructorBean.class);
+
+            // When
+            ContainerException exception = assertThrows(ContainerException.class,
+                    () -> container.getBean(ThrowingConstructorBean.class));
+
+            // Then
+            assertNotNull(exception.getCause(),
+                    "the cause is the only pointer to what actually failed inside the constructor");
+        }
+
+        @Test
+        @DisplayName("Should create the bean normally when all constructor parameters resolve")
+        void testResolvableConstructorSucceeds() {
+            // Given
+            container.registerType(SimpleConstructorDependency.class, new SimpleConstructorDependency());
+            container.registerBean(ResolvableConstructorBean.class);
+
+            // When
+            ResolvableConstructorBean bean = container.getBean(ResolvableConstructorBean.class);
+
+            // Then
+            assertNotNull(bean);
+            assertNotNull(bean.getDependency());
+        }
+    }
+
     // Test helper classes
     public static class LifecycleService {
         private boolean postConstructCalled = false;
@@ -705,6 +774,45 @@ class SimpleContainerComprehensiveTest {
     public static class TestFactory {
         public TestServiceA createService() {
             return new TestServiceA();
+        }
+    }
+
+    // Fixtures for ConstructorInjectionFailureTests -- exercise
+    // createBeanWithConstructorInjection through the full container.getBean(Class) path.
+    public interface NoConstructorInterface {
+        // Interfaces have zero declared constructors, so this reaches the
+        // "no usable constructor" branch of createBeanWithConstructorInjection.
+    }
+
+    public static class UnresolvableConstructorDependency {
+        // Deliberately never registered with the container.
+    }
+
+    public static class UnresolvableConstructorBean {
+        public UnresolvableConstructorBean(UnresolvableConstructorDependency dependency) {
+            // Never reached: the dependency cannot be resolved.
+        }
+    }
+
+    public static class SimpleConstructorDependency {
+        // A plain, resolvable dependency.
+    }
+
+    public static class ThrowingConstructorBean {
+        public ThrowingConstructorBean(SimpleConstructorDependency dependency) {
+            throw new IllegalStateException("constructor body deliberately fails");
+        }
+    }
+
+    public static class ResolvableConstructorBean {
+        private final SimpleConstructorDependency dependency;
+
+        public ResolvableConstructorBean(SimpleConstructorDependency dependency) {
+            this.dependency = dependency;
+        }
+
+        public SimpleConstructorDependency getDependency() {
+            return dependency;
         }
     }
 }

--- a/src/test/java/com/ultikits/ultitools/context/isolationfixture/broken/BrokenService.java
+++ b/src/test/java/com/ultikits/ultitools/context/isolationfixture/broken/BrokenService.java
@@ -1,0 +1,24 @@
+package com.ultikits.ultitools.context.isolationfixture.broken;
+
+import com.ultikits.ultitools.annotations.Autowired;
+import com.ultikits.ultitools.annotations.Service;
+
+/**
+ * Fixture for {@code RequiredDependencyModuleIsolationTest}: a {@code @Service} whose required
+ * dependency ({@link UnregisteredDependency}) is never registered in the container. Scanning
+ * this package and then refreshing the container must abort with {@code ContainerException}
+ * rather than leave the field {@code null} (D-08).
+ * <br>
+ * 用于 {@code RequiredDependencyModuleIsolationTest} 的 fixture：一个必需依赖
+ * （{@link UnregisteredDependency}）永远不会被注册到容器中的 {@code @Service}。扫描本包并刷新容器
+ * 必须以 {@code ContainerException} 中止，而不是把字段留成 {@code null}（D-08）。
+ */
+@Service
+public class BrokenService {
+    @Autowired
+    private UnregisteredDependency dependency;
+
+    public UnregisteredDependency getDependency() {
+        return dependency;
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/context/isolationfixture/broken/UnregisteredDependency.java
+++ b/src/test/java/com/ultikits/ultitools/context/isolationfixture/broken/UnregisteredDependency.java
@@ -1,0 +1,12 @@
+package com.ultikits.ultitools.context.isolationfixture.broken;
+
+/**
+ * Deliberately not annotated {@code @Service}/{@code @Component}, so component scanning never
+ * registers a bean definition for it and {@link BrokenService}'s required {@code @Autowired}
+ * field can never resolve.
+ * <br>
+ * 故意不带 {@code @Service}/{@code @Component} 注解，因此组件扫描永远不会为它注册 bean 定义，
+ * {@link BrokenService} 的必需 {@code @Autowired} 字段也就永远无法解析。
+ */
+public class UnregisteredDependency {
+}

--- a/src/test/java/com/ultikits/ultitools/context/isolationfixture/broken/package-info.java
+++ b/src/test/java/com/ultikits/ultitools/context/isolationfixture/broken/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Fixture package for {@code com.ultikits.ultitools.context.RequiredDependencyModuleIsolationTest}:
+ * holds exactly one {@code @Service} ({@link com.ultikits.ultitools.context.isolationfixture.broken.BrokenService})
+ * whose required {@code @Autowired} dependency can never resolve. This package is scanned and
+ * refreshed on its own {@code SimpleContainer}, deliberately separate from the sibling
+ * {@code .clean} package's container, so the test can assert that this container's own scan
+ * aborts without affecting the sibling container's scan.
+ * <br>
+ * {@code RequiredDependencyModuleIsolationTest} 的 fixture 包：只包含一个必需
+ * {@code @Autowired} 依赖永远无法解析的 {@code @Service}
+ * （{@link com.ultikits.ultitools.context.isolationfixture.broken.BrokenService}）。本包会被扫描并
+ * 在它自己独立的 {@code SimpleContainer} 上刷新，与同级 {@code .clean} 包的容器故意分开，
+ * 以便测试断言本容器自身的扫描会中止，且不影响同级容器的扫描。
+ */
+package com.ultikits.ultitools.context.isolationfixture.broken;

--- a/src/test/java/com/ultikits/ultitools/context/isolationfixture/clean/CleanService.java
+++ b/src/test/java/com/ultikits/ultitools/context/isolationfixture/clean/CleanService.java
@@ -1,0 +1,20 @@
+package com.ultikits.ultitools.context.isolationfixture.clean;
+
+import com.ultikits.ultitools.annotations.Service;
+
+/**
+ * Fixture for {@code RequiredDependencyModuleIsolationTest}: a {@code @Service} with no
+ * dependencies at all, proving a sibling container scanning this package registers and
+ * instantiates normally after a different container's scan of the {@code .broken} package has
+ * already failed.
+ * <br>
+ * 用于 {@code RequiredDependencyModuleIsolationTest} 的 fixture：一个完全没有依赖的
+ * {@code @Service}，用来证明即使另一个容器对 {@code .broken} 包的扫描已经失败，扫描本包的同级
+ * 容器仍能正常注册并实例化。
+ */
+@Service
+public class CleanService {
+    public String ping() {
+        return "pong";
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/context/isolationfixture/clean/package-info.java
+++ b/src/test/java/com/ultikits/ultitools/context/isolationfixture/clean/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * Fixture package for {@code com.ultikits.ultitools.context.RequiredDependencyModuleIsolationTest}:
+ * the "clean" half of the pair, holding a single {@code @Service}
+ * ({@link com.ultikits.ultitools.context.isolationfixture.clean.CleanService}) whose fields all
+ * resolve. See the sibling {@code .broken} package's javadoc for why the two are kept apart.
+ * <br>
+ * {@code RequiredDependencyModuleIsolationTest} 的 fixture 包：这一对中"干净"的一半，只包含一个
+ * 所有字段都能正常解析的 {@code @Service}
+ * （{@link com.ultikits.ultitools.context.isolationfixture.clean.CleanService}）。两者为何分开，
+ * 见同级 {@code .broken} 包的 javadoc。
+ */
+package com.ultikits.ultitools.context.isolationfixture.clean;

--- a/src/test/java/com/ultikits/ultitools/context/scanfixture/markerpkg/MarkerClass.java
+++ b/src/test/java/com/ultikits/ultitools/context/scanfixture/markerpkg/MarkerClass.java
@@ -1,0 +1,12 @@
+package com.ultikits.ultitools.context.scanfixture.markerpkg;
+
+/**
+ * A plain marker class used only as a {@code Class} reference for
+ * {@code scanBasePackageClasses()}/{@code basePackageClasses()} tests (03-09, Task 2) -- it is
+ * never itself scanned or registered as a bean; only its <em>package</em> is what
+ * {@code getPluginScanPackages}/{@code processConfigurationClass} must add to the scan set.
+ */
+public final class MarkerClass {
+    private MarkerClass() {
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/context/scanfixture/markerpkg/MarkerClass.java
+++ b/src/test/java/com/ultikits/ultitools/context/scanfixture/markerpkg/MarkerClass.java
@@ -6,6 +6,7 @@ package com.ultikits.ultitools.context.scanfixture.markerpkg;
  * never itself scanned or registered as a bean; only its <em>package</em> is what
  * {@code getPluginScanPackages}/{@code processConfigurationClass} must add to the scan set.
  */
+@SuppressWarnings("PMD.MissingStaticMethodInNonInstantiatableClass")
 public final class MarkerClass {
     private MarkerClass() {
     }

--- a/src/test/java/com/ultikits/ultitools/context/scanfixture/markerpkg/MarkerService.java
+++ b/src/test/java/com/ultikits/ultitools/context/scanfixture/markerpkg/MarkerService.java
@@ -1,0 +1,12 @@
+package com.ultikits.ultitools.context.scanfixture.markerpkg;
+
+import com.ultikits.ultitools.annotations.Service;
+
+/**
+ * The retrievable component that proves {@code markerpkg} was actually scanned (03-09, Task 2) --
+ * looked up by name from the container, per this phase's success criterion 3 ("looking up the
+ * bean or registration they declare"), not merely by inspecting a resolved package-name array.
+ */
+@Service
+public class MarkerService {
+}

--- a/src/test/java/com/ultikits/ultitools/context/scanfixture/otherpkg/OtherMarkerClass.java
+++ b/src/test/java/com/ultikits/ultitools/context/scanfixture/otherpkg/OtherMarkerClass.java
@@ -5,6 +5,7 @@ package com.ultikits.ultitools.context.scanfixture.otherpkg;
  * {@link com.ultikits.ultitools.context.scanfixture.markerpkg.MarkerClass} so the ordering and
  * adjacency test cases have two real, differently-named packages to combine.
  */
+@SuppressWarnings("PMD.MissingStaticMethodInNonInstantiatableClass")
 public final class OtherMarkerClass {
     private OtherMarkerClass() {
     }

--- a/src/test/java/com/ultikits/ultitools/context/scanfixture/otherpkg/OtherMarkerClass.java
+++ b/src/test/java/com/ultikits/ultitools/context/scanfixture/otherpkg/OtherMarkerClass.java
@@ -1,0 +1,11 @@
+package com.ultikits.ultitools.context.scanfixture.otherpkg;
+
+/**
+ * A second, genuinely distinct marker class (03-09, Task 2) -- paired with
+ * {@link com.ultikits.ultitools.context.scanfixture.markerpkg.MarkerClass} so the ordering and
+ * adjacency test cases have two real, differently-named packages to combine.
+ */
+public final class OtherMarkerClass {
+    private OtherMarkerClass() {
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/context/scanfixture/otherpkg/OtherService.java
+++ b/src/test/java/com/ultikits/ultitools/context/scanfixture/otherpkg/OtherService.java
@@ -1,0 +1,11 @@
+package com.ultikits.ultitools.context.scanfixture.otherpkg;
+
+import com.ultikits.ultitools.annotations.Service;
+
+/**
+ * The retrievable component that proves {@code otherpkg} was actually scanned (03-09, Task 2) --
+ * paired with {@link com.ultikits.ultitools.context.scanfixture.markerpkg.MarkerService}.
+ */
+@Service
+public class OtherService {
+}

--- a/src/test/java/com/ultikits/ultitools/manager/ConditionalOnConfigRegistrationIntegrationTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ConditionalOnConfigRegistrationIntegrationTest.java
@@ -79,6 +79,7 @@ class ConditionalOnConfigRegistrationIntegrationTest {
         }
     }
 
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     private void publishUltiToolsInstance(UltiTools mock) throws Exception {
         java.lang.reflect.Field instanceField = UltiTools.class.getDeclaredField("ultiTools");
         instanceField.setAccessible(true);

--- a/src/test/java/com/ultikits/ultitools/manager/ConditionalOnConfigRegistrationIntegrationTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ConditionalOnConfigRegistrationIntegrationTest.java
@@ -1,0 +1,235 @@
+package com.ultikits.ultitools.manager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.SimpleCommandMap;
+import org.bukkit.plugin.PluginDescriptionFile;
+import org.bukkit.plugin.SimplePluginManager;
+import org.bukkit.plugin.java.JavaPluginLoader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockito.Answers;
+import org.mockito.MockedStatic;
+
+import com.ultikits.testfixtures.conditionallistenerdispatch.FalseConditionDispatchListener;
+import com.ultikits.testfixtures.conditionallistenerdispatch.TrueConditionDispatchListener;
+import com.ultikits.ultitools.UltiTools;
+import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
+import com.ultikits.ultitools.context.SimpleContainer;
+
+/**
+ * WIRE-07 / D-17, D-19: proves at Bukkit's own boundary -- the command map and real event
+ * dispatch -- that a false {@code @ConditionalOnConfig} condition actually removes the
+ * registration, on both the standard command path and the listener package-scan path Task 1
+ * gated.
+ * <p>
+ * Each half runs a true-condition and a false-condition fixture through the same real scan/
+ * registration machinery in a single pass, so the true-condition sibling is the control proving
+ * the false-condition sibling's absence is the gate working, not an unrelated scan/registration
+ * failure (03-04-PLAN.md's "inert case" guard).
+ * <br>
+ * WIRE-07 / D-17、D-19：在 Bukkit 自身的边界——命令表与真实事件分发——上证明一个为
+ * {@code false} 的 {@code @ConditionalOnConfig} 条件确实会移除注册，覆盖标准命令路径与 Task 1
+ * 门控的监听器包扫描路径。
+ * <p>
+ * 两半测试都在同一次真实扫描/注册流程中，让 true 条件与 false 条件两个 fixture 一起跑，因此
+ * true 条件的那一个是对照组，用来证明 false 条件那一个的缺席是门控生效，而不是扫描/注册本身
+ * 出了无关的问题（03-04-PLAN.md 的"inert case"防护）。
+ */
+@DisplayName("@ConditionalOnConfig at the Bukkit boundary (WIRE-07)")
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+class ConditionalOnConfigRegistrationIntegrationTest {
+
+    private ServerMock server;
+
+    @BeforeEach
+    void setUp() {
+        com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
+        server = MockBukkit.mock();
+        MockBukkit.createMockPlugin();
+    }
+
+    @AfterEach
+    void tearDown() {
+        com.ultikits.ultitools.utils.MockBukkitHelper.safeUnmock();
+    }
+
+    private void writeConfig(File tempDir, String content) throws Exception {
+        File configFile = new File(tempDir, "config/config.yml");
+        configFile.getParentFile().mkdirs();
+        try (FileWriter writer = new FileWriter(configFile)) {
+            writer.write(content);
+        }
+    }
+
+    private void publishUltiToolsInstance(UltiTools mock) throws Exception {
+        java.lang.reflect.Field instanceField = UltiTools.class.getDeclaredField("ultiTools");
+        instanceField.setAccessible(true);
+        instanceField.set(null, mock);
+    }
+
+    /**
+     * Command half (D-19): drives the same real machinery
+     * {@code PluginManager.register(Class)} -> {@code registerBukkit(plugin, true)} ->
+     * {@code CommandManager.registerAll(plugin)} relies on -- a real {@link SimpleContainer}
+     * scanning a real fixture package with {@link ComponentScanner}, then the real, non-deprecated
+     * {@code CommandManager.registerAll(UltiToolsPlugin)} bean-resolving overload -- without
+     * needing a full plugin.yml/jar-backed {@code UltiToolsPlugin} construction, which
+     * {@code register(Class)} does but which is orthogonal to the condition-gating claim under
+     * test here.
+     * <p>
+     * {@code CommandManager}'s private {@code getCommandMap()} helper reflectively requires
+     * {@code Bukkit.getPluginManager() instanceof SimplePluginManager} -- true on a real server,
+     * false under MockBukkit's own {@code PluginManagerMock} (verified empirically). A real
+     * {@link SimplePluginManager} wrapping a real {@link SimpleCommandMap} is substituted via a
+     * narrow, single-method {@link MockedStatic} override of {@code Bukkit.getPluginManager()}
+     * (all other {@code Bukkit.*} calls still delegate to the real MockBukkit server), so the
+     * assertion below reads the actual {@link SimpleCommandMap} the framework's own registration
+     * code wrote into.
+     */
+    @Nested
+    @DisplayName("Command half (D-19): the standard bean-resolving path")
+    class CommandHalf {
+
+        @Test
+        @DisplayName("false-condition command is absent from Bukkit's command map; true-condition control is present")
+        void falseConditionCommandAbsentTrueConditionPresent(@TempDir File tempDir) throws Exception {
+            writeConfig(tempDir, "enableFalseCommand: false\nenableTrueCommand: true\n");
+
+            SimpleCommandMap realCommandMap = new SimpleCommandMap(server, new HashMap<>());
+            SimplePluginManager realPluginManager = new SimplePluginManager(server, realCommandMap);
+
+            UltiTools mockUltiTools = mock(UltiTools.class);
+            CommandManager commandManager = new CommandManager();
+            when(mockUltiTools.getCommandManager()).thenReturn(commandManager);
+            when(mockUltiTools.getLogger()).thenReturn(java.util.logging.Logger.getLogger(
+                    "ConditionalOnConfigRegistrationIntegrationTest.CommandHalf"));
+            when(mockUltiTools.getDescription())
+                    .thenReturn(new PluginDescriptionFile("UltiTools", "1.0.0", "com.ultikits.ultitools.UltiTools"));
+            publishUltiToolsInstance(mockUltiTools);
+
+            try (MockedStatic<Bukkit> bukkitMock = mockStatic(Bukkit.class, Answers.CALLS_REAL_METHODS)) {
+                bukkitMock.when(Bukkit::getPluginManager).thenReturn(realPluginManager);
+
+                UltiToolsPlugin mockPlugin = mock(UltiToolsPlugin.class);
+                when(mockPlugin.getResourceFolderPath()).thenReturn(tempDir.getAbsolutePath());
+                when(mockPlugin.i18n(anyString())).thenAnswer(inv -> inv.getArgument(0));
+
+                SimpleContainer container = new SimpleContainer();
+                // Mirrors PluginManager.initializePlugin's own ordering: register the plugin by
+                // type BEFORE scanning, so ConditionalRegistrationEvaluator's container lookup
+                // resolves it during the scan (see 03-04-PLAN.md's flagged assumption).
+                container.registerType(UltiToolsPlugin.class, mockPlugin);
+                when(mockPlugin.getContext()).thenReturn(container);
+                container.scanComponents("com.ultikits.testfixtures.conditionalcommand");
+                container.refresh();
+
+                // Act - the real, non-deprecated bean-resolving overload registerBukkit(plugin,
+                // true) calls.
+                commandManager.registerAll(mockPlugin);
+
+                // Assert - both directions, so the false-condition absence means something.
+                assertThat(realCommandMap.getCommand("conditionalfalsecmd"))
+                        .as("a false @ConditionalOnConfig command must never reach Bukkit's command map")
+                        .isNull();
+                assertThat(realCommandMap.getCommand("conditionaltruecmd"))
+                        .as("inert-case guard: the true-condition control must still register, or the "
+                                + "false-condition absence above would not distinguish the gate working "
+                                + "from the whole scan/registration path being broken")
+                        .isNotNull();
+
+                container.close();
+            }
+        }
+    }
+
+    /**
+     * Listener half: drives {@code ListenerManager.registerAll(plugin, packageName)} (the
+     * overload Task 1 gated) over a real fixture package, then fires a real
+     * {@link org.bukkit.event.player.PlayerJoinEvent} through MockBukkit's own plugin manager and
+     * asserts on each fixture's own hit counter -- not a registration-list inspection, per
+     * 03-04-PLAN.md's explicit instruction ("The listener case is asserted through the actual
+     * event dispatch, not by inspecting a registration list").
+     * <p>
+     * {@code ListenerManager.register(plugin, listener)} calls
+     * {@code Bukkit.getServer().getPluginManager().registerEvents(listener, UltiTools.getInstance())}.
+     * That needs {@code UltiTools.getInstance().getPluginLoader()} to be a real, functioning
+     * {@link JavaPluginLoader} -- the generic Mockito mock the shared {@code TestHelper} stubs
+     * elsewhere in this test tree returns an empty {@code Map} by Mockito's own default answer
+     * for unstubbed methods returning a {@code Map}, which makes {@code registerEvents} silently
+     * attach zero real Bukkit handlers (proven empirically while building this test). A real
+     * {@link JavaPluginLoader} is substituted here instead so a fired event genuinely reaches (or
+     * does not reach) the fixture's {@code @EventHandler} method.
+     */
+    @Nested
+    @DisplayName("Listener half: the package-scan path Task 1 gated")
+    class ListenerHalf {
+
+        @BeforeEach
+        void resetHitCounters() {
+            FalseConditionDispatchListener.HITS.set(0);
+            TrueConditionDispatchListener.HITS.set(0);
+        }
+
+        @Test
+        @DisplayName("false-condition listener receives no events; true-condition control does")
+        void falseConditionListenerReceivesNoEventsTrueConditionDoes(@TempDir File tempDir) throws Exception {
+            writeConfig(tempDir, "enableFalseListener: false\nenableTrueListener: true\n");
+
+            UltiTools mockUltiTools = mock(UltiTools.class);
+            when(mockUltiTools.isEnabled()).thenReturn(true);
+            when(mockUltiTools.getPluginLoader()).thenReturn(new JavaPluginLoader(server));
+            when(mockUltiTools.getLogger()).thenReturn(java.util.logging.Logger.getLogger(
+                    "ConditionalOnConfigRegistrationIntegrationTest.ListenerHalf"));
+            publishUltiToolsInstance(mockUltiTools);
+
+            UltiToolsPlugin mockPlugin = mock(UltiToolsPlugin.class);
+            when(mockPlugin.getResourceFolderPath()).thenReturn(tempDir.getAbsolutePath());
+
+            SimpleContainer container = new SimpleContainer();
+            container.registerType(UltiToolsPlugin.class, mockPlugin);
+            when(mockPlugin.getContext()).thenReturn(container);
+
+            ListenerManager listenerManager = new ListenerManager();
+
+            try {
+                // Act - the overload Task 1 gated with ConditionalRegistrationEvaluator.
+                listenerManager.registerAll(mockPlugin, "com.ultikits.testfixtures.conditionallistenerdispatch");
+
+                // server.addPlayer() itself dispatches a real PlayerJoinEvent through Bukkit's
+                // plugin manager (see PlayerEventManagerRegistrationTest's own fireJoinEvent()
+                // for the same idiom) -- no separate manual callEvent needed.
+                server.addPlayer();
+
+                assertThat(FalseConditionDispatchListener.HITS.get())
+                        .as("a listener whose @ConditionalOnConfig condition is false must receive "
+                                + "no events -- ROADMAP Criterion 4")
+                        .isZero();
+                assertThat(TrueConditionDispatchListener.HITS.get())
+                        .as("inert-case guard: the true-condition control must still receive the "
+                                + "event, or the false-condition zero above would not distinguish the "
+                                + "gate working from event dispatch itself being broken")
+                        .isGreaterThan(0);
+            } finally {
+                container.close();
+            }
+        }
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/manager/DependenceManagersTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/DependenceManagersTest.java
@@ -18,6 +18,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import com.ultikits.ultitools.context.SimpleContainer;
+import com.ultikits.ultitools.services.EmailService;
+import com.ultikits.ultitools.services.NotificationService;
+import com.ultikits.ultitools.services.TeleportService;
 import com.ultikits.ultitools.utils.VersionComparatorUtil;
 
 import java.util.Comparator;
@@ -521,6 +524,61 @@ class DependenceManagersTest {
             // Act & Assert
             int result = comparator.compare("1.0.0-SNAPSHOT", "1.0.0");
             assertThat(result).isNotEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("initCoreServices real registration shape (regression: PR #352 UAT)")
+    class InitCoreServicesRegistrationTests {
+
+        /**
+         * Drives the ACTUAL {@code initCoreServices()} private method -- not a reproduction of
+         * lines 70-81 -- so this test fails the moment the real registration shape in
+         * {@code DependenceManagers} changes, not just when a copy of it drifts out of sync.
+         *
+         * <p>Before the identity-dedup fix in {@code SimpleContainer#getOrderedBeansOfType},
+         * each of these three {@code getBean(Interface.class)} calls threw
+         * {@code ContainerException.ambiguousBeanType}, because the same singleton instance is
+         * deliberately registered under two names each ({@code :70-81}) so both a short internal
+         * name and the interface FQN resolve it. A test covering only {@code NotificationService}
+         * would leave {@code TeleportService} and {@code EmailService} unproven -- all three are
+         * broken by the same defect.
+         */
+        @Test
+        @DisplayName("TeleportService, NotificationService and EmailService all resolve by type without a false ambiguity")
+        void allThreeAliasedCoreServicesResolveByType() throws Exception {
+            // Arrange: a real DependenceManagers instance (constructor bypassed via Unsafe, same
+            // as every other test in this file) with a real, un-mocked SimpleContainer -- the
+            // ambiguity adjudication under test lives in SimpleContainer, so it must be real.
+            DependenceManagers managers = createManagersWithMockedFields();
+            SimpleContainer context = new SimpleContainer();
+            setField(managers, "context", context);
+
+            // Act: invoke the real private initCoreServices() method -- the exact code path
+            // DependenceManagers' own constructor runs, not a hand-copied reproduction of it.
+            java.lang.reflect.Method initCoreServices =
+                    DependenceManagers.class.getDeclaredMethod("initCoreServices");
+            initCoreServices.setAccessible(true); // NOPMD
+            initCoreServices.invoke(managers);
+
+            // Assert: each interface-typed lookup resolves without throwing.
+            TeleportService teleportService = assertDoesNotThrow(
+                    () -> context.getBean(TeleportService.class),
+                    "TeleportService is aliased under two names (:70-71) -- must not be seen as "
+                            + "two ambiguous candidates");
+            assertThat(teleportService).isNotNull();
+
+            NotificationService notificationService = assertDoesNotThrow(
+                    () -> context.getBean(NotificationService.class),
+                    "NotificationService is aliased under two names (:75-76) -- must not be seen "
+                            + "as two ambiguous candidates");
+            assertThat(notificationService).isNotNull();
+
+            EmailService emailService = assertDoesNotThrow(
+                    () -> context.getBean(EmailService.class),
+                    "EmailService is aliased under two names (:80-81) -- must not be seen as two "
+                            + "ambiguous candidates");
+            assertThat(emailService).isNotNull();
         }
     }
 

--- a/src/test/java/com/ultikits/ultitools/manager/ListenerManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/ListenerManagerTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
+import java.io.FileWriter;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -20,6 +22,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
 import com.ultikits.ultitools.annotations.EventListener;
@@ -328,6 +331,61 @@ class ListenerManagerTest {
             Map<UltiToolsPlugin, List<Listener>> map = (Map<UltiToolsPlugin, List<Listener>>) mapField.get(listenerManager);
 
             assertThat(map.get(mockPlugin)).isNull();
+        }
+
+        /**
+         * WIRE-07 / D-17: registerAll(plugin, packageName) must consult
+         * {@code @ConditionalOnConfig} before instantiating a scanned listener, exactly like
+         * {@code ComponentScanner} already does on the IoC-scan path. Scans a real fixture
+         * package (see {@code com.ultikits.testfixtures.conditionallistener}) containing one
+         * false-condition and one true-condition {@code @EventListener} class, over a real
+         * {@link SimpleContainer} (not a mock) so the evaluator can actually resolve the plugin
+         * and read a real config file. This is the registration-bookkeeping half of the proof;
+         * the event-dispatch half lives in
+         * {@code ConditionalOnConfigRegistrationIntegrationTest} (Task 2).
+         * <br>
+         * WIRE-07 / D-17：registerAll(plugin, packageName) 必须在实例化被扫描到的监听器之前
+         * 查询 {@code @ConditionalOnConfig}，就像 {@code ComponentScanner} 在 IoC 扫描路径上
+         * 已经做的那样。本用例扫描一个真实的 fixture 包
+         * （见 {@code com.ultikits.testfixtures.conditionallistener}），其中包含一个 false 条件
+         * 与一个 true 条件的 {@code @EventListener} 类，并使用真实的 {@link SimpleContainer}
+         * （而非 mock），以便判定器能够真正解析插件并读取真实的配置文件。这是"注册台账"这一半的
+         * 证明；事件分发那一半的证明在 {@code ConditionalOnConfigRegistrationIntegrationTest}
+         * （Task 2）中。
+         */
+        @Test
+        @DisplayName("应该跳过 @ConditionalOnConfig 条件为 false 的监听器，只注册条件为 true 的")
+        void conditionalListenersAreGatedByConditionalOnConfig(@TempDir File tempDir) throws Exception {
+            // Arrange
+            File configFile = new File(tempDir, "config/config.yml");
+            configFile.getParentFile().mkdirs();
+            try (FileWriter writer = new FileWriter(configFile)) {
+                writer.write("enableFalseListener: false\nenableTrueListener: true\n");
+            }
+
+            SimpleContainer realContainer = new SimpleContainer();
+            when(mockPlugin.getResourceFolderPath()).thenReturn(tempDir.getAbsolutePath());
+            realContainer.registerType(UltiToolsPlugin.class, mockPlugin);
+            when(mockPlugin.getContext()).thenReturn(realContainer);
+
+            try {
+                // Act
+                listenerManager.registerAll(mockPlugin, "com.ultikits.testfixtures.conditionallistener");
+
+                // Assert
+                Field mapField = ListenerManager.class.getDeclaredField("listenerListMap");
+                mapField.setAccessible(true);
+                @SuppressWarnings("unchecked")
+                Map<UltiToolsPlugin, List<Listener>> map =
+                        (Map<UltiToolsPlugin, List<Listener>>) mapField.get(listenerManager);
+
+                List<Listener> registered = map.get(mockPlugin);
+                assertThat(registered).isNotNull();
+                assertThat(registered).hasSize(1);
+                assertThat(registered.get(0).getClass().getSimpleName()).isEqualTo("TrueConditionListener");
+            } finally {
+                realContainer.close();
+            }
         }
     }
 

--- a/src/test/java/com/ultikits/ultitools/manager/PluginManagerRegisterInstanceOrderingTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/PluginManagerRegisterInstanceOrderingTest.java
@@ -1,0 +1,210 @@
+package com.ultikits.ultitools.manager;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+
+import com.ultikits.testfixtures.registersingletonordering.OrderingFixtureModule;
+import com.ultikits.testfixtures.registersingletonordering.OrderingFixtureService;
+import com.ultikits.ultitools.UltiTools;
+import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
+import com.ultikits.ultitools.context.SimpleContainer;
+import com.ultikits.ultitools.interfaces.DataStore;
+
+/**
+ * WR-03: {@code PluginManager.register(UltiToolsPlugin)} -- a second, public overload distinct
+ * from {@code initializePlugin}/{@code loadPluginMainClass} -- repeats the exact ordering bug
+ * T-03-27 already fixed in that sibling method: it called {@code registerSingleton} on the plugin
+ * instance before any component scan, so an {@code @Autowired} field on the plugin's own class
+ * could never resolve against its own scanned {@code @Service} beans.
+ * <p>
+ * Reuses the {@link OrderingFixtureModule}/{@link OrderingFixtureService} fixture pair
+ * {@code RegisterSingletonAssemblyTest.InitializePluginOrdering} already established for the
+ * sibling method's own T-03-27 regression, and the same jar-backed-{@code CodeSource} loading
+ * trick {@code UltiToolsPlugin}'s no-arg constructor requires -- but drives it through
+ * {@code register(UltiToolsPlugin)} instead of {@code initializePlugin}, since that is the second,
+ * independently-broken call site.
+ */
+@DisplayName("PluginManager.register(UltiToolsPlugin): scan-before-registerSingleton ordering (WR-03)")
+@SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+class PluginManagerRegisterInstanceOrderingTest {
+
+    @TempDir
+    File tempDir;
+
+    @BeforeEach
+    void setUpBukkit() {
+        com.ultikits.ultitools.utils.MockBukkitHelper.ensureCleanState();
+        org.mockbukkit.mockbukkit.MockBukkit.mock();
+    }
+
+    @AfterEach
+    void tearDownBukkit() {
+        com.ultikits.ultitools.utils.MockBukkitHelper.safeUnmock();
+    }
+
+    /**
+     * Child-first for the fixture package only -- identical rationale to the copy in
+     * {@code RegisterSingletonAssemblyTest.InitializePluginOrdering}: {@code UltiToolsPlugin}'s
+     * no-arg constructor needs the plugin class's own {@code CodeSource} to be a real jar file,
+     * which {@code target/test-classes} is not.
+     */
+    private final class FixtureJarClassLoader extends URLClassLoader {
+        private final String isolatedPrefix;
+
+        FixtureJarClassLoader(URL jarUrl, ClassLoader parent, String isolatedPrefix) {
+            super(new URL[]{jarUrl}, parent);
+            this.isolatedPrefix = isolatedPrefix;
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> found = findLoadedClass(name);
+                if (found == null && name.startsWith(isolatedPrefix)) {
+                    try {
+                        found = findClass(name);
+                    } catch (ClassNotFoundException ignored) {
+                        // Not present in this loader's own jar -- fall through to normal
+                        // parent-first delegation below.
+                    }
+                }
+                if (found == null) {
+                    found = super.loadClass(name, false);
+                }
+                if (resolve) {
+                    resolveClass(found);
+                }
+                return found;
+            }
+        }
+    }
+
+    private File buildFixtureJar() throws Exception {
+        File jar = new File(tempDir, "register-instance-ordering-fixture.jar");
+        try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jar.toPath()))) {
+            writeClassEntry(output, OrderingFixtureService.class);
+            writeClassEntry(output, OrderingFixtureModule.class);
+
+            output.putNextEntry(new JarEntry("plugin.yml"));
+            output.write("name: OrderingFixtureModule\nversion: 1.0.0\n"
+                    .getBytes(StandardCharsets.UTF_8));
+            output.closeEntry();
+        }
+        return jar;
+    }
+
+    private void writeClassEntry(JarOutputStream output, Class<?> clazz) throws Exception {
+        String resourceName = clazz.getName().replace('.', '/') + ".class";
+        output.putNextEntry(new JarEntry(resourceName));
+        try (InputStream input = clazz.getResourceAsStream("/" + resourceName)) {
+            assertNotNull(input, "compiled class resource for " + clazz.getName());
+            byte[] buffer = new byte[4096];
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                output.write(buffer, 0, read);
+            }
+        }
+        output.closeEntry();
+    }
+
+    @Test
+    @DisplayName("the plugin instance's own @Autowired field is populated after register(UltiToolsPlugin) returns")
+    void autowiredFieldOnPluginInstanceIsPopulatedAfterRegisterInstance() throws Exception {
+        File jar = buildFixtureJar();
+        FixtureJarClassLoader loader = new FixtureJarClassLoader(jar.toURI().toURL(),
+                Thread.currentThread().getContextClassLoader(),
+                "com.ultikits.testfixtures.registersingletonordering.");
+        Class<?> pluginClass = Class.forName(
+                "com.ultikits.testfixtures.registersingletonordering.OrderingFixtureModule",
+                true, loader);
+
+        DependenceManagers mockDependenceManagers = mock(DependenceManagers.class);
+        when(mockDependenceManagers.getContext()).thenReturn(new SimpleContainer());
+
+        // wireAop (called by register(UltiToolsPlugin) before refresh()) resolves a DataSource
+        // through UltiTools.getInstance().getDataStore() for the @Transactional advisor --
+        // CALLS_REAL_METHODS lets the interface's own default getDataSource(DataScope) run and
+        // throw UnsupportedOperationException, which wireAop already handles as "this backend has
+        // no @Transactional support", exactly like PluginManagerTest's own
+        // CompatibilityGateOrderingTests setup does for the identical need.
+        DataStore dataStore = mock(DataStore.class, CALLS_REAL_METHODS);
+
+        UltiTools mockUltiTools = mock(UltiTools.class);
+        lenient().when(mockUltiTools.getDataFolder()).thenReturn(tempDir);
+        lenient().when(mockUltiTools.getLogger()).thenReturn(
+                Logger.getLogger("PluginManagerRegisterInstanceOrderingTest"));
+        lenient().when(mockUltiTools.getDataStore()).thenReturn(dataStore);
+        lenient().when(mockUltiTools.getDependenceManagers()).thenReturn(mockDependenceManagers);
+        lenient().when(mockUltiTools.getConfigManager()).thenReturn(mock(ConfigManager.class));
+        // UltiToolsPlugin's no-arg constructor reads getConfig().getString("language") (Bukkit's
+        // own JavaPlugin.getConfig(), unstubbed on a full mock returns null and NPEs) -- an empty
+        // YamlConfiguration is enough; a missing "language" key just falls through to the {}
+        // default language.
+        lenient().when(mockUltiTools.getConfig())
+                .thenReturn(new org.bukkit.configuration.file.YamlConfiguration());
+
+        PluginManager pluginManager = new PluginManager();
+        // register(UltiToolsPlugin) reads PluginManager's own `classLoader` field (set normally
+        // by init(ClassLoader), not called here) to pass to SimpleContainer.setClassLoader(...),
+        // which ComponentScanner then uses to resolve the fixture package's classpath resource.
+        // Point it at the same isolated loader the plugin instance itself was constructed with,
+        // so the scan finds OrderingFixtureService in the same jar/loader as the plugin class.
+        Field classLoaderField = PluginManager.class.getDeclaredField("classLoader");
+        classLoaderField.setAccessible(true);
+        classLoaderField.set(pluginManager, loader);
+
+        Object plugin;
+        // passesCompatibilityGates -> UltiTools.getPluginVersion() -> getEnv() reads env.yml
+        // through getInstance().getTextResource(String), which is protected on Bukkit's own
+        // JavaPlugin and cannot be stubbed from this package -- so the STATIC call site is
+        // stubbed directly instead, the same workaround PluginManagerTest's own
+        // CompatibilityGateOrderingTests and RegisterSingletonAssemblyTest.InitializePluginOrdering
+        // both use for the identical problem.
+        try (MockedStatic<UltiTools> ultiToolsStatic =
+                mockStatic(UltiTools.class, CALLS_REAL_METHODS)) {
+            ultiToolsStatic.when(UltiTools::getInstance).thenReturn(mockUltiTools);
+            ultiToolsStatic.when(UltiTools::getPluginVersion).thenReturn(Integer.MAX_VALUE);
+
+            plugin = pluginClass.getDeclaredConstructor().newInstance();
+
+            Method register = PluginManager.class.getDeclaredMethod("register", UltiToolsPlugin.class);
+            boolean result = (Boolean) register.invoke(pluginManager, plugin);
+
+            assertTrue(result, "register(UltiToolsPlugin) must not refuse this module");
+        }
+
+        Field serviceField = pluginClass.getDeclaredField("service");
+        serviceField.setAccessible(true);
+        assertNotNull(serviceField.get(plugin),
+                "the plugin instance's own @Autowired field must be populated -- inert case: "
+                        + "asserting only that register(UltiToolsPlugin) returned true passes even "
+                        + "if the field is null, which is the WR-03 defect this fix exists to "
+                        + "delete. Before the fix, registerSingleton ran on the plugin instance "
+                        + "BEFORE any component scan, so this container had no @Service beans yet "
+                        + "and the @Autowired field could never resolve.");
+    }
+}


### PR DESCRIPTION
Phase 3 of the 6.3.0 milestone, **PR 2 of 2** (D-28). PR 1 (#349, merge `abccc26`) landed the
merged-annotation foundation; this carries plans 03-03 through 03-10 plus the fixes for its own
code review. 37 commits.

The milestone's core value is that a declared API surface must actually do what it declares. Every
change here removes a place where the container read an annotation and did nothing with it, or
promised a guarantee it did not keep.

## What changes

| Plan | Change | Req |
|---|---|---|
| 03-03 | An unresolvable `@Autowired(required = true)` throws `ContainerException` naming the declaring class, field and type, instead of injecting null that surfaces later as an unrelated NPE. Constructor injection throws `ContainerException` rather than bare `RuntimeException`. | SILENT-05 |
| 03-04 | One shared `@ConditionalOnConfig` evaluator, wired into the command and listener registration paths — previously the annotation was honoured only in the IoC scan. | WIRE-07 |
| 03-05 | `@Final` enforcement made transitive and interface-aware; the javadoc arguing the gap was acceptable is deleted; `ContextConfig`'s dead `@ComponentScan` stripped (D-23). | SILENT-20 |
| 03-06 | `getBean(Class)` adjudicates by `@Service(priority)` **before** caching, refuses a genuine tie naming both candidates, and invalidates the by-type cache on new registration. | SILENT-06 |
| 03-07 | Leveled scan diagnostics carrying the throwable; symmetric `ClassNotFoundException \| LinkageError` handling across both scan modes. | SILENT-07 |
| 03-08 | `registerSingleton` performs full assembly unconditionally and **refuses** an instance carrying `@Transactional`/`@ExceptionCatch` it can never honour, rather than registering it with the advice silently inert. | SILENT-09, SILENT-10 |
| 03-09 | `@Bean(name=)`/`@Bean(value=)` determine the registered bean name; `scanBasePackageClasses()` takes effect at both read sites. | WIRE-09, GEN-06 |
| 03-10 | `COMPATIBILITY.md` records every behaviour change above; four issue-body corrections; two new issues. | all ten |

Documentation is a **separate pull request in a separate repository**: UltiKits/UltiTools-Dev-Doc#49,
base `alpha`, 8 checks green. A commit cannot span two repositories.

## Code review findings, fixed in this PR

A deep review of all 79 changed files produced 1 Critical and 3 Warnings, all in this PR's range.
Each fix commits a failing test first, and the RED state was observed before the fix in every case.

**CR-01 — the priority guarantee 03-06 adds could be bypassed entirely.** `getBean(Class)` has a
by-name shortcut two statements above the new adjudication that returns first. `getBeanName(type)`
reads `@Component(value)` then `@Service(value)` then falls back to the decapitalized simple name,
so a bean explicitly named to match an interface's default name silently won over a
higher-`@Service(priority)` implementer — no exception, no adjudication. `SimpleContainerAmbiguityTest`
was green at 17/17 because it had **zero** fixtures using `@Service(value = ...)`.

The shortcut now requires the definition to be assignable to the requested type **and** either to be
a genuine self-match or to carry a bean name the type itself declared — a name derived from
`getBeanName`'s decapitalized fallback no longer short-circuits. This follows Spring's
`DefaultListableBeanFactory#resolveNamedBean`, which never derives a lookup name from the requested
type and always adjudicates by type otherwise.

**WR-01** — `close()` now clears `resolvedTypeCache`, which the classloader-release invariant (D-35/D-38)
requires and which this phase's own `MergedAnnotationResolver` javadoc documents at length.

**WR-02** — `registerSingleton`'s full assembly has no circular-dependency support. Deliberately
**documented rather than "fixed"**: `createBean`'s early-reference exposure works only because the
container constructs the dependency lazily inside the same call stack. `registerSingleton` receives
an already-constructed instance, so in a mutual pair the second object does not exist in the
container in any form when the first is autowired — there is nothing for an early reference to
expose. Implementing it would fix a different circular shape while appearing to fix this one.
Javadoc (EN + ZH) states the limitation and three workarounds; two tests pin the current behaviour.

**WR-03** — `register(UltiToolsPlugin)` repeated the T-03-27 ordering bug that 03-08 fixed in the
sibling `initializePlugin`: it called `registerSingleton` on the plugin instance before any component
scan. Now scans first.

## Verification

- `mvn -B clean test` — **4840 tests, 0 failures, 0 errors, 0 skipped**
- Verification agent: 10/10 must-haves, all five ROADMAP success criteria backed by re-run behavioural tests rather than SUMMARY claims
- RED→GREEN discipline: 16 tasks marked `tdd="true"`, 16 `test(03-XX)` commits, plus 3 RED commits for the review fixes
- `BugEvidenceTest` green

## Known limitation of this PR's UAT

Real-machine UAT on Paper 1.21.4 loads 14 of 16 modules. `UltiEconomy` and `UltiWorlds` fail with
`NoSuchMethodError` against APIs removed in `43f55ea` (2026-02-18,
`refactor!: replace AbstractDataEntity with BaseDataEntity<String> across all framework APIs`) — a
break already present in the released 6.2.5 artifact, verified by `javap` against that jar, and
unrelated to this phase. Tracked in #351.

## Issue closure

Closes #201
Closes #202
Closes #204
Closes #228
Closes #308
Closes #316
Closes #333
Closes #334
Closes #335

Note: `phase-closeout.yml` is currently inert (#350) — it is absent from the default branch, so
GitHub never registered it and it has never run. These nine will need closing by hand until #350
is fixed.
