### PR TITLE
fix(11-01): the reload drift report observes the container instead of asserting a registration state it does not hold

### DIFF
--- a/src/main/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluator.java
+++ b/src/main/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluator.java
@@ -247,20 +247,14 @@ public final class ConditionalRegistrationEvaluator {
         if (context == null) {
             return false;
         }
-        for (String beanName : context.getBeanNamesForType(clazz)) {
-            // isInstance, not a null check: getBeanNamesForType resolves names from definition
-            // and type metadata, while getSingleton returns whatever instance currently sits
-            // under that name. A later registerSingleton(name, other) -- the method is public,
-            // so any module author can pick a colliding name -- shadows a scanned definition
-            // without removing it, and a bare null check would then report an unrelated object
-            // as the conditional component. That is #409's own defect one layer along: claiming
-            // a presence the container was never asked to confirm. This method's javadoc already
-            // says "assignable to clazz"; this is the line that makes that true.
-            if (clazz.isInstance(context.getSingleton(beanName, false))) {
-                return true;
-            }
-        }
-        return false;
+        // One query, asked of the container, rather than a presence answer assembled out here
+        // from a name enumeration. Composing it externally is what produced two successive
+        // false answers of the same shape: first a bare null check that let a name-colliding
+        // object of an unrelated type count as the component, then a name-only search that
+        // could not see an instance bound through registerType at all. Both are #409's own
+        // defect in a new place -- reporting a state the container was never asked to confirm.
+        // SimpleContainer knows where its instances live; ask it.
+        return context.hasConstructedInstanceOfType(clazz);
     }
 
     private static String driftMessage(Class<?> clazz, ConditionalOnConfig condition,

--- a/src/main/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluator.java
+++ b/src/main/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluator.java
@@ -248,7 +248,15 @@ public final class ConditionalRegistrationEvaluator {
             return false;
         }
         for (String beanName : context.getBeanNamesForType(clazz)) {
-            if (context.getSingleton(beanName, false) != null) {
+            // isInstance, not a null check: getBeanNamesForType resolves names from definition
+            // and type metadata, while getSingleton returns whatever instance currently sits
+            // under that name. A later registerSingleton(name, other) -- the method is public,
+            // so any module author can pick a colliding name -- shadows a scanned definition
+            // without removing it, and a bare null check would then report an unrelated object
+            // as the conditional component. That is #409's own defect one layer along: claiming
+            // a presence the container was never asked to confirm. This method's javadoc already
+            // says "assignable to clazz"; this is the line that makes that true.
+            if (clazz.isInstance(context.getSingleton(beanName, false))) {
                 return true;
             }
         }

--- a/src/main/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluator.java
+++ b/src/main/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluator.java
@@ -268,7 +268,47 @@ public final class ConditionalRegistrationEvaluator {
         return "[UltiTools-API] @ConditionalOnConfig drift after reload: " + clazz.getName()
                 + " (" + condition.value() + " -> " + condition.path() + ") now evaluates to "
                 + directionWord + ", " + stateClause + ". @ConditionalOnConfig is evaluated once "
-                + "at component scan; a restart is required for this change to take effect.";
+                + "at component scan; " + adviceFor(actuallyPresent, currentDecision);
+    }
+
+    /**
+     * D-04: the action advice follows the observed {@code (actuallyPresent, currentDecision)}
+     * pair instead of a single fixed template -- the old unconditional "a restart is required"
+     * sentence sent an operator to restart the server in order to remove a component that was
+     * never actually there.
+     * <p>
+     * Four branches, three from D-04's own decision and a fourth extension it does not
+     * enumerate:
+     * <ul>
+     *   <li>present, now disabled -&gt; a restart is required to remove it</li>
+     *   <li>absent, now disabled -&gt; no restart needed; if the operator expected it to be
+     *       present, the cause is at startup, so the startup log is where to look</li>
+     *   <li>absent, now enabled -&gt; a restart is required to create it</li>
+     *   <li>present, now enabled (D-04 does not name this pair; reachable when a bean is
+     *       registered through a non-scanner path such as {@code registerSingleton}/{@code @Bean}
+     *       after the scan-time decision was recorded) -&gt; applying D-04's own principle, the
+     *       observed state already matches this decision, so no restart is needed</li>
+     * </ul>
+     *
+     * @param actuallyPresent whether a constructed singleton is observed in the container now
+     * @param currentDecision whether the condition currently evaluates to "register"
+     * @return the advice sentence, ending the overall drift message
+     */
+    private static String adviceFor(boolean actuallyPresent, boolean currentDecision) {
+        if (actuallyPresent && !currentDecision) {
+            return "a restart is required to remove the component.";
+        }
+        if (!actuallyPresent && !currentDecision) {
+            return "no action is needed -- the component's absence already matches this "
+                    + "decision; if you expected it to be present, check the startup log for a "
+                    + "registration failure.";
+        }
+        if (!actuallyPresent) {
+            // actuallyPresent is false, currentDecision is true here.
+            return "a restart is required to create the component.";
+        }
+        // actuallyPresent && currentDecision: the fourth combination D-04 does not enumerate.
+        return "no action is needed -- this already matches the current decision.";
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluator.java
+++ b/src/main/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluator.java
@@ -193,6 +193,10 @@ public final class ConditionalRegistrationEvaluator {
             snapshot = new LinkedHashMap<>(recorded);
         }
 
+        // Read once per invocation (D-03) -- a null container (no context wired yet) is
+        // tolerated by isActuallyRegistered treating every class as not present.
+        SimpleContainer context = plugin.getContext();
+
         List<String> messages = new ArrayList<>();
         for (Map.Entry<Class<?>, Boolean> entry : snapshot.entrySet()) {
             Class<?> clazz = entry.getKey();
@@ -208,7 +212,11 @@ public final class ConditionalRegistrationEvaluator {
                 if (currentDecision == recordedDecision) {
                     continue;
                 }
-                String message = driftMessage(clazz, condition, currentDecision);
+                // D-03: observe the container at the moment this claim is made, rather than
+                // deriving presence from the re-evaluated condition -- a condition re-evaluating
+                // to "register" says nothing about whether construction actually happened.
+                boolean actuallyPresent = isActuallyRegistered(context, clazz);
+                String message = driftMessage(clazz, condition, currentDecision, actuallyPresent);
                 LOGGER.log(Level.WARNING, message);
                 messages.add(message);
             } catch (RuntimeException e) {
@@ -220,13 +228,43 @@ public final class ConditionalRegistrationEvaluator {
         return Collections.unmodifiableList(messages);
     }
 
-    private static String driftMessage(Class<?> clazz, ConditionalOnConfig condition, boolean currentDecision) {
-        // Report the registration decision, not the raw YAML boolean -- negate=true would
-        // otherwise make the direction word ambiguous relative to what actually happened.
+    /**
+     * Whether {@code clazz} is actually present in {@code context} right now -- a real,
+     * constructed singleton, not merely a registered {@link BeanDefinition} (D-03).
+     * <p>
+     * Deliberately does <b>not</b> use the container's membership-predicate method: that method
+     * ORs a bean definition in with an actual singleton, and using it here would repeat the
+     * exact untrue claim this method exists to avoid. The composition used instead --
+     * {@link SimpleContainer#getBeanNamesForType(Class)} (does not instantiate) followed by
+     * {@link SimpleContainer#getSingleton(String, boolean)} (Level 1 cache read only, no early
+     * reference) -- distinguishes a registered definition from a constructed instance.
+     *
+     * @param context the plugin's container, or {@code null} if none is wired yet
+     * @param clazz   the class to check
+     * @return {@code true} if a constructed singleton assignable to {@code clazz} exists
+     */
+    private static boolean isActuallyRegistered(SimpleContainer context, Class<?> clazz) {
+        if (context == null) {
+            return false;
+        }
+        for (String beanName : context.getBeanNamesForType(clazz)) {
+            if (context.getSingleton(beanName, false) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String driftMessage(Class<?> clazz, ConditionalOnConfig condition,
+            boolean currentDecision, boolean actuallyPresent) {
+        // Report the direction the condition now evaluates to (unchanged) alongside what the
+        // container actually holds right now (D-03) -- the state clause is keyed on the observed
+        // instance, not on currentDecision, so it can never claim a presence the container
+        // doesn't have.
         String directionWord = currentDecision ? "enabled" : "disabled";
-        String stateClause = currentDecision
-                ? "but the component was not registered at startup"
-                : "but the component is already registered";
+        String stateClause = actuallyPresent
+                ? "but the component is already registered"
+                : "but the component was not registered at startup";
         return "[UltiTools-API] @ConditionalOnConfig drift after reload: " + clazz.getName()
                 + " (" + condition.value() + " -> " + condition.path() + ") now evaluates to "
                 + directionWord + ", " + stateClause + ". @ConditionalOnConfig is evaluated once "

--- a/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
+++ b/src/main/java/com/ultikits/ultitools/context/SimpleContainer.java
@@ -536,7 +536,51 @@ public class SimpleContainer {
     }
 
     /**
+     * Report whether a constructed instance assignable to {@code type} already exists in this
+     * container or any parent, without constructing anything.
+     * <p>
+     * This exists because {@link #getBeanNamesForType(Class)} answers a different question. That
+     * method enumerates <i>names</i>, and it draws them from three of the four places an instance
+     * can live: {@link #singletons}, {@link #beanDefinitions} and {@link #supplierTypes}. It does
+     * not consult {@link #typeMappings}, so an instance installed only through
+     * {@link #registerType(Class, Object)} -- which writes to that map and nowhere else -- is
+     * invisible to a name-based presence check, even though {@link #getBean(Class)} returns it.
+     * A caller asking "is it here?" rather than "what is it called?" needs both.
+     * <p>
+     * Name-derived candidates are additionally type-checked against the retrieved singleton:
+     * the definition and supplier sources match on <i>declared</i> metadata, so a definition
+     * naming {@code type} plus a singleton of something else under the same name would otherwise
+     * report a presence that is not there.
+     * <p>
+     * Neither branch instantiates: {@link #getSingleton(String, boolean)} is a Level 1 cache read
+     * with no early reference, and {@link #typeMappings} holds already-constructed objects.
+     *
+     * @param type the type to look for
+     * @return {@code true} if a constructed instance assignable to {@code type} is already held
+     * @since 6.3.0
+     */
+    public boolean hasConstructedInstanceOfType(Class<?> type) {
+        for (Map.Entry<Class<?>, Object> entry : typeMappings.entrySet()) {
+            if (type.isInstance(entry.getValue())) {
+                return true;
+            }
+        }
+        for (String beanName : getBeanNamesForType(type)) {
+            if (type.isInstance(getSingleton(beanName, false))) {
+                return true;
+            }
+        }
+        return parent != null && parent.hasConstructedInstanceOfType(type);
+    }
+
+    /**
      * Get bean names for type.
+     * <p>
+     * Enumerates names from {@link #singletons}, {@link #beanDefinitions} and
+     * {@link #supplierTypes}, plus any parent container. It deliberately answers "what is it
+     * called", not "is it here": {@link #typeMappings} holds instances bound by
+     * {@link #registerType(Class, Object)} under no name at all, so they cannot appear here.
+     * For a presence question, use {@link #hasConstructedInstanceOfType(Class)}.
      *
      * @param type bean type
      * @return bean names

--- a/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
@@ -499,6 +499,35 @@ class ConditionalRegistrationEvaluatorDriftTest {
     }
 
     @Test
+    @DisplayName("An instance bound only through registerType counts as present")
+    void instanceBoundOnlyThroughRegisterTypeIsReportedAsPresent() throws Exception {
+        writeYaml("config/config.yml", "enableFeatureA: false\n");
+        UltiToolsPlugin plugin = mockPlugin();
+        SimpleContainer container = containerFor(plugin);
+
+        // The scan decided "skip", so nothing was registered by name. The component is then
+        // installed by hand through registerType, which writes to typeMappings and nowhere
+        // else -- no singleton, no definition, no supplier, hence no name. PluginManager uses
+        // this API in production (TransactionManager, UltiToolsPlugin, JavaPlugin), so it is a
+        // real installation path, not a test-only one.
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container))
+                .isFalse();
+        container.registerType(FeatureAComponent.class, new FeatureAComponent());
+
+        writeYaml("config/config.yml", "enableFeatureA: true\n");
+
+        List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
+        assertThat(messages).hasSize(1);
+        String message = messages.get(0);
+        // getBean(FeatureAComponent.class) returns the instance, so telling the operator it was
+        // never registered and that a restart will create it is false in both halves. A
+        // name-only presence search cannot see this instance; the container-level query can.
+        assertThat(message)
+                .as("an instance reachable through getBean must not be reported as absent")
+                .contains("already registered");
+    }
+
+    @Test
     @DisplayName("D-04 branch 1/4: present, now disabled -> advises a restart to remove the component")
     void presentInstanceNowDisabledAdvisesRestartToRemove() throws Exception {
         writeYaml("config/config.yml", "enableFeatureA: true\n");

--- a/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
@@ -458,6 +458,47 @@ class ConditionalRegistrationEvaluatorDriftTest {
     }
 
     @Test
+    @DisplayName("A definition-named singleton of an unrelated type is not reported as present")
+    void unrelatedSingletonUnderADefinitionNamedKeyIsNotReportedAsPresent() throws Exception {
+        writeYaml("config/config.yml", "enableFeatureA: true\n");
+        UltiToolsPlugin plugin = mockPlugin();
+        SimpleContainer container = containerFor(plugin);
+
+        // Reaching the collision needs BOTH halves, because getBeanNamesForType draws names
+        // from three sources and only the singleton source already type-checks
+        // (SimpleContainer: `type.isInstance(entry.getValue())`):
+        //   1. a bean DEFINITION under this name whose declared class IS FeatureAComponent --
+        //      this is what makes getBeanNamesForType(FeatureAComponent.class) return the name,
+        //      via `type.isAssignableFrom(entry.getValue().getBeanClass())`;
+        //   2. a SINGLETON under that same name that is NOT a FeatureAComponent -- this is what
+        //      getSingleton then hands back.
+        // registerSingleton is public and takes a caller-chosen name, so this shadowing needs no
+        // internal coincidence; any module author can produce it.
+        //
+        // A test that registers only the singleton proves nothing: source 1 type-checks, the
+        // name is never returned, the loop never runs, and the assertion passes with or without
+        // the fix. That mistake was made once here and is why this comment exists.
+        container.registerBeanDefinition("featureAComponent",
+                new BeanDefinition(FeatureAComponent.class, "featureAComponent"));
+        container.registerSingleton("featureAComponent", new FeatureBComponent());
+
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container))
+                .isTrue();
+
+        writeYaml("config/config.yml", "enableFeatureA: false\n");
+
+        List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
+        assertThat(messages).hasSize(1);
+        String message = messages.get(0);
+        // No FeatureAComponent instance exists, so the report must take the absent branch.
+        // Claiming presence here would be #409's own defect one layer along: asserting a state
+        // the container was never asked to confirm.
+        assertThat(message)
+                .as("an unrelated object under a definition-named key is not a FeatureAComponent")
+                .doesNotContain("already registered");
+    }
+
+    @Test
     @DisplayName("D-04 branch 1/4: present, now disabled -> advises a restart to remove the component")
     void presentInstanceNowDisabledAdvisesRestartToRemove() throws Exception {
         writeYaml("config/config.yml", "enableFeatureA: true\n");

--- a/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
@@ -178,7 +178,8 @@ class ConditionalRegistrationEvaluatorDriftTest {
     }
 
     @Test
-    @DisplayName("scan enabled -> reload disabled emits exactly one WARNING naming class/file/key/direction/restart")
+    @DisplayName("scan enabled -> reload disabled emits exactly one WARNING naming class/file/key/direction; "
+            + "no restart advised since the instance was never actually constructed (D-04)")
     void reloadAfterFlipToDisabledReportsDriftOnce() throws Exception {
         // 1. Scan-time evaluation: enableFeatureA is true, component is registered.
         writeYaml("config/config.yml", "enableFeatureA: true\n");
@@ -227,7 +228,14 @@ class ConditionalRegistrationEvaluatorDriftTest {
         assertThat(message).contains("config/config.yml");
         assertThat(message).contains("enableFeatureA");
         assertThat(message).contains("disabled");
-        assertThat(message).contains("restart");
+        // D-04: this fixture's container never actually holds a FeatureAComponent singleton --
+        // only shouldRegister's decision was recorded "register", nothing was ever constructed
+        // (mirrors a D-03 failure mode) -- so the observed-absent message must NOT ask for a
+        // restart to remove something that was never there, and must name the startup log as
+        // where the real cause lives.
+        assertThat(message).contains("was not registered at startup");
+        assertThat(message).doesNotContain("restart");
+        assertThat(message).contains("startup log");
     }
 
     @Test
@@ -254,8 +262,14 @@ class ConditionalRegistrationEvaluatorDriftTest {
         assertThat(message).contains("config/config.yml");
         assertThat(message).contains("enableFeatureA");
         assertThat(message).contains("enabled");
-        assertThat(message).contains("was not registered");
+        // D-04: this fixture's container never holds a FeatureAComponent singleton, so the
+        // observed-presence half of the sentence must name the absence explicitly (not merely
+        // "was not registered" as a fragment, but the full observed-state clause) -- and since
+        // it is absent while the condition now says "enabled", a restart IS required to create
+        // it, unlike the disabled-direction case above.
+        assertThat(message).contains("was not registered at startup");
         assertThat(message).contains("restart");
+        assertThat(message).contains("create");
 
         assertThat(warningsCaptured())
                 .as("the drift message must reach the log, not only the return value")
@@ -405,6 +419,109 @@ class ConditionalRegistrationEvaluatorDriftTest {
         assertThat(bMessage)
                 .as("FeatureBComponent is a real singleton in this same container -- present")
                 .contains("already registered");
+    }
+
+    @Test
+    @DisplayName("D-04 branch 1/4: present, now disabled -> advises a restart to remove the component")
+    void presentInstanceNowDisabledAdvisesRestartToRemove() throws Exception {
+        writeYaml("config/config.yml", "enableFeatureA: true\n");
+        UltiToolsPlugin plugin = mockPlugin();
+        SimpleContainer container = containerFor(plugin);
+        container.registerSingleton("featureAComponent", new FeatureAComponent());
+
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container))
+                .isTrue();
+
+        writeYaml("config/config.yml", "enableFeatureA: false\n");
+
+        List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
+        assertThat(messages).hasSize(1);
+        String message = messages.get(0);
+        assertThat(message)
+                .as("present + now disabled must advise a restart to remove the component")
+                .contains("disabled")
+                .contains("restart")
+                .contains("remove");
+    }
+
+    @Test
+    @DisplayName("D-04 branch 2/4: absent, now disabled -> no restart needed, points at the startup log")
+    void absentInstanceNowDisabledNeedsNoRestartAndPointsToStartupLog() throws Exception {
+        writeYaml("config/config.yml", "enableFeatureA: true\n");
+        UltiToolsPlugin plugin = mockPlugin();
+        SimpleContainer container = containerFor(plugin);
+        // Deliberately no singleton registered -- mirrors a D-03 failure mode (registration
+        // never happened even though the scan-time decision was "register").
+
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container))
+                .isTrue();
+
+        writeYaml("config/config.yml", "enableFeatureA: false\n");
+
+        List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
+        assertThat(messages).hasSize(1);
+        String message = messages.get(0);
+        assertThat(message)
+                .as("absent + now disabled must NOT ask for a restart -- there is nothing to "
+                        + "remove -- and must point the operator at the startup log")
+                .contains("disabled")
+                .doesNotContain("restart")
+                .contains("startup log");
+        assertThat(message)
+                .as("the message must still be a real, non-empty message naming the class")
+                .contains(FeatureAComponent.class.getName());
+    }
+
+    @Test
+    @DisplayName("D-04 branch 3/4: absent, now enabled -> advises a restart to create the component")
+    void absentInstanceNowEnabledAdvisesRestartToCreate() throws Exception {
+        writeYaml("config/config.yml", "enableFeatureA: false\n");
+        UltiToolsPlugin plugin = mockPlugin();
+        SimpleContainer container = containerFor(plugin);
+
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container))
+                .isFalse();
+
+        writeYaml("config/config.yml", "enableFeatureA: true\n");
+
+        List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
+        assertThat(messages).hasSize(1);
+        String message = messages.get(0);
+        assertThat(message)
+                .as("absent + now enabled must advise a restart to create the component")
+                .contains("enabled")
+                .contains("restart")
+                .contains("create");
+    }
+
+    @Test
+    @DisplayName("D-04 branch 4/4 (extension): present, now (still) enabled -> no restart needed, already matches")
+    void presentInstanceNowEnabledNeedsNoRestartExtensionOfD04() throws Exception {
+        // This is the fourth (present, enabled) combination D-04's own three bullets do not
+        // enumerate: reachable when a bean was registered through a non-scanner path (e.g.
+        // registerSingleton/@Bean/manual) after the scan-time decision was recorded false.
+        // Applying D-04's own principle -- the observed state already matches what the
+        // condition now asks for, so no restart is needed.
+        writeYaml("config/config.yml", "enableFeatureA: false\n");
+        UltiToolsPlugin plugin = mockPlugin();
+        SimpleContainer container = containerFor(plugin);
+
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container))
+                .isFalse();
+
+        // Registered through a non-scanner path after the scan-time decision was recorded.
+        container.registerSingleton("featureAComponent", new FeatureAComponent());
+
+        writeYaml("config/config.yml", "enableFeatureA: true\n");
+
+        List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
+        assertThat(messages).hasSize(1);
+        String message = messages.get(0);
+        assertThat(message)
+                .as("present + now enabled already matches the decision -- no restart needed")
+                .contains("enabled")
+                .contains("already registered")
+                .doesNotContain("restart");
     }
 
     @Test

--- a/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
@@ -139,10 +139,18 @@ class ConditionalRegistrationEvaluatorDriftTest {
     /**
      * A {@link SimpleContainer} with {@code plugin} registered as the resolvable
      * {@link UltiToolsPlugin} bean, tracked for {@code close()} in {@link #tearDown()}.
+     * <p>
+     * Also stubs {@code plugin.getContext()} to return this same container (D-03) -- this is
+     * the container {@code reportDrift} reads at claim time via {@code plugin.getContext()},
+     * mirroring production's {@code UltiToolsPlugin#setContext(SimpleContainer)} wiring. A test
+     * that wants a fixture reported "present" must register it into the returned container
+     * (e.g. via {@code registerSingleton}); a test that leaves it unregistered gets "absent" by
+     * construction, no separate stub needed.
      */
     private SimpleContainer containerFor(UltiToolsPlugin plugin) {
         SimpleContainer container = new SimpleContainer();
         container.registerType(UltiToolsPlugin.class, plugin);
+        when(plugin.getContext()).thenReturn(container);
         containers.add(container);
         return container;
     }
@@ -287,6 +295,11 @@ class ConditionalRegistrationEvaluatorDriftTest {
         assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureBComponent.class, container))
                 .as("negate=true with raw false must register")
                 .isTrue();
+        // The scan-time decision was "register" -- simulate ComponentScanner having gone on to
+        // actually construct the singleton, so the D-03 container query (Task 1) has a real
+        // instance to observe when reportDrift is called below (rather than a coincidental
+        // string match that a fixture with no singleton would produce).
+        container.registerSingleton("featureBComponent", new FeatureBComponent());
 
         // negate=true + raw true -> skipped; the message must say "disabled"/"already
         // registered" (the registration decision), never the raw YAML boolean.
@@ -302,6 +315,96 @@ class ConditionalRegistrationEvaluatorDriftTest {
         assertThat(message).contains("enableFeatureB");
         assertThat(message).contains("disabled");
         assertThat(message).contains("already registered");
+    }
+
+    @Test
+    @DisplayName("D-03: an absent instance is never reported as registered, even when the condition now enables it")
+    void absentInstanceIsNeverReportedAsRegistered() throws Exception {
+        // Recorded false at scan time; no singleton and no bean definition are ever registered
+        // for FeatureAComponent in `container` -- the query must read that absence, not assume
+        // presence from the fact that the condition now says "register".
+        writeYaml("config/config.yml", "enableFeatureA: false\n");
+        UltiToolsPlugin plugin = mockPlugin();
+        SimpleContainer container = containerFor(plugin);
+
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container))
+                .as("scan-time decision with enableFeatureA: false must be skip")
+                .isFalse();
+
+        writeYaml("config/config.yml", "enableFeatureA: true\n");
+
+        List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
+        assertThat(messages).hasSize(1);
+        String message = messages.get(0);
+        assertThat(message)
+                .as("no singleton or definition is registered, so the message must not claim presence")
+                .contains("was not registered at startup")
+                .doesNotContain("already registered");
+    }
+
+    @Test
+    @DisplayName("D-03: a present instance is reported as registered when the condition now disables it")
+    void presentInstanceIsReportedAsRegistered() throws Exception {
+        // Mirror of the above: recorded true at scan time, and a real singleton IS registered
+        // in `container` this time -- the query must read that presence too.
+        writeYaml("config/config.yml", "enableFeatureA: true\n");
+        UltiToolsPlugin plugin = mockPlugin();
+        SimpleContainer container = containerFor(plugin);
+        container.registerSingleton("featureAComponent", new FeatureAComponent());
+
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container))
+                .as("scan-time decision with enableFeatureA: true must be register")
+                .isTrue();
+
+        writeYaml("config/config.yml", "enableFeatureA: false\n");
+
+        List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
+        assertThat(messages).hasSize(1);
+        String message = messages.get(0);
+        assertThat(message)
+                .as("a real singleton is registered, so the message must claim presence")
+                .contains("already registered")
+                .doesNotContain("was not registered at startup");
+    }
+
+    @Test
+    @DisplayName("D-03 control: the same container answers absent for one fixture and present for another in the same run")
+    void containerQueryDistinguishesPresentFromAbsentInSameRun() throws Exception {
+        // A negative result ("absent") is only trustworthy if paired with a positive control
+        // proving the query itself works -- both fixtures are read from the SAME container in
+        // this single test run.
+        writeYaml("config/config.yml", "enableFeatureA: false\nenableFeatureB: true\n");
+        UltiToolsPlugin plugin = mockPlugin();
+        SimpleContainer container = containerFor(plugin);
+        // FeatureBComponent (negate=true) is registered as a real singleton; FeatureAComponent
+        // is deliberately left unregistered.
+        container.registerSingleton("featureBComponent", new FeatureBComponent());
+
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureAComponent.class, container))
+                .as("scan-time decision with enableFeatureA: false must be skip")
+                .isFalse();
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(FeatureBComponent.class, container))
+                .as("negate=true with raw enableFeatureB: true must be skip")
+                .isFalse();
+
+        writeYaml("config/config.yml", "enableFeatureA: true\nenableFeatureB: false\n");
+
+        List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
+        assertThat(messages).hasSize(2);
+        String aMessage = messages.stream()
+                .filter(m -> m.contains(FeatureAComponent.class.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no drift message for FeatureAComponent"));
+        String bMessage = messages.stream()
+                .filter(m -> m.contains(FeatureBComponent.class.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no drift message for FeatureBComponent"));
+        assertThat(aMessage)
+                .as("FeatureAComponent is unregistered in this container -- absent")
+                .contains("was not registered at startup");
+        assertThat(bMessage)
+                .as("FeatureBComponent is a real singleton in this same container -- present")
+                .contains("already registered");
     }
 
     @Test

--- a/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
+++ b/src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java
@@ -73,6 +73,42 @@ class ConditionalRegistrationEvaluatorDriftTest {
     static class PlainComponent {
     }
 
+    /**
+     * D-03 failure modes 1 and 2: a class carrying {@code @ConditionalOnConfig} whose
+     * registration never reached the container -- either because it carries no component
+     * annotation at all (mode 1: {@code ComponentScanner.processClass}'s {@code isComponent}
+     * gate fails before {@code registerComponent} is ever called), or because
+     * {@code registerComponent} itself logged a SEVERE and returned before
+     * {@code registerBeanDefinition} (mode 2: refused {@code @CmdTarget} composition, or a
+     * throwing {@code getBeanName}). Both leave the container holding neither a bean definition
+     * nor a singleton for this class, which is why one fixture stands in for both rows -- the
+     * two modes are indistinguishable at the container-query level this evaluator reads.
+     */
+    @ConditionalOnConfig(value = "config/config.yml", path = "enableConditionOnly")
+    static class ConditionOnlyNoComponent {
+    }
+
+    /**
+     * D-03 failure mode 3: a class whose {@link BeanDefinition} WAS registered (by
+     * {@code ComponentScanner.registerComponent} in production), but whose construction later
+     * threw and was logged-and-skipped (Phase 3 D-25) rather than completing. The container
+     * holds a definition and no singleton -- this is the failure mode issue #409's own text does
+     * not name.
+     */
+    @ConditionalOnConfig(value = "config/config.yml", path = "enableDefinitionOnly")
+    static class DefinitionOnlyComponent {
+    }
+
+    /**
+     * Control fixture, not itself one of D-03's three failure rows: registered as a genuine
+     * singleton, proving the container query answers "present" when the component truly is --
+     * the fact that makes the three negative results above trustworthy rather than an artefact
+     * of a broken probe.
+     */
+    @ConditionalOnConfig(value = "config/config.yml", path = "enablePresent")
+    static class PresentComponent {
+    }
+
     @BeforeEach
     void setUp() {
         mockConfigManager = mock(ConfigManager.class);
@@ -522,6 +558,84 @@ class ConditionalRegistrationEvaluatorDriftTest {
                 .contains("enabled")
                 .contains("already registered")
                 .doesNotContain("restart");
+    }
+
+    @Test
+    @DisplayName("D-03 modes 1/2: no definition, no singleton -> reported not present "
+            + "(no component annotation / registration refused)")
+    void conditionOnlyNoComponentReportsNotPresent() throws Exception {
+        writeYaml("config/config.yml", "enableConditionOnly: false\n");
+        UltiToolsPlugin plugin = mockPlugin();
+        SimpleContainer container = containerFor(plugin);
+        // Deliberately neither a bean definition nor a singleton is registered for this class --
+        // mirrors ComponentScanner never reaching registerBeanDefinition (D-03 rows 1 and 2).
+
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(ConditionOnlyNoComponent.class, container))
+                .as("scan-time decision with enableConditionOnly: false must be skip")
+                .isFalse();
+
+        writeYaml("config/config.yml", "enableConditionOnly: true\n");
+
+        List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
+        assertThat(messages).hasSize(1);
+        assertThat(messages.get(0))
+                .as("neither a definition nor a singleton exists -- the message must not claim presence")
+                .contains("was not registered at startup")
+                .doesNotContain("already registered");
+    }
+
+    @Test
+    @DisplayName("D-03 mode 3: definition registered but never constructed -> reported not present "
+            + "(the failure mode #409's own text does not name)")
+    void definitionOnlyComponentReportsNotPresent() throws Exception {
+        writeYaml("config/config.yml", "enableDefinitionOnly: false\n");
+        UltiToolsPlugin plugin = mockPlugin();
+        SimpleContainer container = containerFor(plugin);
+        // A bean definition IS registered (as ComponentScanner.registerComponent would have
+        // done), but construction never ran -- getBeanNamesForType will find a candidate name
+        // via beanDefinitions, but getSingleton(name, false) must still answer null.
+        container.registerBeanDefinition("definitionOnlyComponent",
+                new BeanDefinition(DefinitionOnlyComponent.class, "definitionOnlyComponent"));
+
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(DefinitionOnlyComponent.class, container))
+                .as("scan-time decision with enableDefinitionOnly: false must be skip")
+                .isFalse();
+
+        writeYaml("config/config.yml", "enableDefinitionOnly: true\n");
+
+        List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
+        assertThat(messages).hasSize(1);
+        assertThat(messages.get(0))
+                .as("a registered definition with no constructed singleton must still report "
+                        + "not present -- getBeanNamesForType finding a candidate name is not "
+                        + "the same as getSingleton finding an instance")
+                .contains("was not registered at startup")
+                .doesNotContain("already registered");
+    }
+
+    @Test
+    @DisplayName("D-03 control: a genuinely present singleton is reported present, making the "
+            + "three negative results above trustworthy")
+    void presentComponentReportsPresent() throws Exception {
+        writeYaml("config/config.yml", "enablePresent: true\n");
+        UltiToolsPlugin plugin = mockPlugin();
+        SimpleContainer container = containerFor(plugin);
+        container.registerSingleton("presentComponent", new PresentComponent());
+
+        assertThat(ConditionalRegistrationEvaluator.shouldRegister(PresentComponent.class, container))
+                .as("scan-time decision with enablePresent: true must be register")
+                .isTrue();
+
+        writeYaml("config/config.yml", "enablePresent: false\n");
+
+        List<String> messages = ConditionalRegistrationEvaluator.reportDrift(plugin);
+        assertThat(messages).hasSize(1);
+        assertThat(messages.get(0))
+                .as("a genuine singleton is registered -- the message must claim presence, "
+                        + "proving the query itself works and the three absent results above "
+                        + "are not an artefact of a broken probe")
+                .contains("already registered")
+                .doesNotContain("was not registered at startup");
     }
 
     @Test


### PR DESCRIPTION
## Issue closure

Closes #409

## What this changes

`@ConditionalOnConfig`'s reload drift report stops asserting a registration state the evaluator does not
hold.

Before this change, `ConditionalRegistrationEvaluator.driftMessage` derived its "the component is
already registered" / "was not registered at startup" claim purely from re-evaluating the
`@ConditionalOnConfig` **condition**, and never consulted the container. A `true` condition does not
imply a registered component: `ComponentScanner.processClass` / `registerComponent` show three distinct
ways a passing condition still does not become a registered singleton, including D-25's rule that
logs-and-skips a class whose construction throws.

The report now reads real container state at the moment it makes the claim, composing
`SimpleContainer.getBeanNamesForType` (public, does not instantiate) with `getSingleton(name, false)`.

`containsBean` was considered and rejected: it ORs a bean *definition* into an *instance* check, which
would reproduce the very defect being fixed rather than close it.

Advice now branches on all four `(instance present, condition decision)` combinations. The fourth —
`(present, now enabled)`, reachable when a bean was registered through a non-scanner path — is handled
as "no restart needed" by applying decision D-04's own principle; it is recorded as an **extension of**
D-04 rather than something D-04 itself decided.

The other half of this requirement, the unused static import in `HelpGateTest`, was already merged as
`89ecc12d` (#408) and is not re-done here.

## Evidence

- `mvn -B clean verify` green: **5407 tests, 0 failures, 0 errors, 0 skipped**, parsed from 1547
  surefire XML reports rather than from a `BUILD SUCCESS` line.
- **Deliberate-break check** — the standing rule for this milestone is that a fix is proven by a test
  that fails when the fix is removed, not by a green suite. Stubbing `isActuallyRegistered` to return
  `true` unconditionally produced 8/16 failures whose messages named the exact absent-instance
  expectation that had been removed; restoring returned 16/16 green.
- **Observed on hardware**, not only in CI: verified on live Paper 1.21.4 running this exact build
  (`UltiTools-API-6.3.0-SNAPSHOT.jar`, 973728 bytes, SHA-256
  `5b8458a74d6f765543b5d17d4d7f60cf5df532969a3a11ef5d79d0579cba60ab`, built from `d615ef24`) through
  `UltiEconomy/InterestService` — a real `present → disabled` drift message backed by live
  `SimpleContainer` observation, plus a confirmed-silent mirror reload.
- japicmp reports no binary-incompatible change; the CJK scope gate exits 0.
- A deep code review of this phase's full source surface found nothing in these two files
  (1 Critical + 3 Warning + 1 Info were all in out-of-repository UAT tooling, all fixed and re-tested).

`mvn verify` passing is explicitly **not** offered as evidence for the hardware claim above. The
ecosystem acceptance pass that motivated this milestone found 45 defects in a tree whose suite was
green; re-verifying by that standard would repeat the error rather than close it.

## Scope

Two files, both in `context/`:

- `src/main/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluator.java`
- `src/test/java/com/ultikits/ultitools/context/ConditionalRegistrationEvaluatorDriftTest.java`

`SimpleContainer.java` is unchanged — the composition uses its existing public and package-private
surface.

Phase 11's other work is deliberately outside this repository: the acceptance-ledger tooling, the
purpose-built probe module and the evidence tree live under `~/servers/`, matching the
`FrameworkBehaviorProbe` precedent. That is why this pull request is two files rather than the phase's
full output.

## Not in this pull request

Phase 11 is not finished, and this pull request does not claim otherwise:

- **Documentation sync is outstanding.** The behaviour changed this cycle has not yet reached the
  documentation repository's unreleased branch. Its propagation pull request
  (`UltiKits/UltiTools-Dev-Doc` #79) is open and unmerged; the content sync follows it.
- **Two ledger rows and one module i18n verdict are unresolved** — each needs a real Minecraft client
  authenticated past UltiLogin, which the real-client session did not reach before its own timeout.
  `UltiBackup#7`'s re-test is recorded as **inconclusive**, not as passing.
- **Five defects this phase's verification surfaced remain open**: #410, #411, #412, #413, #414. #412 is
  the live root cause of two module internationalisation reports and is why `UltiSideBar#9` was left
  open with evidence rather than closed.
- **Four already-merged pull requests had reviews that ran against a non-final commit** — #400, #402,
  #404 and #406 — found by comparing each check's commit against the pull request head rather than
  trusting that a check was present. Recorded in this phase's gate audit; not addressed here.

Passing this phase's verification is **not** release authorization. `alpha` → `main` remains a separate,
explicit gate.
