### PR TITLE
fix(test): reset MockBukkit's real singleton field in MockBukkitHelper

### DIFF
--- a/src/test/java/com/ultikits/ultitools/utils/MockBukkitHelper.java
+++ b/src/test/java/com/ultikits/ultitools/utils/MockBukkitHelper.java
@@ -30,11 +30,16 @@ public final class MockBukkitHelper {
         } catch (Exception ignored) {
         }
 
-        // 2. 强制清理 MockBukkit 的内部状态
+        // 2. 兜底清理 MockBukkit 的内部单例引用
+        //    MockBukkit 4.x 只声明了一个字段：private static ServerMock mock。
+        //    正常路径上 unmock() 会经 setServerInstanceToNull() 把它置空，所以这里
+        //    只是失败路径的兜底：unmock() 的 try/catch 仅覆盖 scheduler 关闭那一段，
+        //    disablePlugins() 或 unload()/reset() 抛异常时会跳过置空，使 mock 残留为非 null，
+        //    导致下一次 MockBukkit.mock() 抛出 IllegalStateException("Already mocking")。
         try {
-            Field mockedField = MockBukkit.class.getDeclaredField("mocked");
-            mockedField.setAccessible(true);
-            mockedField.setBoolean(null, false);
+            Field mockField = MockBukkit.class.getDeclaredField("mock");
+            mockField.setAccessible(true);
+            mockField.set(null, null);
         } catch (Exception ignored) {
         }
 


### PR DESCRIPTION
## Issue closure

None

## Summary

`MockBukkitHelper.ensureCleanState()` step 2 reflected on a MockBukkit field named `mocked` and called `setBoolean(null, false)` on it. That field does not exist, so the block has never executed its intended effect. This points the reflection at the field that does exist.

## The measured facts

`org.mockbukkit.mockbukkit.MockBukkit` 4.101.0 declares **exactly one** field:

```
$ javap -p -classpath mockbukkit-v1.21-4.101.0.jar org.mockbukkit.mockbukkit.MockBukkit
public class org.mockbukkit.mockbukkit.MockBukkit {
  private static org.mockbukkit.mockbukkit.ServerMock mock;
  ...
```

There is no `mocked`, and no boolean field at all. The legacy `be.seeseemelk.mockbukkit` had a boolean `mocked`; the `org.mockbukkit` 4.x rewrite replaced it with the `ServerMock` reference. `getDeclaredField("mocked")` therefore throws `NoSuchFieldException`, which `catch (Exception ignored)` swallows.

## Why this was inert rather than harmful

On the happy path there is nothing for step 2 to do. `MockBukkit.unmock()` reaches `setServerInstanceToNull()`, whose bytecode nulls both `Bukkit.server` and `MockBukkit.mock`:

```
   16: invokevirtual  // Field.set(null, null)     <- Bukkit.server = null
   19: aconst_null
   20: putstatic      // Field mock:...ServerMock  <- MockBukkit.mock = null
```

The block exists for the **failure** path, and there it was doing nothing. `unmock()`'s exception table covers only offsets 25-34:

```
  public static void unmock();
      16..22: PluginManagerMock.disablePlugins()
      25..34: ServerMock.getScheduler().shutdown()
      34..46: PluginManagerMock.unload() / LifecycleEventRunnerMock.reset()
      49:     setServerInstanceToNull()
    Exception table:
       from    to  target type
          25    34    55   any
```

A throw from `disablePlugins()` (16-22) or from `unload()`/`reset()` (34-46) is not caught, so the null-out at offset 49 is skipped and `mock` stays non-null. The next `MockBukkit.mock()` then throws `IllegalStateException("Already mocking")` — the constant is confirmed at `mock(T)` offset 10. Recovering from exactly that state is what this block is for, and it could not.

## Verification

Full suite, because the change makes a previously-inert block actually execute and this helper is called by `TaskManagerTest`, `ConnectorPathRegistrationTest`, `PlayerEventManagerRegistrationTest`, `UltiPanelLogTransmitterTest` and `RegisterSingletonAssemblyTest`, among others:

- `mvn -B test` — **5409 tests, 0 failures, 0 errors, BUILD SUCCESS**
- `mvn -B test -Dgroups=isolated -DexcludedGroups=` — **20 tests, 0 failures, 0 errors, BUILD SUCCESS** (`manager/TaskManagerTest`)

A throwaway probe on the test classpath (run outside the repository, then deleted) confirms the fix is live rather than another no-op. Against a residual non-null `mock`:

```
"mocked" -> NoSuchFieldException (what the old code swallowed)
"mock"   -> RESOLVED: private static ...ServerMock ...MockBukkit.mock

OLD block: swallowed NoSuchFieldException -> no effect
  isMocked() = true
  MockBukkit.mock() THREW: java.lang.IllegalStateException: Already mocking

NEW block: ran with no exception
  isMocked() = false
  MockBukkit.mock() OK
```

## Scope

One file, one commit. Comments corrected to name `mock` and describe what the code does. This file sits outside the CJK gate's scope — `.github/scripts/check-cjk-scope.sh` covers `src/main/java`, `.github/workflows` and `src/test/java/com/ultikits/ultitools/buildtools` — so its existing Chinese comment convention is kept. Line endings preserved (the file is LF and remains LF).

## Why it is being fixed here

Gate-1 code review of Phase 14 traced **six module repositories'** copies of this block back to this file; the silent no-op propagated verbatim into six newly-added files. Those six are being fixed separately. This milestone's core value is that a declared API surface must actually do what it declares, and silent no-ops are the single defect class it exists to eliminate — so the framework's own test helper carrying one is worth closing at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018niHTVSAy67LL7K6Y6D3WC
