### PR TITLE
fix(401): replace over-broad whole-class japicmp exclusions, and gate against new ones

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,10 +336,12 @@
                             <include>com.ultikits.ultitools</include>
                         </includes>
                         <!-- Phase 7's authored removal record (D-04), one entry per removed
-                             symbol - 64 entries at HEAD under accessModifier=protected. No entry
-                             is package-wide (criterion 3 forbids it): a bare FQCN is a whole-class
-                             removal, a Class#member(paramTypes) key names one removed member.
-                             Full justification per entry is in
+                             symbol - 67 entries as of this comment's last edit (2026-09-05); the
+                             <excludes> block below is the source of truth for the live count, not
+                             this sentence, so re-count it rather than trust this figure if it
+                             looks stale. No entry is package-wide (criterion 3 forbids it): a bare
+                             FQCN is a whole-class removal, a Class#member(paramTypes) key names
+                             one removed member. Full justification per entry is in
                              .planning/phases/07-generational-removals/07-JAPICMP-BASELINE.md. This
                              list stays populated during the cycle and is emptied at the release
                              boundary by ReleaseBoundaryInvariant (D-05). -->
@@ -458,36 +460,54 @@
                             <exclude>com.ultikits.ultitools.abstracts.UltiToolsPlugin#getVersionWrapper()</exclude>
                             <exclude>com.ultikits.ultitools.context.UltiToolsBean#getVersionWrapper()</exclude>
                             <exclude>com.ultikits.ultitools.interfaces.TempListener#player(java.lang.Class)</exclude>
-                            <!-- BaseDataEntity survives AbstractDataEntity's deletion but no
-                                 longer extends it (it now owns its own id field directly) —
-                                 japicmp attributes SUPERCLASS_REMOVED to the subclass's own FQN,
-                                 not to the deleted superclass, so this needs its own entry even
-                                 though AbstractDataEntity is already excluded above. -->
-                            <exclude>com.ultikits.ultitools.abstracts.data.BaseDataEntity</exclude>
+                            <!-- A bare fully-qualified-name exclude removes the named class AND
+                                 every one of its members from the comparison, permanently - so it
+                                 is legitimate only for a class that no longer exists at all. This
+                                 entry used to name BaseDataEntity here, on the belief that japicmp
+                                 attributes SUPERCLASS_REMOVED to a surviving subclass's own FQN
+                                 and so the subclass needs its own entry even though its deleted
+                                 superclass (AbstractDataEntity) is already excluded above. That
+                                 belief is false in effect: breakBuildIfCausedByExclusion is
+                                 already false (see above), which is precisely what suppresses a
+                                 SUPERCLASS_REMOVED whose deleted supertype is itself excluded.
+                                 This entry - and the three CloudLoginCommand /
+                                 PluginInstallCommands / UltiToolsCommands entries that used to sit
+                                 below the InventoryConfirm block, added for the identical
+                                 AbstractCommandExecutor -> BaseCommandExecutor reason - were
+                                 therefore never necessary and have been removed; each class's
+                                 surviving public API is back under the gate. -->
                             <!-- InventoryConfirm survives OkCancelPage's deletion by migrating
                                  onto BaseConfirmationPage (07-13-PLAN.md's expanded scope): its
                                  superclass changed and three hook methods were renamed/re-scoped
                                  (getOkName/getCancelName -> getOkButtonName/getCancelButtonName,
-                                 onOk -> onConfirm, onCancel narrowed from public to protected) as
-                                 one coordinated migration, not independent member removals — one
-                                 class-level entry covers the whole reported set (confirmed against
-                                 target/japicmp/japicmp.xml: SUPERCLASS_REMOVED + 4 method changes,
-                                 all under InventoryConfirm's own FQN, nothing else). -->
-                            <exclude>com.ultikits.ultitools.widgets.impl.InventoryConfirm</exclude>
-                            <!-- Pre-existing gap from plan 07-05 (GEN-01, commit 4706bff), not
-                                 part of this plan's (07-13, GEN-04) declared symbol set. 07-05
-                                 migrated these three core commands from AbstractCommandExecutor to
-                                 BaseCommandExecutor but never ran `mvn -B -o clean verify
-                                 -DskipTests` (only `mvn -B test`), so the japicmp gate — live and
-                                 build-breaking since plan 07-01, which landed before 07-05 — never
-                                 saw this SUPERCLASS_REMOVED change until this plan's own verify
-                                 run. Fixed here under Rule 3 (blocking issue): every later Phase 7
-                                 plan's verify step would otherwise inherit this same red build.
+                                 onOk -> onConfirm, onCancel narrowed from public to protected).
+                                 The SUPERCLASS_REMOVED event needs no entry of its own -
+                                 breakBuildIfCausedByExclusion=false already suppresses it, since
+                                 the deleted superclass OkCancelPage is excluded above. The four
+                                 entries below name the complete set of member-level events
+                                 japicmp reports for this class (confirmed against
+                                 target/japicmp/japicmp.xml), so the rest of InventoryConfirm's
+                                 API stays under the gate instead of being silenced wholesale by a
+                                 single class-level entry. See compatibility/records/6.3.0.md's
+                                 recorded instance for the migration itself. -->
+                            <exclude>com.ultikits.ultitools.widgets.impl.InventoryConfirm#getOkName()</exclude>
+                            <exclude>com.ultikits.ultitools.widgets.impl.InventoryConfirm#getCancelName()</exclude>
+                            <exclude>com.ultikits.ultitools.widgets.impl.InventoryConfirm#onOk(org.bukkit.event.inventory.InventoryClickEvent)</exclude>
+                            <exclude>com.ultikits.ultitools.widgets.impl.InventoryConfirm#onCancel(org.bukkit.event.inventory.InventoryClickEvent)</exclude>
+                            <!-- Pre-existing gap from plan 07-05 (GEN-01, commit 4706bff): these
+                                 three core commands migrated from AbstractCommandExecutor to
+                                 BaseCommandExecutor, and the japicmp gate first saw the resulting
+                                 SUPERCLASS_REMOVED only during a later plan's own verify run,
+                                 because 07-05 ran `mvn -B test`, not `mvn -B -o clean verify
+                                 -DskipTests`. The three bare-FQN entries added here at the time
+                                 have since been found unnecessary and removed - see the retraction
+                                 comment above BaseDataEntity's former entry above:
+                                 AbstractCommandExecutor is itself excluded further below, and
+                                 breakBuildIfCausedByExclusion already suppresses SUPERCLASS_REMOVED
+                                 on a surviving subclass whose deleted supertype is excluded.
                                  AbstractCommandExecutor itself is untouched by this plan; only
-                                 these three framework-owned command classes' own supertype changed. -->
-                            <exclude>com.ultikits.ultitools.commands.CloudLoginCommand</exclude>
-                            <exclude>com.ultikits.ultitools.commands.PluginInstallCommands</exclude>
-                            <exclude>com.ultikits.ultitools.commands.UltiToolsCommands</exclude>
+                                 these three framework-owned command classes' own supertype
+                                 changed. -->
                             <!-- 07-14-PLAN.md (GEN-04, second half — the deprecated overloads
                                  living inside classes that otherwise survive; cluster A's whole-
                                  type removals are the entries above). Every entry here is member-

--- a/src/test/java/com/ultikits/ultitools/buildtools/deprecation/DeprecationRegistryGenerator.java
+++ b/src/test/java/com/ultikits/ultitools/buildtools/deprecation/DeprecationRegistryGenerator.java
@@ -335,8 +335,12 @@ public final class DeprecationRegistryGenerator {
      * Reads and parses {@code pom.xml} once. {@link #readPomExcludeKeys(Document)} and
      * {@link #readJapicmpBaselineVersion(Document)} both operate on the same parsed
      * {@link Document} rather than each opening their own XML reader.
+     *
+     * <p>Package-private (not {@code private}) so {@code OverBroadExclusionInvariantTest} can read
+     * the real {@code pom.xml} through the same parser this generator uses, instead of duplicating
+     * the XML-reading logic. Do not narrow this back to {@code private}.
      */
-    private static Document readPomDocument() throws IOException {
+    static Document readPomDocument() throws IOException {
         String xml = new String(Files.readAllBytes(POM_XML), StandardCharsets.UTF_8);
         return parsePomXml(xml);
     }
@@ -345,8 +349,12 @@ public final class DeprecationRegistryGenerator {
      * Reads {@code pom.xml}'s japicmp {@code <plugin>} block and returns every
      * {@code <exclude>} entry as a {@link RegistryKey} - the pom-side input
      * {@link RemovalConsistencyEvaluator} cross-checks against the report and the registry.
+     *
+     * <p>Package-private (not {@code private}) so {@code OverBroadExclusionInvariantTest} can read
+     * the real exclude-key set through the same parser this generator uses, instead of duplicating
+     * the XML-reading logic. Do not narrow this back to {@code private}.
      */
-    private static Set<RegistryKey> readPomExcludeKeys(Document doc) {
+    static Set<RegistryKey> readPomExcludeKeys(Document doc) {
         Element japicmpPlugin = findJapicmpPlugin(doc);
         Set<RegistryKey> keys = new LinkedHashSet<>();
         if (japicmpPlugin == null) {

--- a/src/test/java/com/ultikits/ultitools/buildtools/deprecation/OverBroadExclusionInvariant.java
+++ b/src/test/java/com/ultikits/ultitools/buildtools/deprecation/OverBroadExclusionInvariant.java
@@ -1,0 +1,66 @@
+package com.ultikits.ultitools.buildtools.deprecation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * The rule closing #401: a bare fully-qualified-name (whole-class) japicmp {@code <exclude>} entry
+ * removes the named class AND every one of its members from the binary-compatibility comparison,
+ * permanently. That is legitimate only for a class that no longer exists at all - if the class is
+ * still present in the current build output, the entry is over-broad by construction, silencing the
+ * entire surviving public API of a class nobody removed.
+ *
+ * <p>Pure logic over two already-derived inputs - the pom's {@code <exclude>} key set and the set of
+ * fully-qualified class names present in the build output - mirroring {@link ReleaseBoundaryInvariant}
+ * and {@link RemovalDeadlineEvaluator}'s separation from file I/O so this is unit-testable without
+ * running Maven and without a japicmp report. {@code OverBroadExclusionInvariantTest} is the sole
+ * caller, reading both inputs itself: the exclude keys via {@link DeprecationRegistryGenerator}'s
+ * package-private pom readers, and the build-output class names by walking {@code target/classes}.
+ *
+ * <p>A member-level or field-level key (see {@link RegistryKey#isClassLevel()}) is never a match for
+ * this rule - naming an individual removed member is the correct instrument, and this rule exists to
+ * steer authors toward it. This rule does not catch a bare-FQN entry that is simply a typo naming a
+ * class that never existed; that failure mode is indistinguishable from a legitimate removed-class
+ * entry by this check alone.
+ */
+public final class OverBroadExclusionInvariant {
+
+    private OverBroadExclusionInvariant() {
+    }
+
+    /**
+     * Evaluates the over-broad-exclusion rule. Returns one violation message per class-level
+     * {@code excludeKeys} entry whose class name is present in {@code classesInBuildOutput} - never
+     * throws on a rule violation, only on a {@code null} argument.
+     *
+     * @param excludeKeys          the japicmp {@code <exclude>} entries currently in {@code pom.xml}
+     * @param classesInBuildOutput fully-qualified class names present in the current build output
+     *                             (e.g. {@code target/classes}), exact string form including any
+     *                             nested-class {@code $} separator
+     * @return violation messages, empty when the invariant holds
+     */
+    public static List<String> evaluate(Set<RegistryKey> excludeKeys, Set<String> classesInBuildOutput) {
+        Objects.requireNonNull(excludeKeys, "excludeKeys");
+        Objects.requireNonNull(classesInBuildOutput, "classesInBuildOutput");
+
+        List<String> violations = new ArrayList<>();
+        for (RegistryKey key : new TreeSet<>(excludeKeys)) {
+            if (!key.isClassLevel()) {
+                continue;
+            }
+            String className = key.getClassName();
+            if (classesInBuildOutput.contains(className)) {
+                violations.add("japicmp <exclude>" + className + "</exclude> is a bare fully-qualified-"
+                        + "name (whole-class) entry, but the class is still present in the build output - "
+                        + "this silences the class's entire surviving public API, not just the change that "
+                        + "prompted the entry. Name the individual removed/changed members instead "
+                        + "(Class#member(paramTypes) or Class#field), or remove the entry if it is no "
+                        + "longer needed at all.");
+            }
+        }
+        return violations;
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/buildtools/deprecation/OverBroadExclusionInvariantTest.java
+++ b/src/test/java/com/ultikits/ultitools/buildtools/deprecation/OverBroadExclusionInvariantTest.java
@@ -1,0 +1,187 @@
+package com.ultikits.ultitools.buildtools.deprecation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.w3c.dom.Document;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+/**
+ * Pins {@link OverBroadExclusionInvariant}'s #401 rule: a bare fully-qualified-name (whole-class)
+ * japicmp {@code <exclude>} entry is legitimate only for a class that no longer exists in the build
+ * output. Synthetic cases cover the discrimination logic; the final two tests run the rule against
+ * the real {@code pom.xml} and the real {@code target/classes}, which is what gates the build.
+ */
+@DisplayName("OverBroadExclusionInvariant tests")
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+class OverBroadExclusionInvariantTest {
+
+    @Test
+    @DisplayName("a class-level key whose class is present in the build output produces exactly one violation naming that class")
+    void classLevelKeyPresentInBuildOutputViolates() {
+        Set<RegistryKey> excludeKeys = setOf(RegistryKey.forClass("com.example.Survivor"));
+        Set<String> classesInBuildOutput = setOf("com.example.Survivor");
+
+        List<String> violations = OverBroadExclusionInvariant.evaluate(excludeKeys, classesInBuildOutput);
+
+        assertThat(violations)
+                .hasSize(1)
+                .anySatisfy(v -> assertThat(v).contains("com.example.Survivor"));
+    }
+
+    @Test
+    @DisplayName("a class-level key whose class is absent from the build output produces no violation - the class was genuinely removed")
+    void classLevelKeyAbsentFromBuildOutputIsClean() {
+        Set<RegistryKey> excludeKeys = setOf(RegistryKey.forClass("com.example.Deleted"));
+        Set<String> classesInBuildOutput = setOf("com.example.Unrelated");
+
+        List<String> violations = OverBroadExclusionInvariant.evaluate(excludeKeys, classesInBuildOutput);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("a member-level key produces no violation even when its class is present - member-level is the correct instrument")
+    void memberLevelKeyNeverViolatesEvenWhenClassPresent() {
+        Set<RegistryKey> excludeKeys = setOf(RegistryKey.forMember(
+                "com.example.Survivor", "removedMethod", Collections.singletonList("java.lang.String")));
+        Set<String> classesInBuildOutput = setOf("com.example.Survivor");
+
+        List<String> violations = OverBroadExclusionInvariant.evaluate(excludeKeys, classesInBuildOutput);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("a field key produces no violation")
+    void fieldKeyNeverViolates() {
+        Set<RegistryKey> excludeKeys = setOf(RegistryKey.forField("com.example.Survivor", "removedField"));
+        Set<String> classesInBuildOutput = setOf("com.example.Survivor");
+
+        List<String> violations = OverBroadExclusionInvariant.evaluate(excludeKeys, classesInBuildOutput);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("a nested-class key is tested against the exact $-qualified string - the TempListener$PlayerTempListenerBuilder case")
+    void nestedClassKeyIsMatchedExactlyNotByOuterClassAlone() {
+        RegistryKey nestedKey = RegistryKey.forClass("com.x.Outer$Inner");
+
+        // The outer class survives, the nested class does not - build output holds Outer but not Outer$Inner.
+        List<String> whenOnlyOuterPresent = OverBroadExclusionInvariant.evaluate(
+                setOf(nestedKey), setOf("com.x.Outer"));
+        assertThat(whenOnlyOuterPresent)
+                .as("presence of the outer class alone must not be treated as a match for the nested key")
+                .isEmpty();
+
+        // The nested class itself is still present in the build output - this is the over-broad case.
+        List<String> whenNestedPresent = OverBroadExclusionInvariant.evaluate(
+                setOf(nestedKey), setOf("com.x.Outer$Inner"));
+        assertThat(whenNestedPresent)
+                .hasSize(1)
+                .anySatisfy(v -> assertThat(v).contains("com.x.Outer$Inner"));
+
+        // Neither present - genuinely removed, clean.
+        List<String> whenNeitherPresent = OverBroadExclusionInvariant.evaluate(
+                setOf(nestedKey), setOf("com.x.Unrelated"));
+        assertThat(whenNeitherPresent).isEmpty();
+    }
+
+    @Test
+    @DisplayName("several violations come back in a deterministic order across repeated runs")
+    void violationsAreDeterministicallyOrdered() {
+        Set<RegistryKey> excludeKeys = setOf(
+                RegistryKey.forClass("com.example.Zebra"),
+                RegistryKey.forClass("com.example.Apple"),
+                RegistryKey.forClass("com.example.Mango"));
+        Set<String> classesInBuildOutput = setOf("com.example.Zebra", "com.example.Apple", "com.example.Mango");
+
+        List<String> firstRun = OverBroadExclusionInvariant.evaluate(excludeKeys, classesInBuildOutput);
+        List<String> secondRun = OverBroadExclusionInvariant.evaluate(excludeKeys, classesInBuildOutput);
+
+        assertThat(firstRun).hasSize(3).isEqualTo(secondRun);
+        assertThat(firstRun.get(0)).contains("com.example.Apple");
+        assertThat(firstRun.get(1)).contains("com.example.Mango");
+        assertThat(firstRun.get(2)).contains("com.example.Zebra");
+    }
+
+    @Test
+    @DisplayName("an empty exclude set produces no violations")
+    void emptyExcludeSetIsClean() {
+        List<String> violations = OverBroadExclusionInvariant.evaluate(
+                Collections.emptySet(), setOf("com.example.Anything"));
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("the real check: the real pom.xml against the real target/classes produces zero violations")
+    void realPomAgainstRealBuildOutputIsClean() throws IOException {
+        Document pomDocument = DeprecationRegistryGenerator.readPomDocument();
+        Set<RegistryKey> excludeKeys = DeprecationRegistryGenerator.readPomExcludeKeys(pomDocument);
+        Set<String> classesInBuildOutput = scanBuildOutputClasses();
+
+        List<String> violations = OverBroadExclusionInvariant.evaluate(excludeKeys, classesInBuildOutput);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("the real check fails closed rather than passing vacuously when target/classes is missing or empty")
+    void realCheckFailsClosedOnMissingOrEmptyBuildOutput() throws IOException {
+        Set<String> classesInBuildOutput = scanBuildOutputClasses();
+
+        assertThat(classesInBuildOutput)
+                .as("target/classes must contain compiled classes by the time this test runs - "
+                        + "`compile` runs before `test` in the default Maven lifecycle. An empty scan "
+                        + "here means something is structurally wrong (e.g. target/classes was cleaned "
+                        + "or moved after compile), not that the check passed.")
+                .isNotEmpty();
+    }
+
+    private static Set<RegistryKey> setOf(RegistryKey... keys) {
+        return new LinkedHashSet<>(Arrays.asList(keys));
+    }
+
+    private static Set<String> setOf(String... classNames) {
+        return new LinkedHashSet<>(Arrays.asList(classNames));
+    }
+
+    /**
+     * Walks {@code target/classes} for {@code *.class} files and returns their fully-qualified names:
+     * relativised against {@code target/classes}, the {@code .class} suffix dropped, the path
+     * separator replaced with {@code .}, and any nested-class {@code $} left untouched.
+     */
+    private static Set<String> scanBuildOutputClasses() throws IOException {
+        Path classesRoot = Paths.get("target", "classes");
+        Set<String> classNames = new LinkedHashSet<>();
+        if (!Files.isDirectory(classesRoot)) {
+            return classNames;
+        }
+        try (Stream<Path> paths = Files.walk(classesRoot)) {
+            paths.filter(Files::isRegularFile)
+                    .filter(p -> p.toString().endsWith(".class"))
+                    .forEach(p -> {
+                        String relative = classesRoot.relativize(p).toString();
+                        String withoutSuffix = relative.substring(0, relative.length() - ".class".length());
+                        String fqcn = withoutSuffix.replace(java.io.File.separatorChar, '.');
+                        classNames.add(fqcn);
+                    });
+        }
+        return classNames;
+    }
+}


### PR DESCRIPTION
## Issue closure

Closes #401

## The issue's stated cause is wrong, and the real one is different

#401 attributes the blind spot to `ignoreMissingClasses=true` leaving a removed 6.2.5 supertype
unresolvable, so japicmp drops the subclass. Two experiments refuted that:

- Adding the 6.2.5 jar via `<oldClassPathDependencies>` left the blind set **unchanged**. It only
  produced false positives — `SUPERCLASS_REMOVED` on `BaseInventoryPage` and `DeclarativeGui`, whose
  superclass `mc.obliviate.inventory.Gui` is byte-identical on both sides. japicmp 0.26.1 has no
  `classPathMode` parameter, so the old-side list cannot be set without perturbing resolution.
- Removing `AbstractCommandExecutor` from `<excludes>` made that class itself appear, and left the
  three command classes still absent.

The real cause: all five blind classes are named in `pom.xml`'s japicmp `<excludes>` as **bare-FQN
(whole-class) entries**. A bare-FQN entry removes the class *and every one of its members* from the
comparison, permanently. Each was added during Phase 7 to silence a single `SUPERCLASS_REMOVED`
event on a class that **survives** — only its 6.2.5 supertype was deleted. The side effect the
authoring comments do not account for is that the class's entire public API stops being checked.
That is exactly what let a `PluginInstallCommands#listPlugins` signature change pass the gate
silently, which is how #401 was found.

The pom comment that drove it — "japicmp attributes SUPERCLASS_REMOVED to the subclass's own FQN,
not to the deleted superclass, so this needs its own entry even though AbstractDataEntity is already
excluded above" — is false in effect: `breakBuildIfCausedByExclusion=false` was already set, and
that is precisely what suppresses a `SUPERCLASS_REMOVED` whose deleted supertype is itself excluded.
The comment is retracted in place rather than deleted, so the belief cannot be re-derived.

## What changed

- **Four bare-FQN entries deleted** — `BaseDataEntity`, `CloudLoginCommand`, `PluginInstallCommands`,
  `UltiToolsCommands`. Never necessary; the build is green without them.
- **`InventoryConfirm`'s bare-FQN entry replaced by its four real member-level events** —
  `getOkName()`, `getCancelName()`, `onOk(InventoryClickEvent)`, `onCancel(InventoryClickEvent)`.
  Those four are genuine and stay recorded; the rest of the class's API returns to the gate.
- **A build-time invariant so this cannot recur.** `OverBroadExclusionInvariant` states the rule: a
  bare-FQN exclude is legitimate only for a class that no longer exists. If the class is still in
  `target/classes`, the entry is over-broad by construction.

The invariant runs as a plain JUnit test at the `test` phase, not inside the `verify`-bound
generator. That placement is deliberate: `pom.xml`'s own comment records that plan 07-05 ran
`mvn -B test` rather than `verify`, which is the literal reason three of these five entries exist.
A check the failing command does not reach would reproduce the root cause of the defect it exists to
prevent. It needs no japicmp report — only the pom's exclude keys and the class names under
`target/classes`, which `compile` populates before `test`.

Exact-string matching, no `$`-stripping: `TempListener$PlayerTempListenerBuilder` names a nested
class that is genuinely gone while its outer class survives, and normalising a nested key to its
outer class would turn that correct entry into a false positive.

## Measured

Blind spot computed by intersecting the 6.2.5 baseline jar's and the freshly built shaded jar's
class lists, then subtracting the classes japicmp reports in `target/japicmp/japicmp.xml`. The
parser is positive-controlled against `AbstractCommand` and `AuditableDataEntity`.

| | classes reported | blind top-level, excluding `package-info` |
|---|---|---|
| before | 326 | 7 |
| after | 331 | 2 |

The two remaining are `NonClosingConnectionProxy` and `TransactionAwareDataSource`, both
package-private and therefore correctly skipped by `<accessModifier>protected</accessModifier>`.
After this change the blind spot contains nothing illegitimate.

All 27 bare-FQN entries in the block were tested against `target/classes`: exactly these five named
a surviving class, so the invariant is red before this change and green after, with no third state.

`mvn -B clean verify`: **5397 tests, 0 failures** (baseline 5388 + 9 new), japicmp gate green, CJK
scope gate 0 violations.

Mutations, each restored from a file backup: re-adding a bare-FQN entry for a surviving class turns
the invariant red naming that class; deleting `InventoryConfirm#getOkName()` turns the japicmp gate
red naming that member, proving the four member entries are the real reported set rather than
decorative.

## Not changed, deliberately

`COMPATIBILITY.md` and `compatibility/records/6.3.0.md` are untouched. The four deleted entries
removed nothing from the API — they only stopped it being checked — and the record file already
names all four `InventoryConfirm` members and what an un-recompiled downstream JAR sees.

`UltiToolsModule.additionalEntities():METHOD_ABSTRACT_ADDED_TO_CLASS` is a japicmp false positive
(`javap -v` shows `AnnotationDefault: default_value: []`, and the report marks it
`binaryCompatible="true"`). It needs no entry and did not get one.
