### PR TITLE
fix(398): complete a first-token <param>, instead of skipping it

### DIFF
--- a/src/main/java/com/ultikits/ultitools/abstracts/command/CommandTabCompletionDispatch.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/command/CommandTabCompletionDispatch.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
+import java.util.Set;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
@@ -85,7 +87,7 @@ public final class CommandTabCompletionDispatch {
             return new ArrayList<>();
         }
         if (args.length == 1) {
-            return suggestFirstToken(mappings, player, command, args);
+            return suggestFirstToken(mappings, player, command, args, executorInstance);
         }
         return suggestSubsequentToken(mappings, player, command, args, executorInstance);
     }
@@ -98,7 +100,8 @@ public final class CommandTabCompletionDispatch {
      * behaviour here is a deliberate, named change (see plan 05-05's SUMMARY).
      */
     private static List<String> suggestFirstToken(BiMap<String, Method> mappings, Player player,
-                                                    Command command, String[] args) {
+                                                    Command command, String[] args,
+                                                    Object executorInstance) {
         Map<String, Method> visible = new LinkedHashMap<>();
         for (Map.Entry<String, Method> entry : mappings.entrySet()) {
             if (isVisible(player, entry.getValue())) {
@@ -107,7 +110,46 @@ public final class CommandTabCompletionDispatch {
         }
         TabCompletionManager manager = TabCompletionManager.getInstance();
         TabCompletionContext context = manager.createContext(player, command, args);
-        return manager.suggestFirstArgs(visible, context);
+
+        Set<String> completions = new TreeSet<>(manager.suggestFirstArgs(visible, context));
+        completions.addAll(firstTokenParameterSuggestions(visible, player, command, args,
+                executorInstance));
+        return new ArrayList<>(completions);
+    }
+
+    /**
+     * Resolves the {@code <param>} slot of every visible format whose <em>first</em> token is a
+     * parameter rather than a literal.
+     * <p>
+     * {@code TabCompletionManager.suggestFirstArgs} skips parameter placeholders by construction --
+     * it collects literal subcommand names -- and until 6.3.0 nothing else covered position 0, so
+     * a format like {@code "<name>"} contributed no candidates at all and its
+     * {@code @CmdParam(suggest = ...)} method was never invoked. That silently disabled completion
+     * for the first argument of roughly forty mappings across nine modules, including
+     * {@code /home <name>}, {@code /warp <name>}, {@code /tpa <player>} and {@code /pay}; two of
+     * them had written a suggester that never ran. See #398.
+     * <p>
+     * Position 1 and later were unaffected, because {@code suggestSubsequentToken} has always
+     * resolved parameter slots. UltiMenu declares the same suggester on {@code "<name>"} and on
+     * {@code "open <name>"}, and only the second worked -- same class, same parameter, same
+     * method, differing only in token position.
+     *
+     * @since 6.3.0
+     */
+    private static List<String> firstTokenParameterSuggestions(Map<String, Method> visible,
+                                                                 Player player, Command command,
+                                                                 String[] args,
+                                                                 Object executorInstance) {
+        List<String> completions = new ArrayList<>();
+        for (Map.Entry<String, Method> entry : visible.entrySet()) {
+            String[] formatArgs = splitFormat(entry.getKey());
+            if (formatArgs.length == 0 || !isParameterToken(formatArgs[0])) {
+                continue;
+            }
+            completions.addAll(suggestParameterSlot(player, command, args, 0, entry.getValue(),
+                    formatArgs[0], executorInstance));
+        }
+        return completions;
     }
 
     /**

--- a/src/test/java/com/ultikits/ultitools/abstracts/command/BaseCommandExecutorTabCompletionTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/command/BaseCommandExecutorTabCompletionTest.java
@@ -168,6 +168,80 @@ class BaseCommandExecutorTabCompletionTest {
     // Task 2: one dispatch -- argument-position resolution into commands/tabcomplete/
     // ========================================================================================
 
+
+    @Nested
+    @DisplayName("#398: a first-token <param> is completed, not skipped")
+    class FirstTokenParameterTests {
+
+        /**
+         * The controlled comparison this defect was found by, reproduced as a test.
+         * <p>
+         * {@code FirstTokenExecutor} declares the SAME suggest method on the same parameter name
+         * at two positions -- {@code "<name>"} and {@code "open <name>"} -- exactly as UltiMenu
+         * does. Only the second worked: {@code suggestFirstArgs} collects literal subcommand names
+         * and skips parameter placeholders by construction, and nothing else covered position 0.
+         */
+        @Test
+        @DisplayName("position 0: a bare <param> format yields its suggester's output")
+        void firstTokenParameterIsCompleted() {
+            FirstTokenExecutor executor = new FirstTokenExecutor();
+
+            List<String> completions =
+                    executor.onTabComplete(player, mockCommand, "fixture", new String[]{""});
+
+            assertThat(completions).contains("example", "spawn");
+        }
+
+        @Test
+        @DisplayName("control, position 1: the same suggester on the same parameter already worked")
+        void laterPositionStillWorks() {
+            FirstTokenExecutor executor = new FirstTokenExecutor();
+
+            List<String> completions =
+                    executor.onTabComplete(player, mockCommand, "fixture", new String[]{"open", ""});
+
+            // If this ever fails, the position-0 assertion above proves nothing: the two would be
+            // broken together rather than the first one alone.
+            assertThat(completions).contains("example", "spawn");
+        }
+
+        @Test
+        @DisplayName("literal subcommands are still offered alongside the parameter suggestions")
+        void literalsAndParametersAreMerged() {
+            FirstTokenExecutor executor = new FirstTokenExecutor();
+
+            List<String> completions =
+                    executor.onTabComplete(player, mockCommand, "fixture", new String[]{""});
+
+            // The literal branch must not be displaced by the new one -- both formats are valid
+            // at position 0 and a user needs to see both.
+            assertThat(completions).contains("open", "list");
+        }
+
+        @Test
+        @DisplayName("a partial first token narrows the parameter suggestions")
+        void partialFirstTokenNarrows() {
+            FirstTokenExecutor executor = new FirstTokenExecutor();
+
+            List<String> completions =
+                    executor.onTabComplete(player, mockCommand, "fixture", new String[]{"exa"});
+
+            assertThat(completions).contains("example");
+            assertThat(completions).doesNotContain("spawn");
+        }
+
+        @Test
+        @DisplayName("no duplicates when a suggestion also happens to be a literal subcommand")
+        void noDuplicatesAcrossTheTwoSources() {
+            FirstTokenExecutor executor = new FirstTokenExecutor();
+
+            List<String> completions =
+                    executor.onTabComplete(player, mockCommand, "fixture", new String[]{""});
+
+            assertThat(completions).doesNotHaveDuplicates();
+        }
+    }
+
     @Nested
     @DisplayName("Task 2: entry-point dispatch + argument-position resolution")
     class ArgumentPositionResolutionTests {
@@ -473,6 +547,40 @@ class BaseCommandExecutorTabCompletionTest {
      * String)} (16 of UltiWorlds' 24 downstream call sites).
      */
     @CmdTarget(CmdTarget.CmdTargetType.BOTH)
+    /**
+     * Declares one suggest method on the same parameter name at two token positions, so a test can
+     * hold everything constant except the position. Modelled on UltiMenu's {@code MenuCommands},
+     * where {@code /menu open e<TAB>} offered {@code example} and {@code /menu e<TAB>} offered
+     * nothing (#398).
+     */
+    static class FirstTokenExecutor extends BaseCommandExecutor {
+        @Override
+        protected void handleHelp(CommandSender sender) {
+            // not exercised
+        }
+
+        @CmdMapping(format = "<name>")
+        public void quickOpen(@CmdSender CommandSender sender,
+                              @CmdParam(value = "name", suggest = "suggestNames") String name) {
+            // body not exercised
+        }
+
+        @CmdMapping(format = "open <name>")
+        public void open(@CmdSender CommandSender sender,
+                         @CmdParam(value = "name", suggest = "suggestNames") String name) {
+            // body not exercised
+        }
+
+        @CmdMapping(format = "list")
+        public void list(@CmdSender CommandSender sender) {
+            // body not exercised
+        }
+
+        public List<String> suggestNames() {
+            return Arrays.asList("example", "spawn");
+        }
+    }
+
     static class SignatureShapeExecutor extends BaseCommandExecutor {
         @Override
         protected void handleHelp(CommandSender sender) {


### PR DESCRIPTION
## Issue closure

Closes #398

## What was broken

`onTabComplete` forks on argument position:

```java
if (args.length == 1) {
    return suggestFirstToken(...);
}
return suggestSubsequentToken(...);
```

`suggestSubsequentToken` has always resolved `<param>` slots through `commands/tabcomplete/`. `suggestFirstToken` delegated to `TabCompletionManager.suggestFirstArgs`, which collects literal subcommand names and skips placeholders — its own comment says `// Skip parameter placeholders`. Nothing else covered position 0.

So a format whose first token is a parameter contributed **no** candidates, and its `@CmdParam(suggest = ...)` method was never invoked. Measured: ~40 such mappings across 9 modules, including `/home <name>`, `/warp <name>`, `/tpa <player>`, `/pay`, `/ch <name>`, `/menu <name>`, `/bag <page>`.

Two of them had written a suggester that never ran. UltiChat's carries `@SuppressWarnings("unused")` — the author had noticed the method was never called and suppressed the warning rather than finding out why.

## The fix

`suggestFirstToken` merges what it already produced (literal subcommands, prefix-filtered and sorted) with the parameter slots resolved through the **same** `suggestParameterSlot` that positions 1+ use. Deduplicated and sorted together.

Partial-input narrowing needed nothing new: `MethodInvocationCompleter` already filters by the typed prefix.

## Tests reproduce the comparison the defect was found by

The fixture declares **one** suggest method on the same parameter name at two positions — `"<name>"` and `"open <name>"` — exactly as UltiMenu does. Everything is held constant except the token index.

| assertion | why |
|---|---|
| position 0 completes | the fix |
| **position 1 still completes** | the control — without it the first proves nothing, since both could be broken together |
| literals and parameters merged | the literal branch must not be displaced |
| a partial token narrows | `/menu exa<TAB>` must not offer everything |
| no duplicates | the two sources can overlap |

**Mutation-tested**: disabling the new branch turns the position-0 and partial-narrowing tests red while the position-1 control stays green — the exact asymmetry observed on the server (`/menu open e<TAB>` → `example`, `/menu e<TAB>` → nothing).

## Verification

`mvn clean verify`: **5353 tests, 0 failures**; CJK scope gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQ8annckTbswRvUEZrkNYj