### PR TITLE
fix(384): scan framework-owned objects for @Scheduled, and guard against the next one

### DIFF
--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -127,6 +127,28 @@ public class PluginManager {
     private final Map<String, DataScope> externalScopesByFolder = new ConcurrentHashMap<>();
 
     /**
+     * The framework-owned types whose {@link com.ultikits.ultitools.annotations.Scheduled} methods
+     * this manager registers.
+     * <p>
+     * <b>This set is the wiring, not a description of it.</b> {@link
+     * #registerFrameworkScheduledOwners()} registers exactly the instances whose types appear here
+     * and fails fast if the two disagree, and {@code FrameworkScheduledWiringTest} fails the build
+     * if a framework class carries {@code @Scheduled} without appearing here. Adding a type to
+     * this set and wiring its task are therefore the same act -- which is the point.
+     * <p>
+     * The defect this prevents (#384): {@code TaskManager}'s two original entry points both
+     * iterate a {@code SimpleContainer}'s beans, so an object the framework constructs directly
+     * was reached by neither. {@code PlayerCacheManager.sweepExpiredEntries()} carried a
+     * {@code @Scheduled(period = 5 minutes)} annotation, and its javadoc explained at length why a
+     * clock-driven sweep was chosen over a hand-rolled {@code BukkitRunnable} -- and it never ran
+     * once. Nothing reported an error, because nothing had looked.
+     *
+     * @since 6.3.0
+     */
+    static final Set<Class<?>> FRAMEWORK_SCHEDULED_OWNER_TYPES = Collections.unmodifiableSet(
+            new LinkedHashSet<>(Collections.<Class<?>>singletonList(PlayerCacheManager.class)));
+
+    /**
      * Initialize plugin manager. Please do not call this method manually.
      *
      * @throws IOException IO exception
@@ -341,28 +363,6 @@ public class PluginManager {
             taskManager.cancelAllCore();
         }
     }
-
-    /**
-     * The framework-owned types whose {@link com.ultikits.ultitools.annotations.Scheduled} methods
-     * this manager registers.
-     * <p>
-     * <b>This set is the wiring, not a description of it.</b> {@link
-     * #registerFrameworkScheduledOwners()} registers exactly the instances whose types appear here
-     * and fails fast if the two disagree, and {@code FrameworkScheduledWiringTest} fails the build
-     * if a framework class carries {@code @Scheduled} without appearing here. Adding a type to
-     * this set and wiring its task are therefore the same act -- which is the point.
-     * <p>
-     * The defect this prevents (#384): {@code TaskManager}'s two original entry points both
-     * iterate a {@code SimpleContainer}'s beans, so an object the framework constructs directly
-     * was reached by neither. {@code PlayerCacheManager.sweepExpiredEntries()} carried a
-     * {@code @Scheduled(period = 5 minutes)} annotation, and its javadoc explained at length why a
-     * clock-driven sweep was chosen over a hand-rolled {@code BukkitRunnable} -- and it never ran
-     * once. Nothing reported an error, because nothing had looked.
-     *
-     * @since 6.3.0
-     */
-    static final Set<Class<?>> FRAMEWORK_SCHEDULED_OWNER_TYPES = Collections.unmodifiableSet(
-            new LinkedHashSet<>(Collections.<Class<?>>singletonList(PlayerCacheManager.class)));
 
     /**
      * Register the {@code @Scheduled} methods of every framework-owned object.

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -135,6 +135,7 @@ public class PluginManager {
         this.classLoader = classLoader;
         this.taskManager = new TaskManager(UltiTools.getInstance());
         this.playerCacheManager = new PlayerCacheManager();
+        registerFrameworkScheduledOwners();
         registerPlayerQuitListener();
         registerPluginDisableListener();
         String currentPath = System.getProperty("user.dir");
@@ -332,6 +333,77 @@ public class PluginManager {
         }
         pluginList.clear();
         pluginClassList.clear();
+
+        // Framework-owned tasks are keyed on no plugin, so the unregister loop above does not
+        // reach them. A repeating task left running here survives /reload and the next onEnable
+        // schedules a second copy against the same object.
+        if (taskManager != null) {
+            taskManager.cancelAllCore();
+        }
+    }
+
+    /**
+     * The framework-owned types whose {@link com.ultikits.ultitools.annotations.Scheduled} methods
+     * this manager registers.
+     * <p>
+     * <b>This set is the wiring, not a description of it.</b> {@link
+     * #registerFrameworkScheduledOwners()} registers exactly the instances whose types appear here
+     * and fails fast if the two disagree, and {@code FrameworkScheduledWiringTest} fails the build
+     * if a framework class carries {@code @Scheduled} without appearing here. Adding a type to
+     * this set and wiring its task are therefore the same act -- which is the point.
+     * <p>
+     * The defect this prevents (#384): {@code TaskManager}'s two original entry points both
+     * iterate a {@code SimpleContainer}'s beans, so an object the framework constructs directly
+     * was reached by neither. {@code PlayerCacheManager.sweepExpiredEntries()} carried a
+     * {@code @Scheduled(period = 5 minutes)} annotation, and its javadoc explained at length why a
+     * clock-driven sweep was chosen over a hand-rolled {@code BukkitRunnable} -- and it never ran
+     * once. Nothing reported an error, because nothing had looked.
+     *
+     * @since 6.3.0
+     */
+    static final Set<Class<?>> FRAMEWORK_SCHEDULED_OWNER_TYPES = Collections.unmodifiableSet(
+            new LinkedHashSet<>(Collections.<Class<?>>singletonList(PlayerCacheManager.class)));
+
+    /**
+     * Register the {@code @Scheduled} methods of every framework-owned object.
+     * <p>
+     * Called from {@link #init(ClassLoader)} once {@code taskManager} and the owner instances
+     * exist. Cancellation is the mirror of this, in {@link #close()}.
+     *
+     * @throws IllegalStateException if the instances offered do not match {@link
+     *         #FRAMEWORK_SCHEDULED_OWNER_TYPES}. This is reachable only by editing one of the two
+     *         without the other, which the guard test already fails the build for; it is a
+     *         belt-and-braces check on an invariant, and cannot be triggered by user
+     *         configuration. Failing loudly here is deliberate -- degrading quietly to "some of
+     *         the tasks got registered" is the exact behaviour this whole change exists to remove.
+     * @since 6.3.0
+     */
+    private void registerFrameworkScheduledOwners() {
+        List<Object> owners = frameworkScheduledOwners();
+        Set<Class<?>> offered = new LinkedHashSet<>();
+        for (Object owner : owners) {
+            offered.add(owner.getClass());
+        }
+        if (!offered.equals(FRAMEWORK_SCHEDULED_OWNER_TYPES)) {
+            throw new IllegalStateException(
+                    "Framework @Scheduled wiring is inconsistent: declared "
+                            + FRAMEWORK_SCHEDULED_OWNER_TYPES + " but frameworkScheduledOwners() offered "
+                            + offered + ". Update both together.");
+        }
+        for (Object owner : owners) {
+            taskManager.registerScheduledMethodsCore(owner);
+        }
+    }
+
+    /**
+     * The live instances corresponding to {@link #FRAMEWORK_SCHEDULED_OWNER_TYPES}, in the same
+     * order.
+     *
+     * @return the framework-owned objects to scan for {@code @Scheduled} methods
+     * @since 6.3.0
+     */
+    private List<Object> frameworkScheduledOwners() {
+        return Collections.<Object>singletonList(playerCacheManager);
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/manager/TaskManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/TaskManager.java
@@ -32,6 +32,19 @@ public class TaskManager {
 
     private final Map<UltiToolsPlugin, List<BukkitTask>> pluginTasks = new HashMap<>();
     private final Map<String, List<BukkitTask>> externalTasks = new HashMap<>();
+    /**
+     * Tasks owned by the framework itself rather than by a plugin module or an external plugin.
+     * <p>
+     * A framework-owned object belongs to no {@code SimpleContainer}, so it is reached by neither
+     * {@link #registerScheduledMethods(UltiToolsPlugin, Object)} nor {@link
+     * #registerScheduledMethodsExternal(String, Object)} -- both of which iterate a container's
+     * beans. Before 6.3.0 there was no third bucket, which is why {@code
+     * PlayerCacheManager.sweepExpiredEntries()} carried a {@code @Scheduled} annotation that was
+     * never registered and never ran (#384).
+     *
+     * @since 6.3.0
+     */
+    private final List<BukkitTask> coreTasks = new ArrayList<>();
     private final JavaPlugin hostPlugin;
 
     public TaskManager(JavaPlugin hostPlugin) {
@@ -45,8 +58,69 @@ public class TaskManager {
      * @param bean   the bean instance to scan
      */
     public void registerScheduledMethods(UltiToolsPlugin plugin, Object bean) {
-        // Walk the class hierarchy to find @Scheduled methods (handles ByteBuddy proxies)
+        List<BukkitTask> created = scanAndSchedule(bean);
+        if (!created.isEmpty()) {
+            pluginTasks.computeIfAbsent(plugin, k -> new ArrayList<>()).addAll(created);
+        }
+    }
+
+    /**
+     * Scan a framework-owned object for {@link Scheduled} methods and register them.
+     * <p>
+     * The other two entry points key their tasks on a plugin module or an external plugin, and
+     * both are reached by iterating a {@code SimpleContainer}'s beans. An object the framework
+     * constructs directly -- {@code PlayerCacheManager}, for instance -- belongs to no container
+     * and is therefore reached by neither, which is why its {@code @Scheduled} method silently
+     * never ran before 6.3.0 (#384). This is the third bucket, for objects the framework owns.
+     * <p>
+     * Callers must not invoke this ad hoc. The set of framework-owned types whose scheduled
+     * methods are registered is declared by {@code PluginManager.FRAMEWORK_SCHEDULED_OWNER_TYPES}
+     * and enforced by {@code FrameworkScheduledWiringTest}; adding an object here without adding
+     * its type there would reintroduce exactly the drift that guard exists to prevent.
+     *
+     * @param bean the framework-owned instance to scan
+     * @since 6.3.0
+     */
+    public void registerScheduledMethodsCore(Object bean) {
+        coreTasks.addAll(scanAndSchedule(bean));
+    }
+
+    /**
+     * Cancel every framework-owned scheduled task.
+     * <p>
+     * Called from {@code PluginManager.close()}, which {@code UltiTools.onDisable()} invokes. A
+     * repeating task that is not cancelled here survives a {@code /reload} and a second copy is
+     * scheduled on the next enable.
+     *
+     * @since 6.3.0
+     */
+    public void cancelAllCore() {
+        for (BukkitTask task : coreTasks) {
+            try {
+                task.cancel();
+            } catch (Exception e) {
+                Bukkit.getLogger().log(Level.FINE,
+                        "[UltiTools-API] Task already cancelled: " + task.getTaskId());
+            }
+        }
+        coreTasks.clear();
+    }
+
+    /**
+     * Scan one bean for {@link Scheduled} methods and schedule each valid one.
+     * <p>
+     * The single implementation behind all three registration entry points, which differ only in
+     * which bucket they file the resulting tasks under. Three copies of this body would be three
+     * places to keep a signature check, a scheduling rule or a log line in step.
+     *
+     * @param bean the instance to scan
+     * @return the tasks created, in declaration order; empty if the bean has no valid
+     *         {@link Scheduled} method
+     * @since 6.3.0
+     */
+    private List<BukkitTask> scanAndSchedule(Object bean) {
         Class<?> targetClass = getTargetClass(bean.getClass());
+        List<BukkitTask> created = new ArrayList<>();
 
         for (Method method : targetClass.getDeclaredMethods()) {
             Scheduled scheduled = method.getAnnotation(Scheduled.class);
@@ -54,7 +128,6 @@ public class TaskManager {
                 continue;
             }
 
-            // Validate method signature
             if (method.getParameterCount() != 0) {
                 Bukkit.getLogger().log(Level.WARNING,
                         String.format("[UltiTools-API] @Scheduled method '%s.%s' must have no parameters. Skipping.",
@@ -69,7 +142,6 @@ public class TaskManager {
             }
 
             method.setAccessible(true);
-            // Use a final reference to the method for the lambda
             final Method targetMethod = method;
 
             BukkitRunnable runnable = new BukkitRunnable() {
@@ -99,13 +171,19 @@ public class TaskManager {
                         : runnable.runTaskTimer(hostPlugin, scheduled.delay(), scheduled.period());
             }
 
-            pluginTasks.computeIfAbsent(plugin, k -> new ArrayList<>()).add(task);
+            created.add(task);
 
-            Bukkit.getLogger().log(Level.FINE,
+            // INFO, not FINE. Bukkit's default logger configuration does not print FINE, which
+            // made "registered but not firing" indistinguishable from "never registered" from
+            // outside the JVM -- diagnosing #384 and #382 both required attaching a bytecode
+            // probe to establish something this line already knew. There are 16 @Scheduled
+            // methods across the whole ecosystem, so this is a bounded amount of startup output.
+            Bukkit.getLogger().log(Level.INFO,
                     String.format("[UltiTools-API] Registered @Scheduled task: %s.%s (delay=%d, period=%d, async=%s)",
                             targetClass.getSimpleName(), method.getName(),
                             scheduled.delay(), scheduled.period(), scheduled.async()));
         }
+        return created;
     }
 
     /**
@@ -149,55 +227,9 @@ public class TaskManager {
      * @since 6.2.2
      */
     public void registerScheduledMethodsExternal(String pluginName, Object bean) {
-        Class<?> targetClass = getTargetClass(bean.getClass());
-
-        for (Method method : targetClass.getDeclaredMethods()) {
-            Scheduled scheduled = method.getAnnotation(Scheduled.class);
-            if (scheduled == null) {
-                continue;
-            }
-            if (method.getParameterCount() != 0) {
-                Bukkit.getLogger().log(Level.WARNING,
-                        String.format("[UltiTools-API] @Scheduled method '%s.%s' must have no parameters. Skipping.",
-                                targetClass.getSimpleName(), method.getName()));
-                continue;
-            }
-            if (method.getReturnType() != void.class && method.getReturnType() != Void.class) {
-                Bukkit.getLogger().log(Level.WARNING,
-                        String.format("[UltiTools-API] @Scheduled method '%s.%s' must return void. Skipping.",
-                                targetClass.getSimpleName(), method.getName()));
-                continue;
-            }
-
-            method.setAccessible(true); // NOPMD
-            final Method targetMethod = method;
-
-            BukkitRunnable runnable = new BukkitRunnable() {
-                @Override
-                public void run() {
-                    try {
-                        targetMethod.invoke(bean);
-                    } catch (Exception e) {
-                        Bukkit.getLogger().log(Level.WARNING,
-                                String.format("[UltiTools-API] Error executing @Scheduled method '%s.%s'",
-                                        targetClass.getSimpleName(), targetMethod.getName()),
-                                e);
-                    }
-                }
-            };
-
-            BukkitTask task;
-            if (scheduled.period() <= 0) {
-                task = scheduled.async()
-                        ? runnable.runTaskLaterAsynchronously(hostPlugin, scheduled.delay())
-                        : runnable.runTaskLater(hostPlugin, scheduled.delay());
-            } else {
-                task = scheduled.async()
-                        ? runnable.runTaskTimerAsynchronously(hostPlugin, scheduled.delay(), scheduled.period())
-                        : runnable.runTaskTimer(hostPlugin, scheduled.delay(), scheduled.period());
-            }
-
-            externalTasks.computeIfAbsent(pluginName, k -> new ArrayList<>()).add(task);
+        List<BukkitTask> created = scanAndSchedule(bean);
+        if (!created.isEmpty()) {
+            externalTasks.computeIfAbsent(pluginName, k -> new ArrayList<>()).addAll(created);
         }
     }
 
@@ -227,6 +259,15 @@ public class TaskManager {
     int getTaskCount(UltiToolsPlugin plugin) {
         List<BukkitTask> tasks = pluginTasks.get(plugin);
         return tasks == null ? 0 : tasks.size();
+    }
+
+    /**
+     * Get the number of registered framework-owned tasks (for testing).
+     *
+     * @since 6.3.0
+     */
+    int getCoreTaskCount() {
+        return coreTasks.size();
     }
 
     /**

--- a/src/test/java/com/ultikits/ultitools/manager/FrameworkScheduledWiringTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/FrameworkScheduledWiringTest.java
@@ -128,6 +128,12 @@ class FrameworkScheduledWiringTest {
         for (String name : candidates) {
             Class<?> clazz;
             try {
+                // The name is not attacker-controlled: it is derived by walking this build's own
+                // target/classes directory, filtered to the com.ultikits.ultitools package, and the
+                // load is non-initialising. Rationale precedes the marker deliberately -- an
+                // Opengrep marker only counts on its own line or the one immediately above, so
+                // putting the justification in between would silently disable the suppression.
+                // nosemgrep: java.lang.security.audit.unsafe-reflection.unsafe-reflection
                 clazz = Class.forName(name, false, getClass().getClassLoader());
             } catch (Throwable t) {
                 unloadable.add(name + " (" + t.getClass().getSimpleName() + ")");

--- a/src/test/java/com/ultikits/ultitools/manager/FrameworkScheduledWiringTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/FrameworkScheduledWiringTest.java
@@ -1,0 +1,167 @@
+package com.ultikits.ultitools.manager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ultikits.ultitools.annotations.Scheduled;
+
+/**
+ * Guard against the defect class behind #384: a framework-owned class carrying {@link Scheduled}
+ * that nothing ever scans, so the annotation is inert and nothing reports it.
+ * <p>
+ * {@code TaskManager}'s per-plugin and external entry points both reach their beans by iterating a
+ * {@code SimpleContainer}. An object the framework constructs directly belongs to no container and
+ * is reached by neither. Before 6.3.0 there was no third path at all, so {@code
+ * PlayerCacheManager.sweepExpiredEntries()} -- whose javadoc argues at length for a clock-driven
+ * sweep over a hand-rolled {@code BukkitRunnable} -- never ran once, silently, for the whole life
+ * of the release it shipped in.
+ * <p>
+ * <b>What this test enforces.</b> Every class under {@code com.ultikits.ultitools} that declares a
+ * {@link Scheduled} method must appear in {@link PluginManager#FRAMEWORK_SCHEDULED_OWNER_TYPES},
+ * which is the set {@code PluginManager} actually registers. Adding the annotation without adding
+ * the type fails the build, and adding the type is what wires the task -- so satisfying this test
+ * and wiring the task are the same act. A test that merely asserted the current sweep runs would
+ * have prevented nothing: the next framework class to carry {@code @Scheduled} would break in
+ * exactly the same silent way.
+ *
+ * @since 6.3.0
+ */
+@DisplayName("Framework @Scheduled wiring")
+class FrameworkScheduledWiringTest {
+
+    /**
+     * The annotation's descriptor as it appears in a class file's constant pool.
+     * <p>
+     * Used only as a cheap pre-filter. It cannot be the verdict on its own: a class that merely
+     * <em>mentions</em> the type carries the same descriptor. {@code TaskManager} declares a local
+     * {@code Scheduled scheduled = method.getAnnotation(...)}, and Maven compiles with debug info
+     * by default, so the descriptor lands in its {@code LocalVariableTable} even though
+     * {@code TaskManager} carries no {@code @Scheduled} method of its own. The real verdict is
+     * reflective, below.
+     */
+    private static final String DESCRIPTOR = "Lcom/ultikits/ultitools/annotations/Scheduled;";
+
+    private static final String FRAMEWORK_PACKAGE = "com.ultikits.ultitools";
+
+    @Test
+    @DisplayName("every framework class declaring a @Scheduled method is in the registered set")
+    void everyFrameworkScheduledOwnerIsRegistered() throws Exception {
+        Set<Class<?>> declaring = findFrameworkClassesDeclaringScheduledMethods();
+
+        // Positive control. A scan that reads nothing -- wrong root, changed layout, classes not
+        // built -- returns an empty set, which is indistinguishable from "no violations" and would
+        // make this test pass forever while enforcing nothing. PlayerCacheManager is known to
+        // carry the annotation, so if the instrument works it must be found.
+        assertThat(declaring)
+                .as("positive control: the scan must find PlayerCacheManager, which is known to "
+                        + "declare a @Scheduled method. An empty or incomplete result here means "
+                        + "the scan is broken, not that the codebase is clean.")
+                .contains(PlayerCacheManager.class);
+
+        assertThat(declaring)
+                .as("every framework-owned class declaring a @Scheduled method must appear in "
+                        + "PluginManager.FRAMEWORK_SCHEDULED_OWNER_TYPES, which is the set that is "
+                        + "actually registered. A class missing from it has an annotation that "
+                        + "silently never fires -- see #384.")
+                .isSubsetOf(PluginManager.FRAMEWORK_SCHEDULED_OWNER_TYPES);
+    }
+
+    @Test
+    @DisplayName("the registered set contains no type that has stopped declaring a @Scheduled method")
+    void registeredSetHasNoStaleEntries() throws Exception {
+        Set<Class<?>> declaring = findFrameworkClassesDeclaringScheduledMethods();
+
+        assertThat(PluginManager.FRAMEWORK_SCHEDULED_OWNER_TYPES)
+                .as("a type left in the registered set after its @Scheduled method was removed "
+                        + "costs a pointless scan and, worse, reads as coverage that is no longer "
+                        + "there")
+                .isSubsetOf(declaring);
+    }
+
+    /**
+     * Reflectively determine which framework classes declare a {@link Scheduled} method.
+     * <p>
+     * Classes are loaded with {@code initialize = false} so no static initialiser runs: several
+     * framework classes reach for a live {@code UltiTools.getInstance()} in theirs, and this test
+     * has no server. A candidate that cannot be loaded fails the test rather than being skipped --
+     * a silent skip would reopen the hole this test exists to close.
+     */
+    private Set<Class<?>> findFrameworkClassesDeclaringScheduledMethods()
+            throws IOException, URISyntaxException {
+        Path classesRoot = Paths.get(
+                PluginManager.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+
+        List<String> candidates;
+        try (Stream<Path> files = Files.walk(classesRoot)) {
+            candidates = files
+                    .filter(f -> f.toString().endsWith(".class"))
+                    .filter(this::mentionsScheduledDescriptor)
+                    .map(f -> toClassName(classesRoot, f))
+                    .filter(n -> n.startsWith(FRAMEWORK_PACKAGE))
+                    .collect(Collectors.toList());
+        }
+
+        assertThat(candidates)
+                .as("pre-filter control: scanning %s produced no candidate class files at all, "
+                        + "which means the scan is not reading what it thinks it is", classesRoot)
+                .isNotEmpty();
+
+        Set<Class<?>> declaring = new LinkedHashSet<>();
+        List<String> unloadable = new ArrayList<>();
+        for (String name : candidates) {
+            Class<?> clazz;
+            try {
+                clazz = Class.forName(name, false, getClass().getClassLoader());
+            } catch (Throwable t) {
+                unloadable.add(name + " (" + t.getClass().getSimpleName() + ")");
+                continue;
+            }
+            for (Method method : clazz.getDeclaredMethods()) {
+                if (method.isAnnotationPresent(Scheduled.class)) {
+                    declaring.add(clazz);
+                    break;
+                }
+            }
+        }
+
+        if (!unloadable.isEmpty()) {
+            fail("These candidate classes could not be inspected, so this test cannot say whether "
+                    + "they declare an unwired @Scheduled method. Skipping them silently would "
+                    + "reopen the hole the test exists to close: " + unloadable);
+        }
+        return declaring;
+    }
+
+    private boolean mentionsScheduledDescriptor(Path classFile) {
+        try {
+            byte[] bytes = Files.readAllBytes(classFile);
+            return new String(bytes, StandardCharsets.ISO_8859_1).contains(DESCRIPTOR);
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not read " + classFile, e);
+        }
+    }
+
+    private String toClassName(Path root, Path classFile) {
+        String relative = root.relativize(classFile).toString();
+        return relative
+                .substring(0, relative.length() - ".class".length())
+                .replace(java.io.File.separatorChar, '.');
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/manager/TaskManagerTest.java
+++ b/src/test/java/com/ultikits/ultitools/manager/TaskManagerTest.java
@@ -315,4 +315,58 @@ class TaskManagerTest {
             assertEquals(1, taskManager.getTaskCount(otherPlugin));
         }
     }
+
+    // === Framework-owned (core) bucket -- #384 ===
+
+    @Nested
+    @DisplayName("Framework-owned task registration (#384)")
+    class CoreTaskTests {
+
+        @Test
+        @DisplayName("Should register a framework-owned bean's scheduled methods")
+        void shouldRegisterCoreBean() {
+            taskManager.registerScheduledMethodsCore(new ServiceWithScheduled());
+
+            assertEquals(2, taskManager.getCoreTaskCount());
+        }
+
+        @Test
+        @DisplayName("Core registration does not leak into the per-plugin bucket")
+        void coreRegistrationIsSeparateFromPluginBucket() {
+            taskManager.registerScheduledMethodsCore(new ServiceWithScheduled());
+
+            assertEquals(2, taskManager.getCoreTaskCount());
+            assertEquals(0, taskManager.getTaskCount(mockUltiPlugin));
+        }
+
+        @Test
+        @DisplayName("cancelAllCore cancels framework tasks and leaves plugin tasks alone")
+        void cancelAllCoreOnlyAffectsCoreBucket() {
+            taskManager.registerScheduledMethodsCore(new ServiceWithScheduled());
+            taskManager.registerScheduledMethods(mockUltiPlugin, new ServiceWithDelayedTask());
+
+            taskManager.cancelAllCore();
+
+            assertEquals(0, taskManager.getCoreTaskCount());
+            assertEquals(1, taskManager.getTaskCount(mockUltiPlugin));
+        }
+
+        /**
+         * The concrete #384 regression, stated against the real class rather than a test double.
+         * <p>
+         * {@code PlayerCacheManager.sweepExpiredEntries()} carries {@code @Scheduled} and was
+         * measured on a live server never to run: the framework had no path that scanned an object
+         * it constructs itself. A test double would prove the new bucket works in the abstract;
+         * this proves the actual class whose annotation was inert is now registered.
+         */
+        @Test
+        @DisplayName("PlayerCacheManager's expiry sweep is registered -- the #384 regression")
+        void playerCacheManagerSweepIsRegistered() {
+            taskManager.registerScheduledMethodsCore(new PlayerCacheManager());
+
+            assertEquals(1, taskManager.getCoreTaskCount(),
+                    "PlayerCacheManager declares exactly one @Scheduled method "
+                            + "(sweepExpiredEntries); before #384 it was registered zero times");
+        }
+    }
 }


### PR DESCRIPTION
## Issue closure

Closes #384

## What was wrong

`TaskManager.registerScheduledMethods` has exactly two call sites in all of `src/main`, both in `PluginManager`, and both iterate a **plugin module's** container beans. `PlayerCacheManager` is `new`-ed in `PluginManager.init()` and belongs to no container, so its `@Scheduled` expiry sweep — added in 6.3.0, with javadoc arguing at length for a clock-driven sweep over a hand-rolled `BukkitRunnable` — was never registered and never ran.

Measured on a live Paper 1.21.4 server: a method-entry probe recorded **zero** entries over two full 5-minute periods, while other scheduled tasks entered on their periods in the same window.

The participants were wired correctly — `CooldownValidator` and `UsageLockValidator` both register themselves as `ExpiringPlayerCache`. Only the driver was missing, so `@CmdCD` state was pruned on player quit but never on the clock, and a console sender emits no quit event at all.

## What this changes

**1. A third task bucket, driven by a declared set.** `PluginManager.FRAMEWORK_SCHEDULED_OWNER_TYPES` declares which framework-owned types get registered; `registerFrameworkScheduledOwners()` registers instances of exactly those and throws if the two disagree. `close()` cancels them — `onDisable()` already calls it, and without cancellation a repeating task survives `/reload`.

**2. `FrameworkScheduledWiringTest`, which is the part that matters.** It fails the build if a class under `com.ultikits.ultitools` declares a `@Scheduled` method without appearing in that set. Adding the type to the set is what wires the task, so satisfying the test and wiring the task are the same act.

A test that merely asserted today's sweep runs would have prevented nothing: the next framework class to carry `@Scheduled` would have broken in exactly the same silent way. The criterion applied here is whether the same defect can recur, not whether this instance is fixed.

**3. Registration logs at INFO rather than FINE.** Bukkit's default configuration does not print FINE, which made "registered but not firing" indistinguishable from "never registered" from outside the JVM. Diagnosing both this and #382 required attaching a bytecode probe to learn something this log line already knew. 16 `@Scheduled` methods ecosystem-wide, so the added startup output is bounded.

`TaskManager`'s two near-identical scan-and-schedule bodies are collapsed into one private helper; a third copy for the new bucket would have been three places to keep a signature check, a scheduling rule and a log line in step.

## How the guard test avoids being a false comfort

It pre-filters on the annotation descriptor in the constant pool, then confirms reflectively with `initialize = false` (several framework classes reach for a live `UltiTools.getInstance()` in their static initialisers, and this test has no server).

The byte scan alone is **not** sufficient and is not treated as such: `TaskManager` declares a local `Scheduled` variable, and with debug info on by default the descriptor lands in its `LocalVariableTable`. Measured: the pre-filter yields 2 candidates, reflection narrows to 1.

It carries a **positive control**. A scan that silently reads nothing returns an empty set, which is indistinguishable from "no violations" and would leave the test passing forever while enforcing nothing. The control asserts the scan finds `PlayerCacheManager`, which is known to carry the annotation.

A candidate class that cannot be loaded **fails** the test rather than being skipped — a silent skip would reopen the hole the test exists to close.

## Verification

| Check | Result |
|---|---|
| `mvn -B clean verify` | BUILD SUCCESS — **5363 tests, 0 failures, 0 errors, 0 skipped** |
| Guard test | 2 green |
| New core-bucket tests (`TaskManagerTest`, isolated tag) | 4 green; 20 green in that class |
| Mutation: empty the declared set and owner list | guard goes **red** with the intended message |
| Mutation: break the byte scan | the **positive control** fires |
| `animal-sniffer` Java 8 boundary | pass |

Both mutations were run because a green guard test proves nothing until it has been shown to go red for the reason it exists.

## Gate status — please do not merge yet

| Gate | State |
|---|---|
| 1. Own code review | done |
| 2. Codacy + Codex | pending on this PR |
| 3. Real-machine UAT | **deferred, deliberately** |
| 4. CI green | pending |

Gate 3 is blocked by sequencing, not by an omission. An ecosystem acceptance pass is currently in flight against the jar built from `490cbc7b` — content-identical to `alpha` (`git diff --stat 490cbc7b origin/alpha` is empty) — with 129 of 416 registry items recorded. Installing a rebuilt jar resets that ledger, so this build is deliberately **not deployed** until the pass completes.

The UAT re-run of registry item `SCH-50c4d110` is also the instrument that closes the one coverage gap this PR does not close itself: the set, the runtime consistency check and the registration path are unit-tested, but `init()` actually calling `registerFrameworkScheduledOwners()` is not, because `init()` also scans the plugin directory. That item measures whether the sweep fires at boot.

## Not in scope

#382 (`TradeService.cleanupExpiredRequests`) is a different defect sharing this symptom — that service is a module `@Service` and already in scope for the existing call site. The hypothesis stated in #382 has been separately refuted in a comment there; part 3 of this PR gives that investigation its instrument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQ8annckTbswRvUEZrkNYj
