### PR TITLE
fix(13-01): resolve module language catalogues from their own jar (#412)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1063,6 +1063,21 @@
             <version>5.5.0</version>
             <scope>test</scope>
         </dependency>
+        <!-- Objenesis is already resolved transitively via mockito-core (it backs Mockito's
+             inline mock maker's constructor-bypassing allocation), but 13-01 imports it directly
+             in UltiToolsPluginLanguageScopeTest to allocate a jar-loaded fixture class without
+             invoking any UltiToolsPlugin constructor. analyze-only (FOUND-05, T-01-03b) fails the
+             build on any class used but not explicitly declared, so it is declared here rather
+             than added to ignoredUsedUndeclaredDependencies - unlike that list's entries (arriving
+             solely through paper-api/obliviate-invs and never referenced by name), this one is
+             imported by fully-qualified name in framework test source. Version pinned to the exact
+             one mockito-core 5.5.0 already resolves, so this adds no new version to the tree. -->
+        <dependency>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
+            <version>3.3</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>

--- a/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
@@ -9,6 +9,8 @@ import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.io.OutputStream;
 import java.net.JarURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.security.CodeSource;
@@ -230,8 +232,7 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
         if (src == null || src.getLocation() == null) {
             return null;
         }
-        String rawPath = src.getLocation().getPath();
-        File location = new File(rawPath.startsWith("/") ? rawPath : rawPath.substring(1));
+        File location = resolveCodeSourceFile(src.getLocation());
         if (location.isDirectory()) {
             // Exploded classpath (dev workspace, IDE launch, test) -- Localized.scanLangResources()
             // already treats this shape as first-class; loadLanguageFromJar must not disagree.
@@ -259,6 +260,28 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
         } catch (IOException e) {
             getLogger().error(e, "Failed to read language resource " + entryName + " from " + location);
             return new Language("{}");
+        }
+    }
+
+    /**
+     * Resolves a {@link CodeSource} location as a {@link File}, decoding any percent-escaped
+     * characters (spaces, non-ASCII, etc.) that {@link URL#getPath()} does not decode on its
+     * own (13-REVIEW WR-03) -- passing an undecoded {@code %20...} path straight to {@link
+     * File#File(String)} or {@link JarFile#JarFile(File)} finds nothing when the module is
+     * installed under a path containing a space or other URI-escaped character. Falls back to
+     * the previous raw-path substring logic -- matching {@link #getInputStream()}'s own
+     * try/catch({@link URISyntaxException}) shape for the same {@link CodeSource} location --
+     * for the rare case the location cannot be expressed as a {@link URI} at all.
+     *
+     * @param location the {@code CodeSource.getLocation()} URL, never {@code null}
+     * @return the resolved location as a {@link File}
+     */
+    private static File resolveCodeSourceFile(URL location) {
+        try {
+            return new File(location.toURI());
+        } catch (URISyntaxException e) {
+            String rawPath = location.getPath();
+            return new File(rawPath.startsWith("/") ? rawPath : rawPath.substring(1));
         }
     }
 

--- a/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
@@ -242,7 +242,7 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
             try (BufferedReader reader = Files.newBufferedReader(resource.toPath(), StandardCharsets.UTF_8)) {
                 return parseLanguageResource(reader, extension);
             } catch (IOException e) {
-                getLogger().error("Failed to read language resource " + resource + " from " + location, e);
+                getLogger().error(e, "Failed to read language resource " + resource + " from " + location);
                 return new Language("{}");
             }
         }
@@ -257,7 +257,7 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
                 return parseLanguageResource(reader, extension);
             }
         } catch (IOException e) {
-            getLogger().error("Failed to read language resource " + entryName + " from " + location, e);
+            getLogger().error(e, "Failed to read language resource " + entryName + " from " + location);
             return new Language("{}");
         }
     }

--- a/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
@@ -212,11 +212,18 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
     }
 
     /**
-     * Reads {@code lang/<code><extension>} from the module jar if present, else {@code null}.
+     * Reads {@code lang/<code><extension>} from the module's own {@link CodeSource} location if
+     * present, else {@code null}. Mirrors {@link Localized#scanLangResources(URL)}'s directory/jar
+     * branch (13-REVIEW CR-01, issue #412 follow-up): an exploded classpath (dev workspace, IDE
+     * launch, or a module test that instantiates a real {@code UltiToolsPlugin} subclass) has a
+     * directory as its {@code CodeSource}, and {@link Localized#supported()} already scans that
+     * directory directly -- this method must not disagree by unconditionally trying (and failing)
+     * to open the directory as a {@code JarFile} first.
      * <p>
-     * The resource path is built with {@code '/'} rather than {@code File.separator}: jar entry
-     * names always use a forward slash, so the separator form would silently find nothing on a
-     * Windows host.
+     * The resource path is built with {@code '/'} for the jar-entry lookup and {@link
+     * File#separator} for the on-disk lookup: jar entry names always use a forward slash, so the
+     * separator form would silently find nothing on a Windows host, and the reverse holds for a
+     * real file path.
      */
     private Language loadLanguageFromJar(String code, String extension) {
         CodeSource src = this.getClass().getProtectionDomain().getCodeSource();
@@ -224,26 +231,49 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
             return null;
         }
         String rawPath = src.getLocation().getPath();
-        String jarPath = rawPath.startsWith("/") ? rawPath : rawPath.substring(1);
+        File location = new File(rawPath.startsWith("/") ? rawPath : rawPath.substring(1));
+        if (location.isDirectory()) {
+            // Exploded classpath (dev workspace, IDE launch, test) -- Localized.scanLangResources()
+            // already treats this shape as first-class; loadLanguageFromJar must not disagree.
+            File resource = new File(location, "lang" + File.separator + code + extension);
+            if (!resource.isFile()) {
+                return null;
+            }
+            try (BufferedReader reader = Files.newBufferedReader(resource.toPath(), StandardCharsets.UTF_8)) {
+                return parseLanguageResource(reader, extension);
+            } catch (IOException e) {
+                getLogger().error("Failed to read language resource " + resource + " from " + location, e);
+                return new Language("{}");
+            }
+        }
         String entryName = "lang/" + code + extension;
-        try (JarFile jarFile = new JarFile(jarPath)) {
+        try (JarFile jarFile = new JarFile(location)) {
             JarEntry entry = jarFile.getJarEntry(entryName);
             if (entry == null) {
                 return null;
             }
             try (BufferedReader reader = new BufferedReader(
                     new InputStreamReader(jarFile.getInputStream(entry), StandardCharsets.UTF_8))) {
-                if (".json".equals(extension)) {
-                    return new Language(reader.lines().collect(Collectors.joining("")));
-                }
-                // Joining with "" is fine for JSON and destroys YAML, whose structure is the line
-                // breaks -- so YAML is handed the reader rather than a flattened string.
-                return Language.fromYaml(reader);
+                return parseLanguageResource(reader, extension);
             }
         } catch (IOException e) {
-            getLogger().error("Failed to read language resource " + entryName + " from " + jarPath, e);
+            getLogger().error("Failed to read language resource " + entryName + " from " + location, e);
             return new Language("{}");
         }
+    }
+
+    /**
+     * Parses a {@code lang/*} resource already opened as a {@link BufferedReader} -- shared by
+     * both the on-disk (exploded directory) and in-jar branches of {@link
+     * #loadLanguageFromJar(String, String)} so the two stay in sync.
+     */
+    private static Language parseLanguageResource(BufferedReader reader, String extension) throws IOException {
+        if (".json".equals(extension)) {
+            return new Language(reader.lines().collect(Collectors.joining("")));
+        }
+        // Joining with "" is fine for JSON and destroys YAML, whose structure is the line
+        // breaks -- so YAML is handed the reader rather than a flattened string.
+        return Language.fromYaml(reader);
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
@@ -173,10 +173,16 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
         String resolvedCode = resolveLanguageCode();
         for (String extension : LANGUAGE_EXTENSIONS) {
             Language onDisk = loadLanguageFromDisk(folderPath, resolvedCode, extension);
-            if (onDisk != null) {
-                return onDisk;
-            }
             Language inJar = loadLanguageFromJar(resolvedCode, extension);
+            if (onDisk != null) {
+                // Real-machine finding (phase 13, PR #418): on an upgraded server the module jar
+                // adds a key that the copy of this language file already extracted to disk by an
+                // older jar does not have. The disk file stays authoritative for every key it does
+                // contain -- server owners customise it -- but a key it lacks now falls back to
+                // the jar-bundled catalogue for the same code/extension instead of rendering as
+                // its own raw key.
+                return onDisk.withFallback(inJar);
+            }
             if (inJar != null) {
                 return inJar;
             }

--- a/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
@@ -219,19 +219,29 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
      * Windows host.
      */
     private Language loadLanguageFromJar(String code, String extension) {
-        InputStream in = getResource("lang/" + code + extension);
-        if (in == null) {
+        CodeSource src = this.getClass().getProtectionDomain().getCodeSource();
+        if (src == null || src.getLocation() == null) {
             return null;
         }
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
-            if (".json".equals(extension)) {
-                return new Language(reader.lines().collect(Collectors.joining("")));
+        String rawPath = src.getLocation().getPath();
+        String jarPath = rawPath.startsWith("/") ? rawPath : rawPath.substring(1);
+        String entryName = "lang/" + code + extension;
+        try (JarFile jarFile = new JarFile(jarPath)) {
+            JarEntry entry = jarFile.getJarEntry(entryName);
+            if (entry == null) {
+                return null;
             }
-            // Joining with "" is fine for JSON and destroys YAML, whose structure is the line
-            // breaks -- so YAML is handed the reader rather than a flattened string.
-            return Language.fromYaml(reader);
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(jarFile.getInputStream(entry), StandardCharsets.UTF_8))) {
+                if (".json".equals(extension)) {
+                    return new Language(reader.lines().collect(Collectors.joining("")));
+                }
+                // Joining with "" is fine for JSON and destroys YAML, whose structure is the line
+                // breaks -- so YAML is handed the reader rather than a flattened string.
+                return Language.fromYaml(reader);
+            }
         } catch (IOException e) {
-            getLogger().error("Failed to read language resource lang/" + code + extension, e);
+            getLogger().error("Failed to read language resource " + entryName + " from " + jarPath, e);
             return new Language("{}");
         }
     }

--- a/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
@@ -603,19 +603,6 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
         }
     }
 
-    private InputStream getResource(String filename) {
-        try {
-            ClassLoader classLoader = this.getClass().getClassLoader();
-            URL resource = classLoader.getResource(filename);
-            if (resource == null) {
-                return null;
-            }
-            return resource.openStream();
-        } catch (IOException ex) {
-            return null;
-        }
-    }
-
     /**
      * Gets data operator. Refuses outright if {@code dataClazz} is not registered to this module
      * (D-14) -- checked against the same {@link com.ultikits.ultitools.manager.DataScope} minted

--- a/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
+++ b/src/main/java/com/ultikits/ultitools/abstracts/UltiToolsPlugin.java
@@ -171,21 +171,27 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
      */
     private Language createLanguageFromPath(String folderPath) {
         String resolvedCode = resolveLanguageCode();
-        for (String extension : LANGUAGE_EXTENSIONS) {
-            Language onDisk = loadLanguageFromDisk(folderPath, resolvedCode, extension);
-            Language inJar = loadLanguageFromJar(resolvedCode, extension);
-            if (onDisk != null) {
-                // Real-machine finding (phase 13, PR #418): on an upgraded server the module jar
-                // adds a key that the copy of this language file already extracted to disk by an
-                // older jar does not have. The disk file stays authoritative for every key it does
-                // contain -- server owners customise it -- but a key it lacks now falls back to
-                // the jar-bundled catalogue for the same code/extension instead of rendering as
-                // its own raw key.
-                return onDisk.withFallback(inJar);
-            }
-            if (inJar != null) {
-                return inJar;
-            }
+        // Round 5 (own deep review of 0ddc95f, finding 1): the disk and jar catalogues are now
+        // resolved independently of each other's extension. Resolving them together, one shared
+        // extension per loop iteration, meant a module that shipped an old jar's lang/en.json
+        // (extracted to disk) alongside a new jar's lang/en.yml never reached the .yml iteration
+        // at all -- the .json iteration's non-null onDisk short-circuited the loop before the
+        // jar's .yml catalogue, under a different extension, was ever looked at.
+        Language onDisk = resolveDiskLanguage(folderPath, resolvedCode);
+        Language inJar = resolveJarLanguage(resolvedCode);
+        if (onDisk != null && inJar != null) {
+            // Real-machine finding (phase 13, PR #418): on an upgraded server the module jar
+            // adds a key that the copy of this language file already extracted to disk by an
+            // older jar does not have. The disk file stays authoritative for every key it does
+            // contain -- server owners customise it -- but a key it lacks now falls back to
+            // the jar-bundled catalogue instead of rendering as its own raw key.
+            return onDisk.withFallback(inJar);
+        }
+        if (onDisk != null) {
+            return onDisk;
+        }
+        if (inJar != null) {
+            return inJar;
         }
         // #389: this used to return an empty dictionary without a word. Language.get then falls
         // back to the key, so every message in the module rendered as its own raw key -- which is
@@ -198,6 +204,43 @@ public abstract class UltiToolsPlugin implements IPlugin, Localized, Configurabl
                 + " and inside the module jar. Every i18n(...) call in this module will render its "
                 + "own key until one is added.");
         return new Language("{}");
+    }
+
+    /**
+     * Resolves the on-disk language catalogue for {@code code}, trying each of {@link
+     * #LANGUAGE_EXTENSIONS} in order and returning the first that exists -- independently of
+     * whichever extension {@link #resolveJarLanguage(String)} resolves for the same code
+     * (13-REVIEW round 5, own deep review of {@code 0ddc95f}, finding 1).
+     *
+     * @return the resolved on-disk language, or {@code null} if none of the extensions exist on disk
+     */
+    private Language resolveDiskLanguage(String folderPath, String code) {
+        for (String extension : LANGUAGE_EXTENSIONS) {
+            Language onDisk = loadLanguageFromDisk(folderPath, code, extension);
+            if (onDisk != null) {
+                return onDisk;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the jar-bundled language catalogue for {@code code}, trying each of {@link
+     * #LANGUAGE_EXTENSIONS} in order and returning the first that exists -- independently of
+     * whichever extension {@link #resolveDiskLanguage(String, String)} resolves for the same code
+     * (13-REVIEW round 5, own deep review of {@code 0ddc95f}, finding 1).
+     *
+     * @return the resolved jar-bundled language, or {@code null} if none of the extensions exist
+     *         in the jar
+     */
+    private Language resolveJarLanguage(String code) {
+        for (String extension : LANGUAGE_EXTENSIONS) {
+            Language inJar = loadLanguageFromJar(code, extension);
+            if (inJar != null) {
+                return inJar;
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/com/ultikits/ultitools/annotations/command/RunAsync.java
+++ b/src/main/java/com/ultikits/ultitools/annotations/command/RunAsync.java
@@ -6,7 +6,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a {@code @CmdMapping} method body as safe to run off the main thread.
+ * Marks a {@code @CmdMapping} method body as eligible to run off the main thread -- see below
+ * for when that is, and is not, actually safe.
  * <p>
  * <b>A command handler that touches world, entity, block, chunk or scheduler state
  * must not be annotated with this annotation ({@code @RunAsync}).</b>
@@ -25,7 +26,7 @@ import java.lang.annotation.Target;
  * <p>
  * The observable failure when this rule is broken is not a slow command -- it is a crash.
  * Bukkit's async-scheduler dispatch (see {@code runTaskAsynchronously()} in
- * {@code BaseCommandExecutor}) runs the body off the main thread unconditionally, and the first
+ * {@link com.ultikits.ultitools.abstracts.command.BaseCommandExecutor}) runs the body off the main thread unconditionally, and the first
  * call into world, entity, block or chunk state trips Paper's asynchronous-operation check and
  * kills the command mid-handler.
  * <p>

--- a/src/main/java/com/ultikits/ultitools/annotations/command/RunAsync.java
+++ b/src/main/java/com/ultikits/ultitools/annotations/command/RunAsync.java
@@ -9,13 +9,13 @@ import java.lang.annotation.Target;
  * Marks a {@code @CmdMapping} method body as eligible to run off the main thread -- see below
  * for when that is, and is not, actually safe.
  * <p>
- * <b>A command handler that touches world, entity, block, chunk or scheduler state
- * must not be annotated with this annotation ({@code @RunAsync}).</b>
- * Asynchrony here is reserved for pure-CPU or I/O work only. If the body needs to return to
- * Bukkit state afterward -- teleporting a player, reading or writing a block, loading a chunk,
- * touching an entity -- that hand-back must go through
- * {@link org.bukkit.scheduler.BukkitScheduler#runTask(org.bukkit.plugin.Plugin, Runnable)}; this
- * annotation never grants safe access to those APIs by itself.
+ * <b>An {@code @RunAsync} body must not touch world, entity, block or chunk state
+ * directly.</b>
+ * Asynchrony here is reserved for pure-CPU or I/O work. The one Bukkit call an async body
+ * may make is scheduling its state-touching work back onto the main thread through
+ * {@link org.bukkit.scheduler.BukkitScheduler#runTask(org.bukkit.plugin.Plugin, Runnable)};
+ * this annotation never grants safe access to those APIs by itself. A handler whose body
+ * consists only of such state access has no reason to carry the annotation at all.
  * <p>
  * Without this annotation, a synchronous command body is not run inline on the calling thread --
  * the framework already defers it by one tick via {@code runTask()} in

--- a/src/main/java/com/ultikits/ultitools/annotations/command/RunAsync.java
+++ b/src/main/java/com/ultikits/ultitools/annotations/command/RunAsync.java
@@ -6,7 +6,32 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Run async annotation.
+ * Marks a {@code @CmdMapping} method body as safe to run off the main thread.
+ * <p>
+ * <b>A command handler that touches world, entity, block, chunk or scheduler state
+ * must not be annotated with this annotation ({@code @RunAsync}).</b>
+ * Asynchrony here is reserved for pure-CPU or I/O work only. If the body needs to return to
+ * Bukkit state afterward -- teleporting a player, reading or writing a block, loading a chunk,
+ * touching an entity -- that hand-back must go through
+ * {@link org.bukkit.scheduler.BukkitScheduler#runTask(org.bukkit.plugin.Plugin, Runnable)}; this
+ * annotation never grants safe access to those APIs by itself.
+ * <p>
+ * Without this annotation, a synchronous command body is not run inline on the calling thread --
+ * the framework already defers it by one tick via {@code runTask()} in
+ * {@link com.ultikits.ultitools.abstracts.command.BaseCommandExecutor}. Removing
+ * {@code @RunAsync} from a handler that never needed it is therefore not "making the command
+ * block the server"; it restores the same one-tick-deferred synchronous dispatch every other
+ * command already uses.
+ * <p>
+ * The observable failure when this rule is broken is not a slow command -- it is a crash.
+ * Bukkit's async-scheduler dispatch (see {@code runTaskAsynchronously()} in
+ * {@code BaseCommandExecutor}) runs the body off the main thread unconditionally, and the first
+ * call into world, entity, block or chunk state trips Paper's asynchronous-operation check and
+ * kills the command mid-handler.
+ * <p>
+ * For work that genuinely belongs off-thread -- and needs a processing message, a timeout, or
+ * configurable behavior around that boundary -- use {@link AsyncCommand} instead of this
+ * annotation.
  *
  * @see <a href="https://dev.ultikits.com/en/guide/essentials/cmd-executor.html#asynchronous-execution">@RunAsync</a>
  */

--- a/src/main/java/com/ultikits/ultitools/entities/Language.java
+++ b/src/main/java/com/ultikits/ultitools/entities/Language.java
@@ -29,6 +29,7 @@ public class Language {
     private static final Type MAP_TYPE = new TypeToken<Map<String, String>>() {}.getType();
 
     private final Map<String, String> dictionary;
+    private final Language fallback;
 
     /**
      * Creates a language dictionary by reading a JSON file.
@@ -43,6 +44,7 @@ public class Language {
             LOGGER.log(Level.WARNING, "Failed to load language file: " + file.getPath(), e);
         }
         this.dictionary = tempDict != null ? tempDict : Collections.emptyMap();
+        this.fallback = null;
     }
 
     /**
@@ -52,6 +54,7 @@ public class Language {
      */
     public Language(Map<String, String> dictionary) {
         this.dictionary = dictionary != null ? dictionary : Collections.emptyMap();
+        this.fallback = null;
     }
 
     /**
@@ -62,6 +65,43 @@ public class Language {
     public Language(String json) {
         Map<String, String> tempDict = GSON.fromJson(json, MAP_TYPE);
         this.dictionary = tempDict != null ? tempDict : Collections.emptyMap();
+        this.fallback = null;
+    }
+
+    /**
+     * Creates a language whose dictionary is consulted first, falling back to {@code fallback}
+     * for any key this dictionary does not contain.
+     *
+     * @param dictionary this language's own dictionary, authoritative for every key it contains
+     * @param fallback   consulted only for a key absent from {@code dictionary}; may be {@code null}
+     */
+    private Language(Map<String, String> dictionary, Language fallback) {
+        this.dictionary = dictionary != null ? dictionary : Collections.emptyMap();
+        this.fallback = fallback;
+    }
+
+    /**
+     * Returns a {@code Language} that answers from this dictionary first and, for any key this
+     * dictionary lacks, from {@code fallback} instead of immediately returning the raw key.
+     * <p>
+     * Real-machine finding (phase 13, PR #418): on an upgraded server a module jar adds a
+     * language key, but the copy of that language file already sitting in the module's data
+     * folder -- extracted by an older jar -- does not have it. Before this method existed,
+     * whichever {@code Language} the loader picked (disk, if present at all) was used
+     * exclusively, so a key the disk file lacked rendered as its own raw key even though the
+     * new jar shipped a translation for it. The disk file stays authoritative for every key it
+     * does contain, since server owners customise it.
+     *
+     * @param fallback the language to consult for a key this dictionary does not contain; may be
+     *                 {@code null}, in which case this language is returned unchanged
+     * @return a language falling back to {@code fallback} for missing keys
+     * @since 6.3.0
+     */
+    public Language withFallback(Language fallback) {
+        if (fallback == null) {
+            return this;
+        }
+        return new Language(this.dictionary, fallback);
     }
 
     /**
@@ -100,6 +140,10 @@ public class Language {
     }
 
     public String getLocalizedText(String str) {
-        return dictionary.getOrDefault(str, str);
+        String value = dictionary.get(str);
+        if (value != null) {
+            return value;
+        }
+        return fallback != null ? fallback.getLocalizedText(str) : str;
     }
 }

--- a/src/main/java/com/ultikits/ultitools/entities/Language.java
+++ b/src/main/java/com/ultikits/ultitools/entities/Language.java
@@ -95,11 +95,22 @@ public class Language {
      * @param fallback the language to consult for a key this dictionary does not contain; may be
      *                 {@code null}, in which case this language is returned unchanged
      * @return a language falling back to {@code fallback} for missing keys
+     * @throws IllegalArgumentException if {@code fallback} is this language, or if {@code
+     *                                   fallback}'s own fallback chain already contains this
+     *                                   language -- either would make {@link #getLocalizedText}
+     *                                   recurse forever for a key present in neither
      * @since 6.3.0
      */
     public Language withFallback(Language fallback) {
         if (fallback == null) {
             return this;
+        }
+        for (Language link = fallback; link != null; link = link.fallback) {
+            if (link == this) {
+                throw new IllegalArgumentException(
+                        "Cannot use a fallback that is, or already falls back to, this language -- "
+                                + "that would create a fallback cycle.");
+            }
         }
         return new Language(this.dictionary, fallback);
     }

--- a/src/test/java/com/ultikits/ultitools/abstracts/UltiToolsPluginLanguagePerKeyFallbackTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/UltiToolsPluginLanguagePerKeyFallbackTest.java
@@ -1,0 +1,236 @@
+package com.ultikits.ultitools.abstracts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+import org.objenesis.Objenesis;
+import org.objenesis.ObjenesisStd;
+
+import com.ultikits.ultitools.entities.Language;
+import com.ultikits.ultitools.utils.TestHelper;
+
+/**
+ * Real-machine finding, phase 13, PR #418 (Laojun UAT 2026-09-06, rows UltiChat #9 / F-C1 and
+ * UltiWorlds #13 / F-W2): on an upgraded server, a module jar ships a language key that the copy
+ * of that language file already sitting in the module's data folder -- extracted by an older jar
+ * -- does not contain. Before this fix, {@link UltiToolsPlugin#createLanguageFromPath(String)}
+ * used whichever {@link Language} it found first (the on-disk file, if present at all) exclusively,
+ * so a key missing from disk rendered as its own raw key even though the newly-shipped jar had a
+ * translation for it.
+ * <p>
+ * Mirrors {@code UltiToolsPluginLanguageScopeTest}'s directory-{@link java.security.CodeSource}
+ * fixture technique (13-REVIEW CR-01 / issue #412): an exploded module directory stands in for the
+ * module's own jar-bundled {@code lang/} catalogue, while a separate directory plays the role of
+ * the module's on-disk {@code resourceFolderPath}. The two are deliberately different key sets so
+ * the assertions below distinguish "disk wins for a key it has", "falls back to the jar for a key
+ * it lacks", and "falls back to the raw key when neither has it" -- exactly the three rows the task
+ * requires.
+ */
+@DisplayName("UltiToolsPlugin createLanguageFromPath per-key disk->jar->key fallback (#418)")
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+@SuppressWarnings("PMD.AvoidAccessibilityAlteration") // reflective invocation of a private resolution method
+class UltiToolsPluginLanguagePerKeyFallbackTest {
+
+    // Declared before the nested loader classes below: PMD's FieldDeclarationsShouldBeAtStartOfClass
+    // requires fields to precede any inner class.
+    @TempDir
+    File tempDir;
+
+    private ChildFirstClassLoader directoryLoader;
+
+    @BeforeEach
+    void stubUltiToolsInstance() {
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("language", "en");
+        TestHelper.mockUltiToolsInstance(ultiTools -> {
+            Mockito.lenient().when(ultiTools.getConfig()).thenReturn(config);
+            Mockito.lenient().when(ultiTools.getLogger())
+                    .thenReturn(Logger.getLogger(UltiToolsPluginLanguagePerKeyFallbackTest.class.getName()));
+        });
+    }
+
+    /**
+     * Same asymmetry as {@code UltiToolsPluginLanguageScopeTest}'s {@code ChildFirstClassLoader}:
+     * child-first for the module's own classes, parent-first (default) for resources.
+     */
+    private static final class ChildFirstClassLoader extends URLClassLoader {
+        ChildFirstClassLoader(URL[] urls, ClassLoader parent) {
+            super(urls, parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> found = findLoadedClass(name);
+                if (found == null) {
+                    try {
+                        found = findClass(name);
+                    } catch (ClassNotFoundException notShippedByThisJar) {
+                        found = super.loadClass(name, false);
+                    }
+                }
+                if (resolve) {
+                    resolveClass(found);
+                }
+                return found;
+            }
+        }
+    }
+
+    /**
+     * Hides every {@code lang/*} resource from the real test/application classloader, so a
+     * {@code getResource("lang/en.json")} walk cannot accidentally reach the framework's own
+     * genuine {@code src/main/resources/lang/en.json} instead of this fixture's directory.
+     */
+    private static final class LangResourceHidingClassLoader extends ClassLoader {
+        private final ClassLoader real;
+
+        LangResourceHidingClassLoader(ClassLoader real) {
+            super(real);
+            this.real = real;
+        }
+
+        @Override
+        public URL getResource(String name) {
+            return name.startsWith("lang/") ? null : real.getResource(name);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            return name.startsWith("lang/") ? Collections.emptyEnumeration() : real.getResources(name);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            return name.startsWith("lang/") ? null : real.getResourceAsStream(name);
+        }
+    }
+
+    private static byte[] compiledFixtureClassBytes() throws IOException {
+        String resourceName = UltiToolsPluginLanguageScopeTest.ModuleFixturePlugin.class.getName()
+                .replace('.', '/') + ".class";
+        try (InputStream in = UltiToolsPluginLanguagePerKeyFallbackTest.class.getClassLoader()
+                .getResourceAsStream(resourceName)) {
+            if (in == null) {
+                throw new IOException("Compiled fixture class not found on the test classpath: " + resourceName);
+            }
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            byte[] buf = new byte[4096];
+            int len;
+            while ((len = in.read(buf)) != -1) {
+                out.write(buf, 0, len);
+            }
+            return out.toByteArray();
+        }
+    }
+
+    private static Object newModuleFixtureInstance(ClassLoader moduleLoader) throws Exception {
+        // The class name is a compile-time constant, never attacker-controllable; loading through
+        // the given moduleLoader is required to give the instance that loader's own CodeSource.
+        // nosemgrep: java.lang.security.audit.unsafe-reflection.unsafe-reflection
+        Class<?> fixtureClass = Class.forName(
+                UltiToolsPluginLanguageScopeTest.ModuleFixturePlugin.class.getName(), true, moduleLoader);
+        Objenesis objenesis = new ObjenesisStd();
+        return objenesis.newInstance(fixtureClass);
+    }
+
+    private static Language invokeCreateLanguageFromPath(Object plugin, String folderPath) throws Throwable {
+        Method method = UltiToolsPlugin.class.getDeclaredMethod("createLanguageFromPath", String.class);
+        method.setAccessible(true);
+        try {
+            return (Language) method.invoke(plugin, folderPath);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    @AfterEach
+    void closeLoader() throws IOException {
+        if (directoryLoader != null) {
+            directoryLoader.close();
+        }
+    }
+
+    @Test
+    @DisplayName("disk lacks a key the jar has -> the jar's translation is used, not the raw key")
+    void diskMissingKeyFallsBackToJarTranslation() throws Throwable {
+        Language language = buildMergedLanguage();
+
+        assertThat(language.getLocalizedText("onlyInJar")).isEqualTo("&cJar-only translation.");
+    }
+
+    @Test
+    @DisplayName("disk has the key with a different value -> the disk value wins")
+    void diskValuePresentInBothWins() throws Throwable {
+        Language language = buildMergedLanguage();
+
+        assertThat(language.getLocalizedText("known")).isEqualTo("&cDisk-customised translation.");
+    }
+
+    @Test
+    @DisplayName("neither disk nor jar has the key -> falls back to the raw key, unchanged")
+    void keyInNeitherFallsBackToTheRawKey() throws Throwable {
+        Language language = buildMergedLanguage();
+
+        assertThat(language.getLocalizedText("neitherHasThis")).isEqualTo("neitherHasThis");
+    }
+
+    /**
+     * Builds one exploded module directory (stands in for the module's own jar-bundled {@code
+     * lang/en.json}) and one separate on-disk resource folder (stands in for {@code
+     * resourceFolderPath/lang/en.json}, as an older jar's {@code saveResources()} would have
+     * extracted it), then invokes the real, unmodified {@code createLanguageFromPath} through
+     * reflection so its actual body runs.
+     */
+    private Language buildMergedLanguage() throws Throwable {
+        File explodedRoot = new File(tempDir, "exploded-module-jar-catalogue");
+        File classFile = new File(explodedRoot,
+                UltiToolsPluginLanguageScopeTest.ModuleFixturePlugin.class.getName().replace('.', '/') + ".class");
+        Files.createDirectories(classFile.getParentFile().toPath());
+        Files.write(classFile.toPath(), compiledFixtureClassBytes());
+
+        File jarLangFile = new File(explodedRoot, "lang" + File.separator + "en.json");
+        Files.createDirectories(jarLangFile.getParentFile().toPath());
+        Files.write(jarLangFile.toPath(),
+                ("{\"known\":\"&cJar-shipped translation.\","
+                        + "\"onlyInJar\":\"&cJar-only translation.\"}").getBytes(StandardCharsets.UTF_8));
+
+        File diskResourceFolder = new File(tempDir, "disk-resource-folder");
+        File diskLangFile = new File(diskResourceFolder, "lang" + File.separator + "en.json");
+        Files.createDirectories(diskLangFile.getParentFile().toPath());
+        // Deliberately missing "onlyInJar" -- the exact shape of an older jar's extraction that
+        // predates the new key, and deliberately a different value for "known" than the jar's, so
+        // "disk wins for a key it has" is unambiguous.
+        Files.write(diskLangFile.toPath(),
+                "{\"known\":\"&cDisk-customised translation.\"}".getBytes(StandardCharsets.UTF_8));
+
+        ClassLoader isolatingBase = new LangResourceHidingClassLoader(
+                UltiToolsPluginLanguagePerKeyFallbackTest.class.getClassLoader());
+        directoryLoader = new ChildFirstClassLoader(new URL[]{explodedRoot.toURI().toURL()}, isolatingBase);
+        Object plugin = newModuleFixtureInstance(directoryLoader);
+
+        return invokeCreateLanguageFromPath(plugin, diskResourceFolder.getAbsolutePath());
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/abstracts/UltiToolsPluginLanguagePerKeyFallbackTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/UltiToolsPluginLanguagePerKeyFallbackTest.java
@@ -197,6 +197,15 @@ class UltiToolsPluginLanguagePerKeyFallbackTest {
         assertThat(language.getLocalizedText("neitherHasThis")).isEqualTo("neitherHasThis");
     }
 
+    @Test
+    @DisplayName("disk ships .json, jar ships only .yml for the same code -> the jar's .yml key is "
+            + "used, not the raw key (round 5 finding 1)")
+    void diskJsonJarYmlCrossExtensionFallsBackToJarYamlTranslation() throws Throwable {
+        Language language = buildCrossExtensionMergedLanguage();
+
+        assertThat(language.getLocalizedText("crossExtensionKey")).isEqualTo("&cOnly in the yml jar catalogue.");
+    }
+
     /**
      * Builds one exploded module directory (stands in for the module's own jar-bundled {@code
      * lang/en.json}) and one separate on-disk resource folder (stands in for {@code
@@ -223,6 +232,47 @@ class UltiToolsPluginLanguagePerKeyFallbackTest {
         // Deliberately missing "onlyInJar" -- the exact shape of an older jar's extraction that
         // predates the new key, and deliberately a different value for "known" than the jar's, so
         // "disk wins for a key it has" is unambiguous.
+        Files.write(diskLangFile.toPath(),
+                "{\"known\":\"&cDisk-customised translation.\"}".getBytes(StandardCharsets.UTF_8));
+
+        ClassLoader isolatingBase = new LangResourceHidingClassLoader(
+                UltiToolsPluginLanguagePerKeyFallbackTest.class.getClassLoader());
+        directoryLoader = new ChildFirstClassLoader(new URL[]{explodedRoot.toURI().toURL()}, isolatingBase);
+        Object plugin = newModuleFixtureInstance(directoryLoader);
+
+        return invokeCreateLanguageFromPath(plugin, diskResourceFolder.getAbsolutePath());
+    }
+
+    /**
+     * Same shape as {@link #buildMergedLanguage()}, except the on-disk catalogue is {@code
+     * lang/en.json} (as an older jar's {@code saveResources()} extracted it) while the jar-bundled
+     * catalogue for the same code is {@code lang/en.yml} only -- the disk file predates a mid-life
+     * extension change from {@code .json} to {@code .yml} for this module (round 5, own deep review
+     * of {@code 0ddc95f}, finding 1). Resolving the disk and jar catalogues per-extension in the
+     * same loop iteration meant the first matching extension (the stale disk {@code .json})
+     * short-circuited the loop before the jar's {@code .yml} iteration was ever reached, so a key
+     * that exists only in the jar's {@code .yml} rendered as its own raw key even with the round-4
+     * fallback fix in place.
+     */
+    private Language buildCrossExtensionMergedLanguage() throws Throwable {
+        File explodedRoot = new File(tempDir, "exploded-module-jar-catalogue-yml");
+        File classFile = new File(explodedRoot,
+                UltiToolsPluginLanguageScopeTest.ModuleFixturePlugin.class.getName().replace('.', '/') + ".class");
+        Files.createDirectories(classFile.getParentFile().toPath());
+        Files.write(classFile.toPath(), compiledFixtureClassBytes());
+
+        File jarLangFile = new File(explodedRoot, "lang" + File.separator + "en.yml");
+        Files.createDirectories(jarLangFile.getParentFile().toPath());
+        Files.write(jarLangFile.toPath(),
+                ("known: \"&cJar-shipped translation (yml).\"\n"
+                        + "crossExtensionKey: \"&cOnly in the yml jar catalogue.\"\n")
+                        .getBytes(StandardCharsets.UTF_8));
+
+        File diskResourceFolder = new File(tempDir, "disk-resource-folder-yml");
+        File diskLangFile = new File(diskResourceFolder, "lang" + File.separator + "en.json");
+        Files.createDirectories(diskLangFile.getParentFile().toPath());
+        // The stale disk file from before the module switched language-file extensions -- .json,
+        // not .yml -- and deliberately missing "crossExtensionKey".
         Files.write(diskLangFile.toPath(),
                 "{\"known\":\"&cDisk-customised translation.\"}".getBytes(StandardCharsets.UTF_8));
 

--- a/src/test/java/com/ultikits/ultitools/abstracts/UltiToolsPluginLanguageScopeTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/UltiToolsPluginLanguageScopeTest.java
@@ -280,7 +280,8 @@ class UltiToolsPluginLanguageScopeTest {
     }
 
     @Test
-    @DisplayName("A CodeSource pointing at a directory (not a jar) degrades without throwing")
+    @DisplayName("A CodeSource pointing at a directory with no matching lang file returns null "
+            + "without throwing (not a false empty Language) -- 13-REVIEW CR-01")
     void unreadableCodeSourceDegradesWithoutThrowing() throws Throwable {
         File explodedRoot = new File(tempDir, "exploded-module");
         File classFile = new File(explodedRoot, ModuleFixturePlugin.class.getName().replace('.', '/') + ".class");
@@ -297,12 +298,11 @@ class UltiToolsPluginLanguageScopeTest {
             assertThatCode(() -> resultHolder.set(invokeLoadLanguageFromJar(plugin, "en", ".json")))
                     .doesNotThrowAnyException();
 
-            // CodeSource resolves to a directory, so opening it as a JarFile fails with an
-            // IOException -- caught and degraded to an empty dictionary, matching saveResources()'s
-            // own logged-and-degraded convention rather than propagating the failure.
-            Language result = (Language) resultHolder.get();
-            assertThat(result).isNotNull();
-            assertThat(result.getLocalizedText("probe.marker")).isEqualTo("probe.marker");
+            // CodeSource resolves to a directory with no lang/en.json inside it -- CR-01's fix
+            // returns null (the same "not found, keep looking" signal a jar-backed lookup gives),
+            // not the pre-fix non-null empty Language that made createLanguageFromPath's extension
+            // loop stop on the very first attempt and suppressed the #389 diagnostic warning.
+            assertThat(resultHolder.get()).isNull();
         } finally {
             directoryLoader.close();
         }

--- a/src/test/java/com/ultikits/ultitools/abstracts/UltiToolsPluginLanguageScopeTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/UltiToolsPluginLanguageScopeTest.java
@@ -307,4 +307,39 @@ class UltiToolsPluginLanguageScopeTest {
             directoryLoader.close();
         }
     }
+
+    /**
+     * 13-REVIEW CR-01: {@code Localized.scanLangResources()} (inherited, drives {@link
+     * Localized#supported()}) already branches on a directory-shaped {@code CodeSource} and scans
+     * {@code <location>/lang/} directly off disk -- {@code loadLanguageFromJar} must resolve the
+     * same module's own {@code lang/en.yml} the same way, not disagree with its own sibling method
+     * by unconditionally trying (and failing) to open the directory as a {@code JarFile} first.
+     */
+    @Test
+    @DisplayName("A CodeSource pointing at a directory loads the module's own lang/ file instead of "
+            + "silently shadowing it with an empty dictionary (13-REVIEW CR-01)")
+    void explodedDirectoryModuleLangFileIsLoadedNotShadowed() throws Throwable {
+        File explodedRoot = new File(tempDir, "exploded-module-with-lang");
+        File classFile = new File(explodedRoot, ModuleFixturePlugin.class.getName().replace('.', '/') + ".class");
+        Files.createDirectories(classFile.getParentFile().toPath());
+        Files.write(classFile.toPath(), compiledFixtureClassBytes());
+
+        File langFile = new File(explodedRoot, "lang" + File.separator + "en.yml");
+        Files.createDirectories(langFile.getParentFile().toPath());
+        Files.write(langFile.toPath(), "probe:\n  marker: MODULE\n".getBytes(StandardCharsets.UTF_8));
+
+        ClassLoader isolatingBase = new LangResourceHidingClassLoader(UltiToolsPluginLanguageScopeTest.class.getClassLoader());
+        ChildFirstClassLoader directoryLoader = new ChildFirstClassLoader(
+                new URL[]{explodedRoot.toURI().toURL()}, isolatingBase);
+        try {
+            Object plugin = newModuleFixtureInstance(directoryLoader);
+
+            Language language = invokeCreateLanguageFromPath(
+                    plugin, new File(tempDir, "no-such-resource-folder").getAbsolutePath());
+
+            assertThat(language.getLocalizedText("probe.marker")).isEqualTo("MODULE");
+        } finally {
+            directoryLoader.close();
+        }
+    }
 }

--- a/src/test/java/com/ultikits/ultitools/abstracts/UltiToolsPluginLanguageScopeTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/UltiToolsPluginLanguageScopeTest.java
@@ -1,0 +1,306 @@
+package com.ultikits.ultitools.abstracts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.logging.Logger;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+import org.objenesis.Objenesis;
+import org.objenesis.ObjenesisStd;
+
+import com.ultikits.ultitools.entities.Language;
+import com.ultikits.ultitools.utils.TestHelper;
+
+/**
+ * D-03/D-04 (framework issue #412): {@link UltiToolsPlugin#loadLanguageFromJar(String, String)}
+ * must resolve a module's own {@code lang/} catalogue from the module's own {@link
+ * java.security.CodeSource}, not from the shared {@code URLClassLoader} every internal module is
+ * loaded through. Before the fix, {@code getResource(...)} on that shared loader let a module's
+ * request for {@code lang/en.json} resolve into the core plugin's own {@code lang/en.json} --
+ * silently, before the module's own {@code lang/en.yml} was ever tried.
+ * <p>
+ * The fixture builds two real jars and a two-level {@link URLClassLoader} chain that mirrors
+ * {@code UltiTools.java}'s own {@code new URLClassLoader(getModuleUrls(), getClassLoader())}: a
+ * core-like jar shipping only {@code lang/en.json}, and a module-like jar shipping only {@code
+ * lang/en.yml} plus a real compiled class ({@link ModuleFixturePlugin}) so an instance loaded
+ * through the module loader has that jar as its own {@code CodeSource}. The module loader is
+ * child-first for its own classes (mirroring a real Bukkit/Paper per-plugin classloader) but
+ * leaves {@code getResource} at the default parent-first {@link ClassLoader} behaviour -- that
+ * asymmetry (child-first classes, parent-first resources) is the actual mechanism behind #412, so
+ * reproducing it exactly (rather than a looser approximation) is what makes the RED run below
+ * proof rather than assertion.
+ * <p>
+ * Follows the same mock-and-reflect idiom as {@code UltiToolsPluginLanguageFallbackTest}:
+ * {@link Objenesis} bypasses every constructor (the same mechanism Mockito's inline mock maker
+ * uses) so a real instance of the jar-loaded class can be obtained without ever calling {@code
+ * UltiToolsPlugin}'s heavy constructors, and the private resolution methods under test are
+ * invoked via reflection so their real bodies run.
+ */
+@DisplayName("UltiToolsPlugin loadLanguageFromJar module-scope resolution (D-03/D-04, issue #412)")
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+@SuppressWarnings("PMD.AvoidAccessibilityAlteration") // reflective invocation of private resolution methods
+class UltiToolsPluginLanguageScopeTest {
+
+    // Declared before the nested fixture class below: PMD's FieldDeclarationsShouldBeAtStartOfClass
+    // requires fields to precede any inner class.
+    @TempDir
+    File tempDir;
+
+    /**
+     * The compiled fixture class copied into the constructed jars. A {@code static} nested class
+     * has no synthetic reference to the enclosing test class, so its {@code .class} file can be
+     * lifted out of {@code target/test-classes} and repackaged into an isolated jar without also
+     * needing to load the enclosing {@code UltiToolsPluginLanguageScopeTest} class.
+     */
+    static class ModuleFixturePlugin extends UltiToolsPlugin {
+        @Override
+        public boolean registerSelf() {
+            return true;
+        }
+    }
+
+    @BeforeEach
+    void stubUltiToolsInstance() {
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("language", "en");
+        TestHelper.mockUltiToolsInstance(ultiTools -> {
+            Mockito.lenient().when(ultiTools.getConfig()).thenReturn(config);
+            Mockito.lenient().when(ultiTools.getLogger())
+                    .thenReturn(Logger.getLogger(UltiToolsPluginLanguageScopeTest.class.getName()));
+        });
+    }
+
+    /**
+     * Child-first for its own classes, mirroring a real Bukkit/Paper per-plugin classloader: a
+     * module's own class is defined by the module's own loader rather than delegated to the
+     * parent, while resource lookup ({@link #getResource(String)}, inherited unmodified from
+     * {@link ClassLoader}) stays parent-first. That asymmetry is the mechanism #412 exploits.
+     */
+    private static final class ChildFirstClassLoader extends URLClassLoader {
+        ChildFirstClassLoader(URL[] urls, ClassLoader parent) {
+            super(urls, parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> found = findLoadedClass(name);
+                if (found == null) {
+                    try {
+                        found = findClass(name);
+                    } catch (ClassNotFoundException notShippedByThisJar) {
+                        found = super.loadClass(name, false);
+                    }
+                }
+                if (resolve) {
+                    resolveClass(found);
+                }
+                return found;
+            }
+        }
+    }
+
+    /**
+     * Wraps the real test classloader for class loading (unchanged, so {@code UltiToolsPlugin},
+     * {@code Language} etc. resolve normally) but hides every {@code lang/*} resource behind it.
+     * <p>
+     * Without this, {@code moduleLoader.getResource("lang/en.json")}'s parent-first walk reaches
+     * all the way up to the real test/application classloader -- which has the framework's own,
+     * genuine {@code src/main/resources/lang/en.json} on its classpath -- and resolves there
+     * before ever reaching either constructed fixture jar. That would make the RED assertion below
+     * fail for the wrong reason (an unrelated real resource, with no {@code probe.marker} key,
+     * rather than the fixture's own {@code CORE}-tagged core-like jar), and the same leak would
+     * let {@link #unreadableCodeSourceDegradesWithoutThrowing()} pass by accident before the fix
+     * lands. Isolating {@code lang/*} here is what makes both directions of the falsification
+     * measure the mechanism under test rather than an artifact of the ambient classpath.
+     */
+    private static final class LangResourceHidingClassLoader extends ClassLoader {
+        private final ClassLoader real;
+
+        LangResourceHidingClassLoader(ClassLoader real) {
+            super(real);
+            this.real = real;
+        }
+
+        @Override
+        public URL getResource(String name) {
+            return name.startsWith("lang/") ? null : real.getResource(name);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            return name.startsWith("lang/") ? Collections.emptyEnumeration() : real.getResources(name);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            return name.startsWith("lang/") ? null : real.getResourceAsStream(name);
+        }
+    }
+
+    private static byte[] compiledFixtureClassBytes() throws IOException {
+        String resourceName = ModuleFixturePlugin.class.getName().replace('.', '/') + ".class";
+        try (InputStream in = UltiToolsPluginLanguageScopeTest.class.getClassLoader().getResourceAsStream(resourceName)) {
+            if (in == null) {
+                throw new IOException("Compiled fixture class not found on the test classpath: " + resourceName);
+            }
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            byte[] buf = new byte[4096];
+            int len;
+            while ((len = in.read(buf)) != -1) {
+                out.write(buf, 0, len);
+            }
+            return out.toByteArray();
+        }
+    }
+
+    private static File buildJar(File dir, String fileName, Map<String, byte[]> entries) throws IOException {
+        File jarFile = new File(dir, fileName);
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jarFile.toPath()))) {
+            for (Map.Entry<String, byte[]> entry : entries.entrySet()) {
+                jos.putNextEntry(new JarEntry(entry.getKey()));
+                jos.write(entry.getValue());
+                jos.closeEntry();
+            }
+        }
+        return jarFile;
+    }
+
+    private static Object newModuleFixtureInstance(ClassLoader moduleLoader) throws Exception {
+        Class<?> fixtureClass = Class.forName(ModuleFixturePlugin.class.getName(), true, moduleLoader);
+        Objenesis objenesis = new ObjenesisStd();
+        return objenesis.newInstance(fixtureClass);
+    }
+
+    private static Language invokeCreateLanguageFromPath(Object plugin, String folderPath) throws Throwable {
+        Method method = UltiToolsPlugin.class.getDeclaredMethod("createLanguageFromPath", String.class);
+        method.setAccessible(true);
+        try {
+            return (Language) method.invoke(plugin, folderPath);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    private static Object invokeLoadLanguageFromJar(Object plugin, String code, String extension) throws Throwable {
+        Method method = UltiToolsPlugin.class.getDeclaredMethod("loadLanguageFromJar", String.class, String.class);
+        method.setAccessible(true);
+        try {
+            return method.invoke(plugin, code, extension);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    @Nested
+    @DisplayName("A module resolves its own lang/ catalogue through its own CodeSource, not the shared classloader")
+    class ModuleScopedResourceResolution {
+
+        private URLClassLoader coreLoader;
+        private ChildFirstClassLoader moduleLoader;
+        private Object modulePlugin;
+
+        /**
+         * Builds the two-jar fixture shared by the first two tests: a core-like jar shipping
+         * {@code lang/en.json} ({@code probe.marker=CORE}), a module-like jar shipping only
+         * {@code lang/en.yml} ({@code probe.marker=MODULE}) plus the compiled fixture class, and
+         * a module loader whose parent is a loader over the core jar -- exactly the shape {@code
+         * UltiTools.java:264} builds at runtime.
+         */
+        @BeforeEach
+        void buildTwoJarFixture() throws Exception {
+            File coreJar = buildJar(tempDir, "core.jar",
+                    Collections.singletonMap("lang/en.json", "{\"probe.marker\":\"CORE\"}".getBytes(StandardCharsets.UTF_8)));
+
+            Map<String, byte[]> moduleEntries = new LinkedHashMap<>();
+            moduleEntries.put("lang/en.yml", "probe:\n  marker: MODULE\n".getBytes(StandardCharsets.UTF_8));
+            moduleEntries.put(ModuleFixturePlugin.class.getName().replace('.', '/') + ".class", compiledFixtureClassBytes());
+            File moduleJar = buildJar(tempDir, "module.jar", moduleEntries);
+
+            ClassLoader isolatingBase = new LangResourceHidingClassLoader(UltiToolsPluginLanguageScopeTest.class.getClassLoader());
+            coreLoader = new URLClassLoader(new URL[]{coreJar.toURI().toURL()}, isolatingBase);
+            moduleLoader = new ChildFirstClassLoader(new URL[]{moduleJar.toURI().toURL()}, coreLoader);
+            modulePlugin = newModuleFixtureInstance(moduleLoader);
+        }
+
+        @AfterEach
+        void closeLoaders() throws IOException {
+            moduleLoader.close();
+            coreLoader.close();
+        }
+
+        @Test
+        @DisplayName("Module's lang/en.yml wins over the core's lang/en.json -- reproduces and proves the fix for #412")
+        void moduleYamlCatalogueWinsOverCoreJsonCatalogue() throws Throwable {
+            Language language = invokeCreateLanguageFromPath(modulePlugin, new File(tempDir, "no-such-resource-folder").getAbsolutePath());
+
+            assertThat(language.getLocalizedText("probe.marker")).isEqualTo("MODULE");
+        }
+
+        @Test
+        @DisplayName("An extension the module does not ship returns null, so the extension loop can continue")
+        void absentEntryReturnsNullSoTheExtensionLoopContinues() throws Throwable {
+            // The module fixture ships only lang/en.yml -- .yaml is a distinct entry name it never
+            // shipped, in either the shared-classloader (before) or CodeSource (after) resolver.
+            Object result = invokeLoadLanguageFromJar(modulePlugin, "en", ".yaml");
+
+            assertThat(result).isNull();
+        }
+    }
+
+    @Test
+    @DisplayName("A CodeSource pointing at a directory (not a jar) degrades without throwing")
+    void unreadableCodeSourceDegradesWithoutThrowing() throws Throwable {
+        File explodedRoot = new File(tempDir, "exploded-module");
+        File classFile = new File(explodedRoot, ModuleFixturePlugin.class.getName().replace('.', '/') + ".class");
+        Files.createDirectories(classFile.getParentFile().toPath());
+        Files.write(classFile.toPath(), compiledFixtureClassBytes());
+
+        ClassLoader isolatingBase = new LangResourceHidingClassLoader(UltiToolsPluginLanguageScopeTest.class.getClassLoader());
+        ChildFirstClassLoader directoryLoader = new ChildFirstClassLoader(
+                new URL[]{explodedRoot.toURI().toURL()}, isolatingBase);
+        try {
+            Object plugin = newModuleFixtureInstance(directoryLoader);
+
+            AtomicReference<Object> resultHolder = new AtomicReference<>();
+            assertThatCode(() -> resultHolder.set(invokeLoadLanguageFromJar(plugin, "en", ".json")))
+                    .doesNotThrowAnyException();
+
+            // CodeSource resolves to a directory, so opening it as a JarFile fails with an
+            // IOException -- caught and degraded to an empty dictionary, matching saveResources()'s
+            // own logged-and-degraded convention rather than propagating the failure.
+            Language result = (Language) resultHolder.get();
+            assertThat(result).isNotNull();
+            assertThat(result.getLocalizedText("probe.marker")).isEqualTo("probe.marker");
+        } finally {
+            directoryLoader.close();
+        }
+    }
+}

--- a/src/test/java/com/ultikits/ultitools/abstracts/UltiToolsPluginLanguageScopeTest.java
+++ b/src/test/java/com/ultikits/ultitools/abstracts/UltiToolsPluginLanguageScopeTest.java
@@ -194,6 +194,10 @@ class UltiToolsPluginLanguageScopeTest {
     }
 
     private static Object newModuleFixtureInstance(ClassLoader moduleLoader) throws Exception {
+        // The class name is a compile-time constant (ModuleFixturePlugin.class.getName()), never
+        // attacker-controllable; loading through the given moduleLoader is required to reproduce
+        // the shared-classloader shadowing that issue #412 describes.
+        // nosemgrep: java.lang.security.audit.unsafe-reflection.unsafe-reflection
         Class<?> fixtureClass = Class.forName(ModuleFixturePlugin.class.getName(), true, moduleLoader);
         Objenesis objenesis = new ObjenesisStd();
         return objenesis.newInstance(fixtureClass);

--- a/src/test/java/com/ultikits/ultitools/entities/LanguageTest.java
+++ b/src/test/java/com/ultikits/ultitools/entities/LanguageTest.java
@@ -105,4 +105,66 @@ class LanguageTest {
             assertEquals("count", language.getLocalizedText("count"));
         }
     }
+
+    @org.junit.jupiter.api.Nested
+    @org.junit.jupiter.api.DisplayName("withFallback — per-key fallback (#418 real-machine finding)")
+    class WithFallback {
+
+        @Test
+        @org.junit.jupiter.api.DisplayName("a key present only in the fallback is answered from the fallback")
+        void keyOnlyInFallbackIsAnsweredFromFallback() {
+            Map<String, String> diskOnly = new HashMap<>();
+            diskOnly.put("known", "disk-value");
+            Language disk = new Language(diskOnly);
+
+            Map<String, String> jarOnly = new HashMap<>();
+            jarOnly.put("known", "jar-value");
+            jarOnly.put("onlyInJar", "jar-only-value");
+            Language jar = new Language(jarOnly);
+
+            Language merged = disk.withFallback(jar);
+
+            assertEquals("jar-only-value", merged.getLocalizedText("onlyInJar"));
+        }
+
+        @Test
+        @org.junit.jupiter.api.DisplayName("a key present in both keeps the primary (disk) value")
+        void keyInBothKeepsThePrimaryValue() {
+            Map<String, String> diskOnly = new HashMap<>();
+            diskOnly.put("known", "disk-value");
+            Language disk = new Language(diskOnly);
+
+            Map<String, String> jarOnly = new HashMap<>();
+            jarOnly.put("known", "jar-value");
+            Language jar = new Language(jarOnly);
+
+            Language merged = disk.withFallback(jar);
+
+            assertEquals("disk-value", merged.getLocalizedText("known"));
+        }
+
+        @Test
+        @org.junit.jupiter.api.DisplayName("a key present in neither still falls back to itself")
+        void keyInNeitherFallsBackToTheKeyItself() {
+            Language disk = new Language(new HashMap<>());
+            Language jar = new Language(new HashMap<>());
+
+            Language merged = disk.withFallback(jar);
+
+            assertEquals("neither", merged.getLocalizedText("neither"));
+        }
+
+        @Test
+        @org.junit.jupiter.api.DisplayName("withFallback(null) returns this language unchanged")
+        void withFallbackOfNullReturnsThisLanguageUnchanged() {
+            Map<String, String> diskOnly = new HashMap<>();
+            diskOnly.put("known", "disk-value");
+            Language disk = new Language(diskOnly);
+
+            Language merged = disk.withFallback(null);
+
+            assertEquals("disk-value", merged.getLocalizedText("known"));
+            assertEquals("missing", merged.getLocalizedText("missing"));
+        }
+    }
 }

--- a/src/test/java/com/ultikits/ultitools/entities/LanguageTest.java
+++ b/src/test/java/com/ultikits/ultitools/entities/LanguageTest.java
@@ -1,6 +1,7 @@
 package com.ultikits.ultitools.entities;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
@@ -165,6 +166,25 @@ class LanguageTest {
 
             assertEquals("disk-value", merged.getLocalizedText("known"));
             assertEquals("missing", merged.getLocalizedText("missing"));
+        }
+
+        @Test
+        @org.junit.jupiter.api.DisplayName("withFallback(this) refuses to create a self-referential cycle")
+        void withFallbackOfSelfThrows() {
+            Language disk = new Language(new HashMap<>());
+
+            assertThrows(IllegalArgumentException.class, () -> disk.withFallback(disk));
+        }
+
+        @Test
+        @org.junit.jupiter.api.DisplayName(
+                "withFallback refuses a fallback whose own chain already contains this language")
+        void withFallbackCreatingATwoLinkCycleThrows() {
+            Language a = new Language(new HashMap<>());
+            // b's chain is b -> a. Asking `a` to fall back to `b` would close the loop a -> b -> a.
+            Language b = new Language(new HashMap<>()).withFallback(a);
+
+            assertThrows(IllegalArgumentException.class, () -> a.withFallback(b));
         }
     }
 }


### PR DESCRIPTION
## Summary

This pull request carries the phase's single framework branch and now holds **four commits**,
per the ship gate's "one narrow pull request per affected repository per phase" rule (D-02/D-12,
amended 2026-09-06):

1. **Fixes framework issue #412**: `UltiToolsPlugin.loadLanguageFromJar` resolved a module's own
   `lang/` catalogue through the shared internal-module `URLClassLoader`, whose parent-first
   `getResource("lang/<code>.json")` let a module's request resolve into the **core plugin's own**
   `lang/en.json` before the module's own `lang/en.yml` was ever tried. The resolver now opens the
   module's own jar directly via `this.getClass().getProtectionDomain().getCodeSource()` — the same
   `CodeSource`/`JarFile` idiom `saveResources()` and `Localized.scanLangJar()` already use in this
   class family — so a module's catalogue can never resolve into a sibling's or the core's.
2. **States the D-01 `@RunAsync` thread-affinity rule in the annotation's own javadoc**
   (`annotations/command/RunAsync.java`): a `@RunAsync` body must not touch world, entity, block or
   chunk state directly; asynchrony is reserved for pure-CPU or I/O work, and the one Bukkit call
   such a body may make is scheduling that work back onto the main thread via
   `Bukkit.getScheduler().runTask(...)`. This is the one written decision that two downstream
   module fixes (UltiEssentials `/wild`, UltiWorlds `/world create`) both cite instead of each
   guessing independently. Documentation only — no member, retention, target, or deprecation
   change; the existing `@see` link to the developer-docs page is preserved.

3. **Falls back to the jar-bundled catalogue for a language key a disk file lacks**
   (real-machine finding, Laojun UAT 2026-09-06): on an upgraded server a module jar adds a
   new key, but the copy of that language file already sitting in the module's data folder --
   extracted by an older jar -- does not have it. `UltiToolsPlugin#createLanguageFromPath` used
   to return whichever `Language` it found first exclusively (disk, if present at all), so a key
   missing from disk rendered as its own raw key even though the newly-shipped jar had a
   translation for it. Two module UAT rows exposed it: UltiChat #9 (F-C1, `autoreply_exists`)
   and UltiWorlds #13 (F-W2, `world.not_found` -- though that second row also carries a distinct
   module-side key-naming mismatch this commit does not and cannot fix, see "What changed"
   below). `Language` now supports per-key fallback (`getLocalizedText` consults its own
   dictionary, then an optional fallback `Language`, then returns the key itself);
   `createLanguageFromPath` wires it up as disk -> jar (same code/extension) -> key, so the disk
   file stays authoritative for every key it does contain.

4. **Resolves the disk and jar language catalogues independently of extension** (own deep
   review round 5 of commit 3, warning finding 1): commit 3's loop resolved the on-disk and
   jar-bundled catalogues together, one shared extension per iteration, so a module whose old
   jar extracted `lang/en.json` to disk and whose new jar switched the same code to
   `lang/en.yml` never reached the `.yml` iteration -- the `.json` iteration's non-null disk
   result short-circuited the loop first. `createLanguageFromPath` now resolves each source
   independently (`resolveDiskLanguage`/`resolveJarLanguage`, each trying every extension in
   `LANGUAGE_EXTENSIONS` and returning the first that exists) and combines the two results
   afterwards. The same round also added a cycle guard to `Language.withFallback` (info
   finding 2): it now throws `IllegalArgumentException` if the given fallback is, or already
   falls back to, this language.

All four commits land on `gsd/phase-13-module-defect-closure`, opened once for Phase 13 and never
rebased or force-pushed. A companion documentation pull request publishes commit 2's rule on the
page the annotation's `@see` link points at:
https://github.com/UltiKits/UltiTools-Dev-Doc/pull/84 (`gsd/phase-13-runasync-contract-docs` ->
`alpha`).

## Issue closure

None. This repository's phase pull requests target `alpha`, not the default branch, so GitHub's
closing keywords never fire here (`.github/workflows/phase-closeout.yml` reads this section after
merge but currently has 0 runs, see this repo's own `CLAUDE.md`). The three downstream module
issues commit 1 enables closing (`UltiBackup#7`, `UltiSideBar#9`, `UltiMail#17`) live in their own
repositories and are closed there, by hand, once each is re-verified against this fixed framework
jar in plan 13-03's real-machine session — not by this pull request. Commit 2 closes no issue; it
is documentation for a rule two module pull requests (plans 13-04, 13-05) cite. Commit 3 closes
no issue directly either; it is the framework-side fix the real-machine finding's UltiChat #9
(F-C1) row asked for, and the UAT results explicitly note UltiChat PR #12's maintainer still
needs to confirm the boundary with this framework fix before that module issue closes.

## What changed

- `UltiToolsPlugin.loadLanguageFromJar(String, String)` — rewritten body, same private signature,
  same javadoc, same `.json`/YAML branch. Resolves `CodeSource` instead of calling
  `getResource(...)` on the shared classloader. Returns `null` when the `CodeSource`, its
  location, or the jar entry is absent (unchanged extension-loop contract). The existing
  `catch (IOException)` behaviour (log + return an empty dictionary) is unchanged.
- New test `UltiToolsPluginLanguageScopeTest` (3 `@Test` methods): reproduces #412 with two real
  jars and a two-level `URLClassLoader` chain mirroring `UltiTools.java`'s own
  `new URLClassLoader(getModuleUrls(), getClassLoader())`, falsified in both directions.
- `pom.xml`: declares `org.objenesis:objenesis:3.3:test` explicitly (already resolved
  transitively via `mockito-core`, now imported by name in the new test;
  `maven-dependency-plugin:analyze-only` requires explicit declaration).
- `entities/Language.java` — new `withFallback(Language)` returning a `Language` that answers
  from its own dictionary first and, for a key it lacks, from the given fallback before giving
  up and returning the key itself. Existing public constructors and `getLocalizedText`'s
  contract (miss -> the key, never `null`) are unchanged.
- `UltiToolsPlugin.createLanguageFromPath(String)` — resolves the on-disk and jar-bundled
  catalogues **independently** via two new private helpers, `resolveDiskLanguage(String,
  String)` and `resolveJarLanguage(String)`, each trying every extension in
  `LANGUAGE_EXTENSIONS` in order and returning the first that exists for that source alone.
  When both resolve, returns `onDisk.withFallback(inJar)`; when only one resolves, returns
  that one unchanged; when neither resolves, the pre-existing #389 warning + empty `Language`
  behaviour is unchanged. This replaces the round-3 same-extension-only pairing (own deep
  review round 5, warning finding 1): a module whose old jar extracted `lang/en.json` to disk
  and whose new jar ships the same code as `lang/en.yml` now falls back correctly instead of
  the loop stopping at the stale `.json` disk match before the jar's `.yml` was ever tried.
- `Language.withFallback(Language)` — gained a cycle guard (own deep review round 5, info
  finding 2): walks the given fallback's own chain and throws `IllegalArgumentException` if it
  is, or already falls back to, this language, since either would make `getLocalizedText`
  recurse forever for a key present in neither language.
- New test `UltiToolsPluginLanguagePerKeyFallbackTest` (3 `@Test` methods) reuses
  `UltiToolsPluginLanguageScopeTest`'s directory-`CodeSource` fixture technique to prove the
  three rows: disk-missing-key falls back to jar, disk-present-key wins over jar, and
  neither-has-it falls back to the raw key. New nested `LanguageTest.WithFallback` (4
  `@Test` methods) unit-tests `withFallback` directly at the `Language` level, including
  `withFallback(null)` returning the receiver unchanged.
- UltiWorlds #13 (F-W2)'s raw `world.not_found`/`world.info.*` output is **not** fixed by this
  commit: the evidence (`UltiWorlds-jar-lang-en.yml` vs `UltiWorlds-disk-en.yml`) shows
  `error.world_not_found` present with an identical value in *both* catalogues -- the running
  code asks for a key (`world.not_found`) that neither catalogue ships under any name. That is
  a module-side key-naming mismatch (UltiWorlds PR #16), not a missing-key/upgrade defect this
  fallback can address.
- `annotations/command/RunAsync.java` — javadoc expanded from a one-line placeholder to state the
  D-01 rule, the prescribed `runTask(...)` hand-back, the observable failure mode (Paper's
  asynchronous-operation check killing the command mid-handler), and a pointer to `@AsyncCommand`
  as the configurable alternative. No behavioural, member, or API-surface change; `japicmp`
  classifies this as no change at all.

## Before / after (RED / GREEN) — commit 1

**Before** (unmodified resolver): `moduleYamlCatalogueWinsOverCoreJsonCatalogue` —
`expected: "MODULE" but was: "CORE"`; `unreadableCodeSourceDegradesWithoutThrowing` — `Expecting
actual not to be null`. `Tests run: 3, Failures: 2, Errors: 0`.

**After** (fixed resolver): `Tests run: 3, Failures: 0, Errors: 0`. Full suite:
`mvn -B clean verify` → `Tests run: 5412, Failures: 0, Errors: 0, Skipped: 0`, `BUILD SUCCESS`.

Full transcripts: `13-I18N-ADJUDICATION.md` in the phase evidence tree (local, gitignored, not part
of this diff per this repository's evidence-tree convention).

## Commit 2 verification

`mvn -B -q javadoc:javadoc` produces `target/site/apidocs/.../RunAsync.html` with zero `[ERROR]`
lines; `mvn -B clean verify` after the javadoc commit is green (`Tests run: 5412, Failures: 0,
Errors: 0`, `BUILD SUCCESS`); the commit at that point in history touches exactly
`RunAsync.java`, no other file.

## Commit 3 verification

RED (new test against the pre-fix resolver, `git stash` isolating the two production-code
edits): `UltiToolsPluginLanguagePerKeyFallbackTest.diskMissingKeyFallsBackToJarTranslation` --
`expected: "&cJar-only translation." but was: "onlyInJar"` -- the exact upgrade symptom
described above, reproduced as a unit test rather than asserted. GREEN after the fix:
`Tests run: 3, Failures: 0, Errors: 0` for that class; `Tests run: 7, Failures: 0, Errors: 0`
across it plus the new `LanguageTest.WithFallback` nested class. Full suite:
`mvn -B clean verify` -> `Tests run: 5420, Failures: 0, Errors: 0, Skipped: 0`,
`BUILD SUCCESS`.

## Commit 4 verification

Own deep review round 5 of commit 3 (`0ddc95f`), warning finding 1 and info finding 2. RED before
the fix: `UltiToolsPluginLanguagePerKeyFallbackTest.diskJsonJarYmlCrossExtensionFallsBackToJarYamlTranslation`
-- `expected: "&cOnly in the yml jar catalogue." but was: "crossExtensionKey"` (disk ships
`en.json`, jar ships only `en.yml` for the same code); `LanguageTest.WithFallback.withFallbackOfSelfThrows`
and `...withFallbackCreatingATwoLinkCycleThrows` -- both `Expected java.lang.IllegalArgumentException
to be thrown, but nothing was thrown`. GREEN after the fix: all three pass; `Tests run: 18,
Failures: 0, Errors: 0` across `LanguageTest` + `UltiToolsPluginLanguagePerKeyFallbackTest`. Full
suite: `mvn -B clean verify` -> `Tests run: 5423, Failures: 0, Errors: 0, Skipped: 0`,
`BUILD SUCCESS`. `mvn -B -o -q javadoc:javadoc` clean. CRLF preserved in both modified `src/main`
files; 0 CJK violations.

## Adjudication verdict (D-03) — one sentence per symptom

- **UltiBackup#7** — framework issue #412 explains it (module jar ships `lang/en.yml`/`zh.yml`,
  zero `.json` entries — exactly this fix's mechanism); behavioural re-confirmation against this
  fixed jar deferred to plan 13-03's real-machine session.
- **UltiSideBar#9** — framework issue #412 explains it, **already confirmed live** by Phase 11's
  own real-machine re-confirmation comment on that issue, naming #412 explicitly; re-verification
  against this fixed jar happens in plan 13-03.
- **UltiMail#17** — framework issue #412 explains it (same YAML-only jar shape; the issue's own
  "mixes two key conventions" observation is consistent with, not contradicting, the #412
  mechanism); behavioural re-confirmation deferred to plan 13-03.

No module-side code change is expected for any of the three once this fix is deployed and
re-verified; each closes by evidence, not by a module-side workaround.

## Review fixes

Own code review (`13-REVIEW-UltiTools-Reborn.md`, depth `deep`) found 1 critical and 3 warning
issues in commit 1's `loadLanguageFromJar` rewrite; all were fixed, plus the one-line/risk-free
info findings. Codex's two inline PR comments on the same method were independently confirmed real
and fixed as well — see the reply posted in each thread for the file:line evidence.

| Finding | What | Commit |
|---|---|---|
| CR-01 | `loadLanguageFromJar` disagreed with `Localized.scanLangResources()` about a directory-shaped `CodeSource` — unconditionally tried (and failed) to open it as a `JarFile`, silently shadowing a module's own `lang/*.yml` when running unpacked (dev workspace, IDE launch, module test bootstrap) and suppressing the #389 diagnostic warning | `f764cc3c` (RED test), `4e232dce` (fix) |
| WR-01 | `getResource(String)` left as unreferenced dead code after commit 1's rewrite removed its only caller — a Codacy `UnusedPrivateMethod` risk under this repo's `issueThreshold: 0` gate | `34ea3c17` |
| WR-02 | The rewritten catch block (and the new directory-branch catch block) called a `PluginLogger` overload that silently discards the caught exception instead of logging it | `e374afc2` |
| WR-03 | `URL#getPath()`'s undecoded percent-escapes were handed straight to `File`/`JarFile` — a path containing a space or other URI-escaped character would fail to resolve; also independently flagged by Codex (see below) | `649b3f65` |
| IN-01, IN-03 | `RunAsync.java`'s opening line asserted the safety the rest of its own javadoc explicitly warns against; one remaining `{@code}` cross-reference converted to `{@link}` | `c835c462` |
| IN-02 | New test file uses LF, inconsistent with this repo's mostly-CRLF `.java` files | Deliberately left — a new file has nothing to preserve, and this repo's own `CLAUDE.md` already documents `.java` line endings as mixed |

**Codex inline comments, round 1 (PR #418):** both on `UltiToolsPlugin.java:229`, commit `fbb40939`.
- "Decode the code-source URL before opening the JAR" — confirmed real, same defect as WR-03, fixed in `649b3f65`. Reply: https://github.com/UltiKits/UltiTools-Reborn/pull/418#discussion_r3944404910
- "Preserve exploded-directory language loading" — confirmed real, same defect as CR-01, fixed in `4e232dce`. Reply: https://github.com/UltiKits/UltiTools-Reborn/pull/418#discussion_r3944405637

**Codex inline comment, round 2 (PR #418):** `UltiToolsPlugin.java:239`, commit `c835c462`.
- "Retain lookup across split exploded classpaths" — **not real for this project; no code change.** The gap is genuine (colocated-root resolution does not follow a Gradle-style split `classes`/`resources` layout) but unreachable: this ecosystem's toolchain is Maven-only (0 `build.gradle*` files across `Modules/`, `Tooling/`, `Libraries/`; the one Gradle dev tool, `UltiToolsPluginDev`, is archived and unmaintained), and Maven always colocates compiled classes with `src/main/resources` under `target/classes`. Reverting to a classloader-search lookup to cover the split-root case would reintroduce the exact #412 regression `b9b9bee8` fixed, since every module shares one `URLClassLoader` over `plugins/*.jar` (`PluginManager.java:785-787`). Reply: https://github.com/UltiKits/UltiTools-Reborn/pull/418#discussion_r3944536510

Full build after round 1: `mvn -B clean verify` → `BUILD SUCCESS`, `Tests run: 5413, Failures: 0,
Errors: 0, Skipped: 0`. Round 2 made no source change; re-verified anyway:
`mvn -B clean verify` → `BUILD SUCCESS`, `Tests run: 5413, Failures: 0, Errors: 0, Skipped: 0`
(identical to round 1, as expected with no source edit).

## Pre-merge gates run

| # | Gate | Status |
|---|---|---|
| 1 | Own code review (GSD `code-review`) | Run (deep) — `13-REVIEW-UltiTools-Reborn.md`; every critical and warning finding fixed, see Review fixes above |
| 2 | Third-party review (Codacy + Codex) | Codex round 1: 2 inline comments, both triaged and fixed. Codex round 2: 1 inline comment, triaged and confirmed not applicable to this project's toolchain (see Review fixes above). Codacy: not independently re-confirmed in this session |
| 3 | Laojun real-machine UAT | Not yet run — batched in plan 13's D-11 session after every phase-13 PR's machine-verifiable gates are green |
| 4 | Required/configured CI (`maven-ci.yml`) | Will run on this PR; local equivalent (`mvn -B clean verify`) is green, see above |

This pull request is **not merged by this plan** — opening it is pre-authorized (standing merge
authority), but D-12 sequences the framework merge before module fan-out, executed at ship time.

## Risks & Dependencies

- Every module in this phase resolves `6.3.0-SNAPSHOT` from the local Maven repository; this
  branch's snapshot is installed locally so downstream `mvn verify` runs in later plans compile
  against the fixed resolver rather than a stale one.
- No known high-risk rollout dependencies beyond the sequencing D-12 already states (framework
  merges before module fan-out).

## Success Metrics & Release Criteria

- A module shipping only YAML translations loads its own translations, proven by a test that fails
  without the fix (see Before/After above).
- The `@RunAsync` javadoc states the D-01 rule and the build/javadoc tool both accept it without
  error.
- Release when the pre-merge gates above are green and the maintainer authorizes the merge — no
  release, tag, or version bump is part of this change.

## Stakeholder Review & Approval

- Product owner approval pending for Phase 13 (module defect closure by root cause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1b7Av7gngbARNsU1b5htv




