### PR TITLE
feat(phase-09): publish 6.3.0-SNAPSHOT to Central and guard against accidental releases

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -1,0 +1,52 @@
+name: Snapshot Publish
+
+on:
+  push:
+    branches: [alpha]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot-publish:
+    name: Publish SNAPSHOT to Central
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4 (v4.8.0)
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+          server-id: ultikits-sonatype
+          server-username: SONATYPE_USERNAME
+          server-password: SONATYPE_PASSWORD
+
+      - name: Refuse to publish a non-SNAPSHOT version
+        # This workflow fires on every push to alpha. Without this guard, a branch that ever
+        # carries a release version (e.g. mid-release-prep, or a maintainer mistake) would
+        # publish a release from a routine push -- breaching the standing rule that a release
+        # requires an explicit maintainer instruction. A -SNAPSHOT project version is required
+        # to reach the deploy step below.
+        run: |
+          set -euo pipefail
+          VERSION="$(mvn -B -q help:evaluate -Dexpression=project.version -DforceStdout)"
+          echo "Project version: ${VERSION}"
+          if [[ "${VERSION}" != *-SNAPSHOT ]]; then
+            echo "::error::project.version [${VERSION}] does not end in -SNAPSHOT -- refusing to publish. This workflow only ever publishes snapshots; releases require an explicit maintainer instruction."
+            exit 1
+          fi
+
+      - name: Deploy snapshot to Central
+        # Deliberately does not activate the release Maven profile: that profile exists only
+        # to attach GPG signing, and Sonatype performs no validation on snapshot deploys, so
+        # signing is neither required nor meaningful for this job.
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+        run: mvn -B deploy -Dmaven.test.skip=true

--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,14 @@
     </properties>
 
     <distributionManagement>
+        <!-- central-publishing-maven-plugin auto-routes -SNAPSHOT deploys to Central's own snapshot
+             endpoint, but it respects an existing override here rather than always applying its own
+             default, so this entry names the destination explicitly instead of relying on that
+             default. The previous value pointed at the retired legacy OSSRH staging host, which
+             returns 404 at its own root and would silently defeat any deploy. -->
         <snapshotRepository>
             <id>ultikits-sonatype</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
         <repository>
             <id>ultikits-sonatype</id>


### PR DESCRIPTION
## Issue closure

None. This phase's requirements are tracked as `MOD-01`..`MOD-06` in `.planning/REQUIREMENTS.md`,
which carry `#TBD` rather than filed issue numbers, so there is no issue for this pull request to
close. Stated explicitly rather than omitted, per the phase-closeout convention.

## What this changes

Phase 9 brings the sixteen module repositories and the external example onto the 6.3.0 lineage.
Almost all of that work lands in those repositories; **this pull request is the framework side, and
it is two files.**

- `pom.xml` — `<distributionManagement><snapshotRepository>` pointed at
  `https://central.sonatype.com/repository/maven-snapshots/`. It previously named the retired
  `s01.oss.sonatype.org` host, whose snapshot path returns 404 at its own root, so a snapshot deploy
  would have gone to a dead target. The `<id>ultikits-sonatype</id>` is unchanged so it keeps
  matching the release job and `~/.m2/settings.xml`. File remains CRLF.
- `.github/workflows/snapshot-publish.yml` — new. Triggers on push to `alpha` plus
  `workflow_dispatch`, holds `permissions: contents: read` only, and **refuses to deploy anything
  whose project version does not end in `-SNAPSHOT`**. Without that guard a branch that ever carried
  a release version would publish a release from a routine push, which would breach the standing
  rule that a release needs an explicit maintainer instruction. No GPG inputs and no `-P release`:
  Sonatype performs no validation on snapshots, so signing is neither required nor meaningful.

This is what makes `com.ultikits:UltiTools-API:6.3.0-SNAPSHOT` resolvable, which every one of the
seventeen downstream pull requests depends on.

## Verification

- `mvn -B clean verify` — BUILD SUCCESS, **5361 tests / 1541 test classes / 0 failures / 0 errors /
  0 skipped**.
- The channel was proven end to end, not by a zero exit code: `6.3.0-SNAPSHOT` was deployed and then
  resolved back from a **freshly created, previously non-existent** local repository, which deposited
  the real jar. Central's assigned build is `6.3.0-20260903.172404-1`.
- A control was used for the negative result: `com/ultikits/UltiTools-API/maven-metadata.xml`
  returned 404 before the deploy and 200 after, while a deliberately non-existent sibling path stayed
  404 throughout — Nexus serves an HTML shell for any directory-shaped path, so a 200 there proves
  nothing on its own.
- Real-machine load of the whole rebuilt ecosystem on Paper 1.21.4:
  `[UltiTools-API] Succeeded loaded 16, Failed 0.`, with zero module-skip lines, zero
  `NoSuchMethodError`, zero command-class refusals and zero SEVERE lines, each asserted alongside a
  positive control.

## Not in this pull request

The seventeen downstream pull requests are open and unmerged pending maintainer review. No module
version was bumped and no release was created anywhere — verified across all sixteen repositories
against their default branches, control-paired against an empty extraction.
