### PR TITLE
fix(392): report @ConditionalOnConfig drift on reload instead of staying silent

### DIFF
--- a/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.ApiStatus;
 import com.ultikits.ultitools.UltiTools;
 import com.ultikits.ultitools.abstracts.data.BaseDataEntity;
 import com.ultikits.ultitools.annotations.EnableAutoRegister;
+import com.ultikits.ultitools.context.ConditionalRegistrationEvaluator;
 import com.ultikits.ultitools.context.MergedAnnotationResolver;
 import com.ultikits.ultitools.context.SimpleContainer;
 import com.ultikits.ultitools.entities.Language;
@@ -627,11 +628,24 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
         getListenerManager().unregisterAll(this);
     }
 
+    /**
+     * Reload this plugin's configuration and language files.
+     * <p>
+     * Also reports (but does not act on) any {@code @ConditionalOnConfig} drift: the condition
+     * is evaluated once, at component-scan time during startup, so a reload can only log that a
+     * watched key has changed direction since then -- it never registers, unregisters, or
+     * rebuilds anything (issue #392, D-01). A module overriding {@code reloadSelf()} without
+     * calling {@code super.reloadSelf()} will not get this report; that is pre-existing
+     * behaviour for the two statements above too, stated here so it is not a surprise.
+     */
     @Override
     public void reloadSelf() {
         getConfigManager().reloadConfigs(this);
         // Reinitialize language in case language setting changed
         language = createLanguageFromPath(resourceFolderPath);
+        // @ConditionalOnConfig is evaluated once at component-scan time; a reload can only
+        // report drift on a watched key, never re-register or rebuild anything (#392, D-01).
+        ConditionalRegistrationEvaluator.reportDrift(this);
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/annotations/ConditionalOnConfig.java
+++ b/src/main/java/com/ultikits/ultitools/annotations/ConditionalOnConfig.java
@@ -29,10 +29,11 @@ import java.lang.annotation.Target;
  * com.ultikits.ultitools.context.ConditionalRegistrationEvaluator} for the reporting mechanism
  * and why re-registering on reload was rejected.
  *
- * @apiNote This is <b>not</b> equivalent to an in-code {@code if (config.isEnabled())} block,
- *         which re-reads the config value on every call and therefore does follow a reload. A
- *         module author migrating off a hand-written {@code if} block onto this annotation is
- *         trading that per-call freshness for load-time simplicity -- know that before switching.
+ * <p><b>This is not equivalent to an in-code {@code if (config.isEnabled())} block</b>, which
+ * re-reads the config value on every call and therefore does follow a reload. A module author
+ * migrating off a hand-written {@code if} block onto this annotation is trading that per-call
+ * freshness for load-time simplicity -- know that before switching.
+ *
  * @since 6.2.0
  */
 @Target(ElementType.TYPE)

--- a/src/main/java/com/ultikits/ultitools/annotations/ConditionalOnConfig.java
+++ b/src/main/java/com/ultikits/ultitools/annotations/ConditionalOnConfig.java
@@ -8,11 +8,10 @@ import java.lang.annotation.Target;
 /**
  * Conditionally registers a component based on a YAML config value.
  * <p>
- * This is the framework-supported replacement for an in-code {@code if (config.isEnabled())}
- * block: when placed on a {@code @Service}, {@code @CmdExecutor}, {@code @EventListener},
- * or any component class, the framework checks the specified config file and key
- * during component scanning. If the config value is {@code false} (or missing),
- * the component is skipped entirely.
+ * When placed on a {@code @Service}, {@code @CmdExecutor}, {@code @EventListener}, or any
+ * component class, the framework checks the specified config file and key <b>once</b>, during
+ * component scanning at plugin startup. If the config value is {@code false} (or missing), the
+ * component is skipped entirely for the lifetime of that startup.
  *
  * <p>Usage example:
  * <pre>{@code
@@ -23,6 +22,17 @@ import java.lang.annotation.Target;
  * }
  * }</pre>
  *
+ * <p><b>A restart is required for a change to the named key to take effect, in both
+ * directions.</b> {@code ul reload} re-reads the config file, but only <i>reports</i> the drift
+ * as a {@code Level.WARNING} naming the class, the file, the key, and the new direction -- it
+ * does not register or unregister anything (issue #392, D-01). See {@code
+ * com.ultikits.ultitools.context.ConditionalRegistrationEvaluator} for the reporting mechanism
+ * and why re-registering on reload was rejected.
+ *
+ * @apiNote This is <b>not</b> equivalent to an in-code {@code if (config.isEnabled())} block,
+ *         which re-reads the config value on every call and therefore does follow a reload. A
+ *         module author migrating off a hand-written {@code if} block onto this annotation is
+ *         trading that per-call freshness for load-time simplicity -- know that before switching.
  * @since 6.2.0
  */
 @Target(ElementType.TYPE)

--- a/src/main/java/com/ultikits/ultitools/context/ComponentScanner.java
+++ b/src/main/java/com/ultikits/ultitools/context/ComponentScanner.java
@@ -225,8 +225,10 @@ public class ComponentScanner {
      * Check if a class should be registered based on @ConditionalOnConfig.
      * <p>
      * Delegates to {@link ConditionalRegistrationEvaluator}, the single shared implementation
-     * of this decision (D-17) -- also consulted by {@code ListenerManager}'s package-scan
-     * overload, so the annotation is honoured identically on both reflection paths.
+     * of this decision (D-17). This is the only call site of that evaluator in {@code src/main}
+     * (verified: {@code ListenerManager} and {@code CommandManager} have no package-scan
+     * overload that consults it), so this scanner is the one place the annotation needs to be
+     * honoured correctly.
      *
      * @param clazz the class to check
      * @return true if the class should be registered

--- a/src/main/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluator.java
+++ b/src/main/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluator.java
@@ -1,6 +1,12 @@
 package com.ultikits.ultitools.context;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -13,10 +19,39 @@ import org.jetbrains.annotations.ApiStatus;
 /**
  * The single shared {@code @ConditionalOnConfig} registration decision (D-17).
  * <p>
- * Both {@link ComponentScanner} (the IoC-scan path) and {@code ListenerManager}'s
- * reflective package-scan overload consult this evaluator, so the annotation is honoured
- * identically wherever it is read instead of each caller carrying its own copy of the
- * decision that can drift out of sync with the other.
+ * {@link ComponentScanner#shouldRegister(Class)} is the only caller of this evaluator in
+ * {@code src/main} -- recording the decision here therefore catches every path the annotation
+ * is honoured on, without needing a second copy of the decision anywhere else.
+ * <p>
+ * <b>Reload drift reporting (issue #392, D-01).</b> {@code @ConditionalOnConfig} is evaluated
+ * exactly once, during component scanning at plugin startup. {@code ul reload} re-reads the
+ * config file but this framework deliberately does <b>not</b> rebuild the container or
+ * re-register/unregister the component on reload -- see D-01 in the issue for the rejected
+ * "unregister and re-register the module" alternative and why it was rejected (it would discard
+ * the whole module's in-memory state, turning a config reload into a de-facto restart while
+ * players are online). Instead, {@link #shouldRegister(Class, SimpleContainer)} records every
+ * decision it makes, and {@link #reportDrift(UltiToolsPlugin)} -- called from
+ * {@link UltiToolsPlugin#reloadSelf()} -- re-evaluates each recorded class and logs a
+ * {@code Level.WARNING} for any class whose answer has changed, naming the class, the config
+ * file, the key, the new direction, and that a restart is required. This turns a previously
+ * silent no-op into a visible one without changing what reload actually does.
+ * <p>
+ * <b>Where the record lives, and why.</b> The record is a private static map keyed by the
+ * owning {@link UltiToolsPlugin} <i>instance</i> (identity, not equality -- a plugin has no
+ * value-based {@code equals()}), because: (a) the decision is inherently per-plugin, since the
+ * same class annotated on two different plugins would resolve against two different resource
+ * folders; (b) it is released by an explicit {@link #clear(UltiToolsPlugin)} call from
+ * {@code PluginManager.unregister}, the same place this codebase already releases the other
+ * module-scoped registries that would otherwise pin the module's ClassLoader after unload
+ * ({@code TabCompletionManager}, {@code EventBus}, {@code PanelResponderRegistry}) -- the record
+ * holds {@code Class<?>} objects, so leaving it behind would pin the loader exactly the same
+ * way; (c) it is safe for the framework's own core context, which has no {@code UltiToolsPlugin}
+ * bean at all, because evaluation exits down the existing fail-open branch before anything is
+ * recorded, and a class carrying no {@code @ConditionalOnConfig} returns {@code true} before
+ * that. Rejected alternative: storing the record as a field on {@code UltiToolsPlugin} would
+ * make garbage collection automatic (no {@code clear()} call needed), but it would widen a
+ * public abstract class's API surface for an {@link ApiStatus.Internal} bookkeeping concern that
+ * has nothing to do with what a module author subclasses {@code UltiToolsPlugin} for.
  *
  * @since 6.3.0
  */
@@ -25,6 +60,19 @@ public final class ConditionalRegistrationEvaluator {
 
     private static final Logger LOGGER =
             Logger.getLogger(ConditionalRegistrationEvaluator.class.getName());
+
+    /**
+     * Guards every read, write, and iteration of {@link #STARTUP_DECISIONS}.
+     */
+    private static final Object RECORD_LOCK = new Object();
+
+    /**
+     * Every scan-time {@code @ConditionalOnConfig} decision, keyed by owning plugin instance
+     * (identity) then by the evaluated class. The inner map is a {@link LinkedHashMap} so
+     * {@link #reportDrift(UltiToolsPlugin)} reports drift in a deterministic order.
+     */
+    private static final Map<UltiToolsPlugin, Map<Class<?>, Boolean>> STARTUP_DECISIONS =
+            new IdentityHashMap<>();
 
     private ConditionalRegistrationEvaluator() {
     }
@@ -38,6 +86,10 @@ public final class ConditionalRegistrationEvaluator {
      * reason, rather than silently registering by default (D-20). The config-file-missing
      * branch is unaffected: it returns {@code condition.negate()}, i.e. missing means
      * disabled, which already matches the annotation's own javadoc.
+     * <p>
+     * The decision made here -- including a {@code false} (skipped) decision, which never
+     * appears in any container -- is recorded against the resolved plugin so a later
+     * {@link #reportDrift(UltiToolsPlugin)} call can detect drift (issue #392, D-01).
      *
      * @param clazz     the class to check
      * @param container the container used to resolve the owning {@link UltiToolsPlugin}
@@ -56,7 +108,9 @@ public final class ConditionalRegistrationEvaluator {
         } catch (Exception e) {
             // No plugin in container — skip conditional (register by default), but say so:
             // a component that should have been enabled and was silently skipped is harder to
-            // diagnose than the reverse (D-20).
+            // diagnose than the reverse (D-20). Nothing is recorded: there is no plugin to key
+            // the record against, and this is the framework's own core context, which never
+            // reloads through UltiToolsPlugin.reloadSelf() anyway.
             LOGGER.log(Level.WARNING, "@ConditionalOnConfig on " + clazz.getName()
                     + " could not be evaluated: no UltiToolsPlugin could be resolved from the "
                     + "container (" + e.getMessage() + "). Registering by default (fail-open).");
@@ -72,6 +126,22 @@ public final class ConditionalRegistrationEvaluator {
             return true;
         }
 
+        boolean decision = evaluate(plugin, condition);
+        record(plugin, clazz, decision);
+        return decision;
+    }
+
+    /**
+     * The decision logic extracted verbatim from the pre-6.3.0 {@code shouldRegister} body --
+     * no existing decision semantics changed by this extraction. Kept separate from
+     * {@link #shouldRegister(Class, SimpleContainer)} so {@link #reportDrift(UltiToolsPlugin)}
+     * can re-run exactly the same logic against the current file contents.
+     *
+     * @param plugin    the resolved, non-null owning plugin
+     * @param condition the class's {@code @ConditionalOnConfig} annotation
+     * @return true if the condition currently evaluates to "register"
+     */
+    private static boolean evaluate(UltiToolsPlugin plugin, ConditionalOnConfig condition) {
         // Load the referenced config file from the plugin's config folder
         File configFile = new File(plugin.getResourceFolderPath(), condition.value());
         if (!configFile.exists()) {
@@ -82,5 +152,104 @@ public final class ConditionalRegistrationEvaluator {
         YamlConfiguration yaml = YamlConfiguration.loadConfiguration(configFile);
         boolean value = yaml.getBoolean(condition.path(), false);
         return condition.negate() ? !value : value;
+    }
+
+    private static void record(UltiToolsPlugin plugin, Class<?> clazz, boolean decision) {
+        synchronized (RECORD_LOCK) {
+            STARTUP_DECISIONS
+                    .computeIfAbsent(plugin, unused -> new LinkedHashMap<>())
+                    .put(clazz, decision);
+        }
+    }
+
+    /**
+     * Re-evaluate every {@code @ConditionalOnConfig} decision recorded for {@code plugin} and
+     * log (and return) one {@code Level.WARNING} message for each class whose answer has
+     * changed since it was recorded (issue #392, D-01).
+     * <p>
+     * Per D-01, this method only reports -- it never registers, unregisters, or rebuilds
+     * anything. Re-evaluation runs outside {@link #RECORD_LOCK} (it does disk I/O via
+     * {@link YamlConfiguration#loadConfiguration(File)}, which must never run while holding a
+     * lock other reload/scan threads might contend on); the plugin's recorded map is snapshotted
+     * inside the lock first. Each class is re-evaluated in its own {@code try}/{@code catch} so
+     * one unreadable config file cannot abort the reload or the remaining classes.
+     *
+     * @param plugin the plugin being reloaded
+     * @return an unmodifiable list of the drift messages emitted, in recording order; empty if
+     *         there was no drift, if {@code plugin} is {@code null}, or if nothing is recorded
+     *         for {@code plugin}
+     */
+    public static List<String> reportDrift(UltiToolsPlugin plugin) {
+        if (plugin == null) {
+            return Collections.emptyList();
+        }
+
+        Map<Class<?>, Boolean> snapshot;
+        synchronized (RECORD_LOCK) {
+            Map<Class<?>, Boolean> recorded = STARTUP_DECISIONS.get(plugin);
+            if (recorded == null || recorded.isEmpty()) {
+                return Collections.emptyList();
+            }
+            snapshot = new LinkedHashMap<>(recorded);
+        }
+
+        List<String> messages = new ArrayList<>();
+        for (Map.Entry<Class<?>, Boolean> entry : snapshot.entrySet()) {
+            Class<?> clazz = entry.getKey();
+            boolean recordedDecision = entry.getValue();
+            try {
+                ConditionalOnConfig condition = clazz.getAnnotation(ConditionalOnConfig.class);
+                if (condition == null) {
+                    // Annotation removed since scan time (should not happen in practice, but the
+                    // record must not crash a reload over it) — nothing to compare against.
+                    continue;
+                }
+                boolean currentDecision = evaluate(plugin, condition);
+                if (currentDecision == recordedDecision) {
+                    continue;
+                }
+                String message = driftMessage(clazz, condition, currentDecision);
+                LOGGER.log(Level.WARNING, message);
+                messages.add(message);
+            } catch (RuntimeException e) {
+                LOGGER.log(Level.WARNING, "@ConditionalOnConfig drift check failed for "
+                        + clazz.getName() + ": " + e.getMessage()
+                        + ". Skipping this class for this reload.");
+            }
+        }
+        return Collections.unmodifiableList(messages);
+    }
+
+    private static String driftMessage(Class<?> clazz, ConditionalOnConfig condition, boolean currentDecision) {
+        // Report the registration decision, not the raw YAML boolean -- negate=true would
+        // otherwise make the direction word ambiguous relative to what actually happened.
+        String directionWord = currentDecision ? "enabled" : "disabled";
+        String stateClause = currentDecision
+                ? "but the component was not registered at startup"
+                : "but the component is already registered";
+        return "[UltiTools-API] @ConditionalOnConfig drift after reload: " + clazz.getName()
+                + " (" + condition.value() + " -> " + condition.path() + ") now evaluates to "
+                + directionWord + ", " + stateClause + ". @ConditionalOnConfig is evaluated once "
+                + "at component scan; a restart is required for this change to take effect.";
+    }
+
+    /**
+     * Release every decision recorded for {@code plugin}.
+     * <p>
+     * Called from {@code PluginManager.unregister} when a module unloads -- the record holds
+     * {@code Class<?>} references, and would otherwise pin the module's ClassLoader after
+     * unload, exactly like the {@code TabCompletionManager} / {@code EventBus} /
+     * {@code PanelResponderRegistry} releases it sits alongside there.
+     *
+     * @param plugin the plugin whose recorded decisions should be released; {@code null} is a
+     *               no-op, as is a plugin with nothing recorded
+     */
+    public static void clear(UltiToolsPlugin plugin) {
+        if (plugin == null) {
+            return;
+        }
+        synchronized (RECORD_LOCK) {
+            STARTUP_DECISIONS.remove(plugin);
+        }
     }
 }

--- a/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
+++ b/src/main/java/com/ultikits/ultitools/manager/PluginManager.java
@@ -62,6 +62,7 @@ import com.ultikits.ultitools.commands.tabcomplete.TabCompletionManager;
 import com.ultikits.ultitools.events.EventBus;
 import com.ultikits.ultitools.events.ModuleEvent;
 import com.ultikits.ultitools.websocket.PanelResponderRegistry;
+import com.ultikits.ultitools.context.ConditionalRegistrationEvaluator;
 import com.ultikits.ultitools.context.SimpleContainer;
 import com.ultikits.ultitools.context.MergedAnnotationResolver;
 import com.ultikits.ultitools.exceptions.ErrorCode;
@@ -332,6 +333,11 @@ public class PluginManager {
         if (panelResponderRegistry != null) {
             panelResponderRegistry.unregisterAll(plugin.getPluginName());
         }
+        // Release this module's recorded @ConditionalOnConfig scan-time decisions (#392, D-01).
+        // The record holds Class<?> references and would otherwise pin the module's ClassLoader
+        // after unload, exactly like the TabCompletionManager / EventBus / PanelResponderRegistry
+        // releases immediately above.
+        ConditionalRegistrationEvaluator.clear(plugin);
         UltiTools.getInstance().getListenerManager().unregisterAll(plugin);
         plugin.unregisterSelf();
         // unregister() is reachable with an instance the caller constructed directly, which never

--- a/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
@@ -1,0 +1,157 @@
+package com.ultikits.ultitools.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.ultikits.ultitools.abstracts.UltiToolsPlugin;
+import com.ultikits.ultitools.annotations.ConditionalOnConfig;
+import com.ultikits.ultitools.interfaces.impl.logger.PluginLogger;
+import com.ultikits.ultitools.manager.ConfigManager;
+import com.ultikits.ultitools.utils.TestHelper;
+
+/**
+ * Issue #392 / D-01: {@code @ConditionalOnConfig} is evaluated once at component-scan time, so
+ * {@code ul reload} re-reads the config file but never re-evaluates the condition. Per the locked
+ * decision, the framework does not rebuild or re-register anything on reload -- it records the
+ * scan-time decision and reports drift as a {@code Level.WARNING} when {@link
+ * UltiToolsPlugin#reloadSelf()} is called, so an operator sees the flip instead of silence.
+ * <p>
+ * This class proves the end-to-end path first (scan -&gt; config flip -&gt; reload -&gt; warning),
+ * following the {@code doCallRealMethod()} idiom used by {@code UltiToolsPluginLanguageFallbackTest}.
+ *
+ * @since 6.3.0
+ */
+@DisplayName("ConditionalRegistrationEvaluator drift report (#392, D-01)")
+@SuppressWarnings("PMD.AvoidAccessibilityAlteration") // reflective field set mirrors the proven idiom
+class ConditionalRegistrationEvaluatorDriftTest {
+
+    @TempDir
+    File tempDir;
+
+    private ConfigManager mockConfigManager;
+    private final List<LogRecord> captured = new ArrayList<>();
+    private Handler captureHandler;
+
+    abstract static class FixturePlugin extends UltiToolsPlugin {
+    }
+
+    @ConditionalOnConfig(value = "config/config.yml", path = "enableFeatureA")
+    static class FeatureAComponent {
+    }
+
+    @BeforeEach
+    void setUp() {
+        mockConfigManager = mock(ConfigManager.class);
+        TestHelper.mockUltiToolsInstance(ultiTools -> when(ultiTools.getConfigManager()).thenReturn(mockConfigManager));
+
+        captureHandler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                captured.add(record);
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        Logger.getLogger(ConditionalRegistrationEvaluator.class.getName()).addHandler(captureHandler);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Logger.getLogger(ConditionalRegistrationEvaluator.class.getName()).removeHandler(captureHandler);
+    }
+
+    private void writeYaml(String relativePath, String content) throws IOException {
+        File configFile = new File(tempDir, relativePath);
+        configFile.getParentFile().mkdirs();
+        try (FileWriter writer = new FileWriter(configFile)) {
+            writer.write(content);
+        }
+    }
+
+    private void writeLangFile(String code, String jsonContent) throws IOException {
+        File langDir = new File(tempDir, "lang");
+        langDir.mkdirs();
+        Files.write(new File(langDir, code + ".json").toPath(), jsonContent.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    @DisplayName("scan enabled -> reload disabled emits exactly one WARNING naming class/file/key/direction/restart")
+    void reloadAfterFlipToDisabledReportsDriftOnce() throws Exception {
+        // 1. Scan-time evaluation: enableFeatureA is true, component is registered.
+        writeYaml("config/config.yml", "enableFeatureA: true\n");
+        writeLangFile("en", "{\"greeting\":\"Hi\"}");
+
+        UltiToolsPlugin plugin = mock(FixturePlugin.class);
+        when(plugin.getResourceFolderPath()).thenReturn(tempDir.getAbsolutePath());
+        when(plugin.getLanguageCode()).thenReturn("en");
+        when(plugin.supported()).thenReturn(Collections.singletonList("en"));
+        when(plugin.getPluginName()).thenReturn("TestModule");
+        PluginLogger mockLogger = mock(PluginLogger.class);
+        when(plugin.getLogger()).thenReturn(mockLogger);
+
+        // reloadSelf() reads the private field directly, not the getter -- mirror the proven
+        // idiom from UltiToolsPluginLanguageFallbackTest.
+        Field resourceFolderPathField = UltiToolsPlugin.class.getDeclaredField("resourceFolderPath");
+        resourceFolderPathField.setAccessible(true);
+        resourceFolderPathField.set(plugin, tempDir.getAbsolutePath());
+
+        SimpleContainer container = new SimpleContainer();
+        container.registerType(UltiToolsPlugin.class, plugin);
+
+        boolean registeredAtScanTime = ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container);
+        assertThat(registeredAtScanTime).isTrue();
+
+        // 2. Flip the key on disk -- exactly what an operator does before `ul reload`.
+        writeYaml("config/config.yml", "enableFeatureA: false\n");
+
+        // 3. Reload -- must call the real reloadSelf() body, including the new drift report.
+        doCallRealMethod().when(plugin).reloadSelf();
+        plugin.reloadSelf();
+
+        // 4. Exactly one WARNING, naming the class, the config file, the key, the direction, and
+        // the restart requirement.
+        List<LogRecord> warnings = new ArrayList<>();
+        for (LogRecord record : captured) {
+            if (record.getLevel() == Level.WARNING) {
+                warnings.add(record);
+            }
+        }
+        assertThat(warnings).hasSize(1);
+        String message = warnings.get(0).getMessage();
+        assertThat(message).contains(FeatureAComponent.class.getName());
+        assertThat(message).contains("config/config.yml");
+        assertThat(message).contains("enableFeatureA");
+        assertThat(message).contains("disabled");
+        assertThat(message).contains("restart");
+
+        container.close();
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
@@ -189,7 +189,9 @@ class ConditionalRegistrationEvaluatorDriftTest {
         SimpleContainer container = containerFor(plugin);
 
         boolean registeredAtScanTime = ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container);
-        assertThat(registeredAtScanTime).isTrue();
+        assertThat(registeredAtScanTime)
+                .as("scan-time decision with enableFeatureA: true must be register")
+                .isTrue();
 
         // 2. Flip the key on disk -- exactly what an operator does before `ul reload`.
         writeYaml("config/config.yml", "enableFeatureA: false\n");
@@ -201,7 +203,12 @@ class ConditionalRegistrationEvaluatorDriftTest {
         // 4. Exactly one WARNING, naming the class, the config file, the key, the direction, and
         // the restart requirement.
         List<LogRecord> warnings = warningsCaptured();
-        assertThat(warnings).hasSize(1);
+        assertThat(warnings)
+                .as("reloadSelf() must emit exactly one @ConditionalOnConfig drift WARNING after "
+                        + "enableFeatureA flipped true -> false; an empty list means "
+                        + "ConditionalRegistrationEvaluator.reportDrift is no longer wired into "
+                        + "UltiToolsPlugin.reloadSelf()")
+                .hasSize(1);
         String message = warnings.get(0).getMessage();
         assertThat(message).contains(FeatureAComponent.class.getName());
         assertThat(message).contains("config/config.yml");
@@ -218,12 +225,17 @@ class ConditionalRegistrationEvaluatorDriftTest {
         SimpleContainer container = containerFor(plugin);
 
         boolean registeredAtScanTime = ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container);
-        assertThat(registeredAtScanTime).isFalse();
+        assertThat(registeredAtScanTime)
+                .as("scan-time decision with enableFeatureA: false must be skip")
+                .isFalse();
 
         writeYaml("config/config.yml", "enableFeatureA: true\n");
 
         List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
-        assertThat(messages).hasSize(1);
+        assertThat(messages)
+                .as("the disabled -> enabled direction must report too; #392 measured BOTH "
+                        + "directions inert, so covering only one would leave half the defect")
+                .hasSize(1);
         String message = messages.get(0);
         assertThat(message).contains(FeatureAComponent.class.getName());
         assertThat(message).contains("config/config.yml");
@@ -232,7 +244,9 @@ class ConditionalRegistrationEvaluatorDriftTest {
         assertThat(message).contains("was not registered");
         assertThat(message).contains("restart");
 
-        assertThat(warningsCaptured()).hasSize(1);
+        assertThat(warningsCaptured())
+                .as("the drift message must reach the log, not only the return value")
+                .hasSize(1);
     }
 
     @Test
@@ -242,12 +256,19 @@ class ConditionalRegistrationEvaluatorDriftTest {
         UltiToolsPlugin plugin = mockPlugin();
         SimpleContainer container = containerFor(plugin);
 
-        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container)).isTrue();
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container))
+                .as("scan-time decision with enableFeatureA: true")
+                .isTrue();
 
         // No change to the file before reporting.
         List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
-        assertThat(messages).isEmpty();
-        assertThat(warningsCaptured()).isEmpty();
+        assertThat(messages)
+                .as("an unchanged config must produce no drift report; a report here means "
+                        + "reportDrift compares against something other than the recorded decision")
+                .isEmpty();
+        assertThat(warningsCaptured())
+                .as("an unchanged config must not log a drift WARNING")
+                .isEmpty();
     }
 
     @Test
@@ -258,14 +279,18 @@ class ConditionalRegistrationEvaluatorDriftTest {
         UltiToolsPlugin plugin = mockPlugin();
         SimpleContainer container = containerFor(plugin);
 
-        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureBComponent.class, container)).isTrue();
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureBComponent.class, container))
+                .as("negate=true with raw false must register")
+                .isTrue();
 
         // negate=true + raw true -> skipped; the message must say "disabled"/"already
         // registered" (the registration decision), never the raw YAML boolean.
         writeYaml("config/config.yml", "enableFeatureB: true\n");
 
         List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
-        assertThat(messages).hasSize(1);
+        assertThat(messages)
+                .as("negate=true must still report drift when the registration decision flips")
+                .hasSize(1);
         String message = messages.get(0);
         assertThat(message).contains(FeatureBComponent.class.getName());
         assertThat(message).contains("config/config.yml");
@@ -281,14 +306,21 @@ class ConditionalRegistrationEvaluatorDriftTest {
         UltiToolsPlugin plugin = mockPlugin();
         SimpleContainer container = containerFor(plugin);
 
-        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container)).isTrue();
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container))
+                .as("scan-time decision, recorded so clear() has something to release")
+                .isTrue();
 
         writeYaml("config/config.yml", "enableFeatureA: false\n");
 
         ConditionalRegistrationEvaluator.clear(plugin);
 
-        assertThat(ConditionalRegistrationEvaluator.reportDrift(plugin)).isEmpty();
-        assertThat(warningsCaptured()).isEmpty();
+        assertThat(ConditionalRegistrationEvaluator.reportDrift(plugin))
+                .as("clear(plugin) must release the record; a report here means PluginManager."
+                        + "unregister would leave the module ClassLoader pinned after unload")
+                .isEmpty();
+        assertThat(warningsCaptured())
+                .as("a released record must not log either")
+                .isEmpty();
     }
 
     @Test
@@ -297,15 +329,25 @@ class ConditionalRegistrationEvaluatorDriftTest {
         // (a) A container with no UltiToolsPlugin bean at all -- mirrors the framework's own
         // core context. Fail-open (true), and nothing is recorded against any plugin.
         SimpleContainer emptyContainer = containerWithNoPlugin();
-        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, emptyContainer)).isTrue();
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, emptyContainer))
+                .as("a container with no UltiToolsPlugin bean must fail open (D-20)")
+                .isTrue();
 
         UltiToolsPlugin plugin = mockPlugin();
-        assertThat(ConditionalRegistrationEvaluator.reportDrift(plugin)).isEmpty();
+        assertThat(ConditionalRegistrationEvaluator.reportDrift(plugin))
+                .as("the core-context fail-open path must record nothing against any plugin; a "
+                        + "non-empty list here means the record is keyed on something other than "
+                        + "a resolved UltiToolsPlugin")
+                .isEmpty();
 
         // (b) A class with no @ConditionalOnConfig at all is also a no-op, even against a real,
         // resolvable plugin.
         SimpleContainer container = containerFor(plugin);
-        assertThat(ConditionalRegistrationEvaluator.shouldRegister(PlainComponent.class, container)).isTrue();
-        assertThat(ConditionalRegistrationEvaluator.reportDrift(plugin)).isEmpty();
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(PlainComponent.class, container))
+                .as("an unannotated class always registers")
+                .isTrue();
+        assertThat(ConditionalRegistrationEvaluator.reportDrift(plugin))
+                .as("a class carrying no @ConditionalOnConfig must record nothing, so it can never drift")
+                .isEmpty();
     }
 }

--- a/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
@@ -38,8 +38,11 @@ import com.ultikits.ultitools.utils.TestHelper;
  * scan-time decision and reports drift as a {@code Level.WARNING} when {@link
  * UltiToolsPlugin#reloadSelf()} is called, so an operator sees the flip instead of silence.
  * <p>
- * This class proves the end-to-end path first (scan -&gt; config flip -&gt; reload -&gt; warning),
- * following the {@code doCallRealMethod()} idiom used by {@code UltiToolsPluginLanguageFallbackTest}.
+ * {@link #reloadAfterFlipToDisabledReportsDriftOnce()} proves the end-to-end path first (scan
+ * -&gt; config flip -&gt; reload -&gt; warning), following the {@code doCallRealMethod()} idiom
+ * used by {@code UltiToolsPluginLanguageFallbackTest}. The remaining tests exercise
+ * {@link ConditionalRegistrationEvaluator#reportDrift(UltiToolsPlugin)} directly, which the
+ * tracer test already proved is reachable from {@code reloadSelf()}.
  *
  * @since 6.3.0
  */
@@ -53,12 +56,21 @@ class ConditionalRegistrationEvaluatorDriftTest {
     private ConfigManager mockConfigManager;
     private final List<LogRecord> captured = new ArrayList<>();
     private Handler captureHandler;
+    private final List<UltiToolsPlugin> registeredPlugins = new ArrayList<>();
+    private final List<SimpleContainer> containers = new ArrayList<>();
 
     abstract static class FixturePlugin extends UltiToolsPlugin {
     }
 
     @ConditionalOnConfig(value = "config/config.yml", path = "enableFeatureA")
     static class FeatureAComponent {
+    }
+
+    @ConditionalOnConfig(value = "config/config.yml", path = "enableFeatureB", negate = true)
+    static class FeatureBComponent {
+    }
+
+    static class PlainComponent {
     }
 
     @BeforeEach
@@ -86,6 +98,14 @@ class ConditionalRegistrationEvaluatorDriftTest {
     @AfterEach
     void tearDown() {
         Logger.getLogger(ConditionalRegistrationEvaluator.class.getName()).removeHandler(captureHandler);
+        // The record is a static map -- release everything this test registered so it cannot
+        // leak into a later test in this class (Task 2, "lifecycle release" coverage note).
+        for (UltiToolsPlugin plugin : registeredPlugins) {
+            ConditionalRegistrationEvaluator.clear(plugin);
+        }
+        for (SimpleContainer container : containers) {
+            container.close();
+        }
     }
 
     private void writeYaml(String relativePath, String content) throws IOException {
@@ -102,6 +122,48 @@ class ConditionalRegistrationEvaluatorDriftTest {
         Files.write(new File(langDir, code + ".json").toPath(), jsonContent.getBytes(StandardCharsets.UTF_8));
     }
 
+    /**
+     * A plain {@code mock(UltiToolsPlugin.class)} with {@code getResourceFolderPath()} stubbed to
+     * {@link #tempDir}, tracked for release in {@link #tearDown()}.
+     */
+    private UltiToolsPlugin mockPlugin() {
+        UltiToolsPlugin plugin = mock(UltiToolsPlugin.class);
+        when(plugin.getResourceFolderPath()).thenReturn(tempDir.getAbsolutePath());
+        registeredPlugins.add(plugin);
+        return plugin;
+    }
+
+    /**
+     * A {@link SimpleContainer} with {@code plugin} registered as the resolvable
+     * {@link UltiToolsPlugin} bean, tracked for {@code close()} in {@link #tearDown()}.
+     */
+    private SimpleContainer containerFor(UltiToolsPlugin plugin) {
+        SimpleContainer container = new SimpleContainer();
+        container.registerType(UltiToolsPlugin.class, plugin);
+        containers.add(container);
+        return container;
+    }
+
+    /**
+     * A {@link SimpleContainer} with no {@link UltiToolsPlugin} bean at all -- mirrors the
+     * framework's own core context, which never resolves a plugin (Test 6).
+     */
+    private SimpleContainer containerWithNoPlugin() {
+        SimpleContainer container = new SimpleContainer();
+        containers.add(container);
+        return container;
+    }
+
+    private List<LogRecord> warningsCaptured() {
+        List<LogRecord> warnings = new ArrayList<>();
+        for (LogRecord record : captured) {
+            if (record.getLevel() == Level.WARNING) {
+                warnings.add(record);
+            }
+        }
+        return warnings;
+    }
+
     @Test
     @DisplayName("scan enabled -> reload disabled emits exactly one WARNING naming class/file/key/direction/restart")
     void reloadAfterFlipToDisabledReportsDriftOnce() throws Exception {
@@ -110,6 +172,7 @@ class ConditionalRegistrationEvaluatorDriftTest {
         writeLangFile("en", "{\"greeting\":\"Hi\"}");
 
         UltiToolsPlugin plugin = mock(FixturePlugin.class);
+        registeredPlugins.add(plugin);
         when(plugin.getResourceFolderPath()).thenReturn(tempDir.getAbsolutePath());
         when(plugin.getLanguageCode()).thenReturn("en");
         when(plugin.supported()).thenReturn(Collections.singletonList("en"));
@@ -123,8 +186,7 @@ class ConditionalRegistrationEvaluatorDriftTest {
         resourceFolderPathField.setAccessible(true);
         resourceFolderPathField.set(plugin, tempDir.getAbsolutePath());
 
-        SimpleContainer container = new SimpleContainer();
-        container.registerType(UltiToolsPlugin.class, plugin);
+        SimpleContainer container = containerFor(plugin);
 
         boolean registeredAtScanTime = ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container);
         assertThat(registeredAtScanTime).isTrue();
@@ -138,12 +200,7 @@ class ConditionalRegistrationEvaluatorDriftTest {
 
         // 4. Exactly one WARNING, naming the class, the config file, the key, the direction, and
         // the restart requirement.
-        List<LogRecord> warnings = new ArrayList<>();
-        for (LogRecord record : captured) {
-            if (record.getLevel() == Level.WARNING) {
-                warnings.add(record);
-            }
-        }
+        List<LogRecord> warnings = warningsCaptured();
         assertThat(warnings).hasSize(1);
         String message = warnings.get(0).getMessage();
         assertThat(message).contains(FeatureAComponent.class.getName());
@@ -151,7 +208,104 @@ class ConditionalRegistrationEvaluatorDriftTest {
         assertThat(message).contains("enableFeatureA");
         assertThat(message).contains("disabled");
         assertThat(message).contains("restart");
+    }
 
-        container.close();
+    @Test
+    @DisplayName("scan disabled -> reload enabled reports the reverse direction, mirror wording")
+    void reloadAfterFlipToEnabledReportsDrift() throws Exception {
+        writeYaml("config/config.yml", "enableFeatureA: false\n");
+        UltiToolsPlugin plugin = mockPlugin();
+        SimpleContainer container = containerFor(plugin);
+
+        boolean registeredAtScanTime = ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container);
+        assertThat(registeredAtScanTime).isFalse();
+
+        writeYaml("config/config.yml", "enableFeatureA: true\n");
+
+        List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
+        assertThat(messages).hasSize(1);
+        String message = messages.get(0);
+        assertThat(message).contains(FeatureAComponent.class.getName());
+        assertThat(message).contains("config/config.yml");
+        assertThat(message).contains("enableFeatureA");
+        assertThat(message).contains("enabled");
+        assertThat(message).contains("was not registered");
+        assertThat(message).contains("restart");
+
+        assertThat(warningsCaptured()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("no config change across a reload emits no drift and returns an empty list")
+    void noDriftEmitsNothing() throws Exception {
+        writeYaml("config/config.yml", "enableFeatureA: true\n");
+        UltiToolsPlugin plugin = mockPlugin();
+        SimpleContainer container = containerFor(plugin);
+
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container)).isTrue();
+
+        // No change to the file before reporting.
+        List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
+        assertThat(messages).isEmpty();
+        assertThat(warningsCaptured()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("negate=true reports the registration decision, not the raw YAML boolean")
+    void negateReportsRegistrationDecisionNotRawBoolean() throws Exception {
+        // negate=true + raw false -> registered.
+        writeYaml("config/config.yml", "enableFeatureB: false\n");
+        UltiToolsPlugin plugin = mockPlugin();
+        SimpleContainer container = containerFor(plugin);
+
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureBComponent.class, container)).isTrue();
+
+        // negate=true + raw true -> skipped; the message must say "disabled"/"already
+        // registered" (the registration decision), never the raw YAML boolean.
+        writeYaml("config/config.yml", "enableFeatureB: true\n");
+
+        List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
+        assertThat(messages).hasSize(1);
+        String message = messages.get(0);
+        assertThat(message).contains(FeatureBComponent.class.getName());
+        assertThat(message).contains("config/config.yml");
+        assertThat(message).contains("enableFeatureB");
+        assertThat(message).contains("disabled");
+        assertThat(message).contains("already registered");
+    }
+
+    @Test
+    @DisplayName("clear(plugin) releases the record so a subsequent reportDrift stays empty despite drift")
+    void clearReleasesRecordedDecisions() throws Exception {
+        writeYaml("config/config.yml", "enableFeatureA: true\n");
+        UltiToolsPlugin plugin = mockPlugin();
+        SimpleContainer container = containerFor(plugin);
+
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container)).isTrue();
+
+        writeYaml("config/config.yml", "enableFeatureA: false\n");
+
+        ConditionalRegistrationEvaluator.clear(plugin);
+
+        assertThat(ConditionalRegistrationEvaluator.reportDrift(plugin)).isEmpty();
+        assertThat(warningsCaptured()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("no UltiToolsPlugin in the container fail-opens and records nothing; unconditional classes record nothing")
+    void coreContextAndUnconditionalClassesRecordNothing() throws Exception {
+        // (a) A container with no UltiToolsPlugin bean at all -- mirrors the framework's own
+        // core context. Fail-open (true), and nothing is recorded against any plugin.
+        SimpleContainer emptyContainer = containerWithNoPlugin();
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, emptyContainer)).isTrue();
+
+        UltiToolsPlugin plugin = mockPlugin();
+        assertThat(ConditionalRegistrationEvaluator.reportDrift(plugin)).isEmpty();
+
+        // (b) A class with no @ConditionalOnConfig at all is also a no-op, even against a real,
+        // resolvable plugin.
+        SimpleContainer container = containerFor(plugin);
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(PlainComponent.class, container)).isTrue();
+        assertThat(ConditionalRegistrationEvaluator.reportDrift(plugin)).isEmpty();
     }
 }

--- a/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
@@ -86,10 +86,13 @@ class ConditionalRegistrationEvaluatorDriftTest {
 
             @Override
             public void flush() {
+                // Nothing to flush: publish() appends straight to the in-memory list.
             }
 
             @Override
             public void close() {
+                // Nothing to release: the captured records outlive this handler on purpose, so
+                // a test can still read them after tearDown() detaches it.
             }
         };
         Logger.getLogger(ConditionalRegistrationEvaluator.class.getName()).addHandler(captureHandler);
@@ -157,7 +160,9 @@ class ConditionalRegistrationEvaluatorDriftTest {
     private List<LogRecord> warningsCaptured() {
         List<LogRecord> warnings = new ArrayList<>();
         for (LogRecord record : captured) {
-            if (record.getLevel() == Level.WARNING) {
+            // Level.equals compares intValue(), so this also matches a custom Level
+            // registered at WARNING severity -- which is what "logged as a warning" means.
+            if (Level.WARNING.equals(record.getLevel())) {
                 warnings.add(record);
             }
         }


### PR DESCRIPTION
## Issue closure

Closes #392

## What was wrong

`@ConditionalOnConfig` is evaluated exactly once, during component scanning at startup. `ul reload`
re-reads the config file but never re-evaluates the condition, so flipping the key it names has no
effect until the server restarts — in **both** directions. Measured on a real Paper 1.21.4 server
across three modules (UltiEconomy `InterestService`, UltiRecipe `RecipeService`/`RecipeCommand`,
UltiChat `ChannelCommands`), with instance counts taken from `GC.class_histogram` rather than
inferred. Cold start was correct every time; reload was inert every time.

The annotation's own javadoc made this worse by calling itself "the framework-supported replacement
for an in-code `if (config.isEnabled())` block". A real `if (config.isEnabled())` re-reads the value
on every call and *does* follow a reload. Anyone migrating off the hand-written `if` lost reload
responsiveness and was told they were getting a like-for-like replacement.

## What this does, and what it deliberately does not

Maintainer decision, 2026-09-04: **re-evaluate and report**, plus narrow the declaration. This does
**not** rebuild the container or re-register anything.

The rejected alternative was to unregister and re-register the affected module on reload. It was
rejected because conditions are evaluated during component scan, so a single bean cannot be rebuilt
without rescanning the whole module — which would discard that module's entire in-memory state
(pending trades, login sessions, player caches) and silently turn `ul reload` from "reload
configuration" into "restart modules" while players are online.

Precedent: core Spring Boot has no runtime refresh mechanism for config-file changes.
`@ConditionalOnProperty` is evaluated once at context refresh and a restart is required;
re-evaluation is the job of the separate Spring Cloud `@RefreshScope` module. Narrowing a
declaration to match behaviour is also what this milestone's own core value prescribes when the
behaviour cannot be delivered.

Three parts:

1. **`ConditionalRegistrationEvaluator` records every decision it makes**, including the `false`
   (skipped) ones, which never appear in any container and so cannot be recovered from one. The
   record is a private static identity-keyed map of plugin → class → decision.
2. **`UltiToolsPlugin.reloadSelf()` calls `reportDrift(this)`** after the config reload. Each class
   whose answer has changed produces one `Level.WARNING` naming the class, the config file, the key,
   the new direction, and that a restart is required. Both `ul reload` and `ul reload <name>` reach
   `reloadSelf()`; that was verified through the call chain, not assumed.
3. **The javadoc no longer claims equivalence with `if (config.isEnabled())`** and states plainly
   that evaluation happens once at startup.

`PluginManager.unregister` calls `clear(plugin)`, alongside the existing `TabCompletionManager` /
`EventBus` / `PanelResponderRegistry` releases — the record holds `Class<?>` references and would
otherwise pin an unloaded module's ClassLoader for the same reason those do.

The framework's own core context is safe without a special case: it has no `UltiToolsPlugin` bean, so
evaluation exits down the pre-existing fail-open branch before anything is recorded.

## Verification

`mvn -B clean verify`: **5388 tests, 0 failures** (baseline 5382 + 6 new), javadoc jar generated,
japicmp gate green, CJK scope gate 0 violations.

Six new tests cover both drift directions, the no-drift silence, `negate = true` reporting the
registration decision rather than the raw YAML boolean, the lifecycle release, and the core-context
path recording nothing. Each was mutation-tested individually: the guarded behaviour was broken, the
test confirmed red with a message naming the right thing, then restored.

The last commit fixes two defects found reviewing the first three: `@apiNote` was this tree's first
use of that tag and fails `mvn clean verify` outright ("unknown tag: apiNote" — the pom's own `<tags>`
block already records that an unregistered javadoc tag is fatal, not a warning), and every assertion
in the new test was bare, so a wiring regression would have reported only `Expected size: 1 but was:
0 in: []`.

## Follow-ups, not in this PR

- `Docs/UltiTools-Dev-Doc` documents this annotation in `conditional-registration.md` and
  `ioc-container.md` (both locales). A companion PR into that repository's `alpha` branch is required
  by the doc-sync obligation.
- `PluginManager.java:1828-1839` carries the same class of stale "package-scan overload" claim that
  this PR corrected in `ConditionalRegistrationEvaluator` and `ComponentScanner`. Left alone to keep
  this change narrow.
