### PR TITLE
chore: drop an unused static import left by #405

### DIFF
--- a/src/test/java/com/ultikits/ultitools/abstracts/command/HelpGateTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/command/HelpGateTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
 
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;


### PR DESCRIPTION
## Issue closure

None

## What

`HelpGateTest` carried `import static org.mockito.Mockito.when;` while all seven of its `when(`
uses are qualified — `ultiToolsMock.when(...)` and `lenient().when(...)` — so the static import is
never exercised. One line.

## How it was found, and the false negative on the way

An IDE diagnostic flagged it. Rather than fix only that line, every Java file changed since
`d730d55c` was re-scanned, on the same reasoning this repository already applies to Codacy: a report
naming one instance is not an exhaustive list.

The first scan returned **zero**, which was wrong. It tested whether an import's simple name appeared
anywhere in the body, and `when` appears in every `.when(` call site — so a qualified call masked the
unused static import. Requiring the name to appear *unqualified* (not preceded by a dot) finds it.
The scan now carries a control assertion that it detects this known instance, so a future zero is
evidence rather than an artefact of a broken query.

Result: exactly one unused import across fourteen changed files.

## Verification

`mvn -B -o test`: 5397 tests, 0 failures.
