### PR TITLE
fix(420): compile test sources during snapshot publish so the deprecation-registry generator can run

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -49,4 +49,4 @@ jobs:
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        run: mvn -B deploy -Dmaven.test.skip=true
+        run: mvn -B deploy -DskipTests


### PR DESCRIPTION
## Issue closure

Closes #420

## What changed

One token, one line: `.github/workflows/snapshot-publish.yml`'s `Deploy snapshot to Central` step now runs `mvn -B deploy -DskipTests` instead of `mvn -B deploy -Dmaven.test.skip=true`.

## Why

Quoted from #420's diagnosis:

> `maven.test.skip=true` skips **compiling** `src/test/java`, not only running it. The `verify`-phase execution `generate-deprecation-registry` (`exec-maven-plugin`, `classpathScope=test`) runs `com.ultikits.ultitools.buildtools.deprecation.DeprecationRegistryGenerator`, which lives in `src/test/java/com/ultikits/ultitools/buildtools/deprecation/`. With test compilation skipped the class is absent from the exec classpath, so the step fails.

`snapshot-publish.yml` has failed on every push to `alpha` since it was added (six consecutive `failure` runs, 2026-09-04 through 2026-09-06). The published `6.3.0-SNAPSHOT` on Sonatype is stale relative to `alpha` as a result.

## Proof

Both runs were done on a clean worktree checked out from `origin/alpha` at `a30da0cd` (this PR's base), inside a temporary git worktree — the maintainer's main checkout was never touched.

- **RED** — `mvn -B -Dmaven.test.skip=true verify` (log: `fw-snapshot-red.log`):
  ```
  [ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.6.3:java (generate-deprecation-registry) on project UltiTools-API: An exception occurred while executing the Java class. com.ultikits.ultitools.buildtools.deprecation.DeprecationRegistryGenerator -> [Help 1]
  ```
  (root cause: `java.lang.ClassNotFoundException: com.ultikits.ultitools.buildtools.deprecation.DeprecationRegistryGenerator`)

- **GREEN** — `mvn -B -DskipTests verify` (log: `fw-snapshot-green.log`):
  ```
  [INFO] --- exec-maven-plugin:3.6.3:java (generate-deprecation-registry) @ UltiTools-API ---
  DeprecationRegistryGenerator: wrote 55 entries to compatibility/deprecations.json and compatibility/DEPRECATIONS.md
  [INFO] BUILD SUCCESS
  ```
  `japicmp-maven-plugin:0.26.1:cmp` also ran and completed successfully immediately before the generator step in this run.

Neither run reached the actual `deploy` goal locally (no Sonatype credentials in this environment) — `verify` is the phase immediately before `deploy`, and it is the phase that reproduces the reported failure.

## Expected side effect after merge

Merging republishes the `6.3.0-SNAPSHOT` from the current `alpha` HEAD. As stated in #420: `UltiKits/UltiLogin`'s `master` CI will go red until `UltiLogin#18` merges, because that branch still references the deleted `ContextHolder` — that is the true state, which the stale snapshot has been hiding until now.

## Gates

- Own code review: pending by the orchestrator.
- Third-party review (Codacy + Codex): awaited on this PR.
- Required CI (`🧪 Test & Coverage`): awaited.
- Real-machine (Laojun) UAT: not applicable — this change is a single line in a GitHub Actions workflow file, not a built artifact. The workflow's own next run after merge (a push to `alpha`) is the acceptance evidence.

Do NOT merge — opened for review only, per explicit instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1b7Av7gngbARNsU1b5htv
